### PR TITLE
Enable dynamic properties in rule builder

### DIFF
--- a/components/ifc-model.tsx
+++ b/components/ifc-model.tsx
@@ -182,7 +182,6 @@ export function IFCModel({ modelData, outlineLayer }: IFCModelProps) {
     highlightedClassificationCode,
     setModelIDForLoadedModel,
     setAvailableCategoriesForModel,
-    setAvailableProperties,
     classifications,
     showAllClassificationColors,
     userHiddenElements,
@@ -588,15 +587,21 @@ export function IFCModel({ modelData, outlineLayer }: IFCModelProps) {
           originalMaterials.current.set(expressID, mesh.material);
         }
         const trueOriginalMaterial = originalMaterials.current.get(expressID)!;
-        let targetMaterial: THREE.Material | THREE.Material[] = trueOriginalMaterial;
+        let targetMaterial: THREE.Material | THREE.Material[] =
+          trueOriginalMaterial;
         let isCurrentlyVisible = true;
 
         // Step 1: Apply "Show All Classification Colors" if active
         if (showAllClassificationColors) {
           let elementClassificationColor: string | null = null;
-          for (const classification of Object.values(classifications as Record<string, any>)) {
+          for (const classification of Object.values(
+            classifications as Record<string, any>
+          )) {
             const isInClassification = classification.elements?.some(
-              (el: SelectedElementInfo) => el && el.modelID === currentModelID && el.expressID === expressID
+              (el: SelectedElementInfo) =>
+                el &&
+                el.modelID === currentModelID &&
+                el.expressID === expressID
             );
             if (isInClassification) {
               elementClassificationColor = classification.color || "#808080";
@@ -606,8 +611,12 @@ export function IFCModel({ modelData, outlineLayer }: IFCModelProps) {
           if (elementClassificationColor) {
             let isCorrectMaterial = false;
             if (mesh.material instanceof THREE.MeshStandardMaterial) {
-              if (mesh.material.color.getHexString().toLowerCase() === elementClassificationColor.substring(1).toLowerCase() &&
-                mesh.material.opacity === 0.9 && mesh.material.transparent) {
+              if (
+                mesh.material.color.getHexString().toLowerCase() ===
+                  elementClassificationColor.substring(1).toLowerCase() &&
+                mesh.material.opacity === 0.9 &&
+                mesh.material.transparent
+              ) {
                 isCorrectMaterial = true;
                 targetMaterial = mesh.material; // Use existing material instance
               }
@@ -627,18 +636,27 @@ export function IFCModel({ modelData, outlineLayer }: IFCModelProps) {
 
         // Step 2: Apply single highlighted classification effects
         if (highlightedClassificationCode) {
-          const activeClassification = classifications[highlightedClassificationCode];
-          const isElementInActiveClassification = activeClassification?.elements?.some(
-            (el: SelectedElementInfo) => el && el.modelID === currentModelID && el.expressID === expressID
-          );
+          const activeClassification =
+            classifications[highlightedClassificationCode];
+          const isElementInActiveClassification =
+            activeClassification?.elements?.some(
+              (el: SelectedElementInfo) =>
+                el &&
+                el.modelID === currentModelID &&
+                el.expressID === expressID
+            );
 
           if (isElementInActiveClassification) {
             isCurrentlyVisible = true;
             if (activeClassification && activeClassification.color) {
               let isCorrectMaterial = false;
               if (mesh.material instanceof THREE.MeshStandardMaterial) {
-                if (mesh.material.color.getHexString().toLowerCase() === activeClassification.color.substring(1).toLowerCase() &&
-                  mesh.material.opacity === 0.7 && mesh.material.transparent) {
+                if (
+                  mesh.material.color.getHexString().toLowerCase() ===
+                    activeClassification.color.substring(1).toLowerCase() &&
+                  mesh.material.opacity === 0.7 &&
+                  mesh.material.transparent
+                ) {
                   isCorrectMaterial = true;
                   targetMaterial = mesh.material;
                 }
@@ -646,12 +664,18 @@ export function IFCModel({ modelData, outlineLayer }: IFCModelProps) {
               if (!isCorrectMaterial) {
                 targetMaterial = new THREE.MeshStandardMaterial({
                   color: new THREE.Color(activeClassification.color),
-                  transparent: true, opacity: 0.7, side: THREE.DoubleSide,
+                  transparent: true,
+                  opacity: 0.7,
+                  side: THREE.DoubleSide,
                 });
               }
             }
           } else {
-            if (activeClassification && activeClassification.elements && activeClassification.elements.length > 0) {
+            if (
+              activeClassification &&
+              activeClassification.elements &&
+              activeClassification.elements.length > 0
+            ) {
               isCurrentlyVisible = false;
               targetMaterial = trueOriginalMaterial;
             } else {
@@ -662,7 +686,9 @@ export function IFCModel({ modelData, outlineLayer }: IFCModelProps) {
 
         // Step 3: Apply User Hidden State (high precedence, but selected can override)
         const isUserExplicitlyHidden = userHiddenElements.some(
-          (hiddenEl) => hiddenEl.modelID === currentModelID && hiddenEl.expressID === expressID
+          (hiddenEl) =>
+            hiddenEl.modelID === currentModelID &&
+            hiddenEl.expressID === expressID
         );
 
         if (isUserExplicitlyHidden) {
@@ -670,7 +696,11 @@ export function IFCModel({ modelData, outlineLayer }: IFCModelProps) {
         }
 
         // Step 4: Selected Element (highest priority for visibility and material)
-        if (selectedElement && selectedElement.modelID === currentModelID && selectedElement.expressID === expressID) {
+        if (
+          selectedElement &&
+          selectedElement.modelID === currentModelID &&
+          selectedElement.expressID === expressID
+        ) {
           targetMaterial = selectionMaterial;
           isCurrentlyVisible = true;
         }
@@ -680,15 +710,34 @@ export function IFCModel({ modelData, outlineLayer }: IFCModelProps) {
         // Apply the determined targetMaterial, with disposal check
         if (mesh.material !== targetMaterial && isCurrentlyVisible) {
           const oldMaterial = mesh.material as THREE.Material;
-          if (oldMaterial !== trueOriginalMaterial && !(Array.isArray(trueOriginalMaterial) && trueOriginalMaterial.includes(oldMaterial)) && !Array.isArray(oldMaterial)) {
-            if (typeof oldMaterial.dispose === 'function') oldMaterial.dispose();
+          if (
+            oldMaterial !== trueOriginalMaterial &&
+            !(
+              Array.isArray(trueOriginalMaterial) &&
+              trueOriginalMaterial.includes(oldMaterial)
+            ) &&
+            !Array.isArray(oldMaterial)
+          ) {
+            if (typeof oldMaterial.dispose === "function")
+              oldMaterial.dispose();
           }
           mesh.material = targetMaterial;
-        } else if (!isCurrentlyVisible && mesh.material !== trueOriginalMaterial) {
+        } else if (
+          !isCurrentlyVisible &&
+          mesh.material !== trueOriginalMaterial
+        ) {
           if (mesh.material !== trueOriginalMaterial) {
             const oldMaterial = mesh.material as THREE.Material;
-            if (oldMaterial !== trueOriginalMaterial && !(Array.isArray(trueOriginalMaterial) && trueOriginalMaterial.includes(oldMaterial)) && !Array.isArray(oldMaterial)) {
-              if (typeof oldMaterial.dispose === 'function') oldMaterial.dispose();
+            if (
+              oldMaterial !== trueOriginalMaterial &&
+              !(
+                Array.isArray(trueOriginalMaterial) &&
+                trueOriginalMaterial.includes(oldMaterial)
+              ) &&
+              !Array.isArray(oldMaterial)
+            ) {
+              if (typeof oldMaterial.dispose === "function")
+                oldMaterial.dispose();
             }
             mesh.material = trueOriginalMaterial;
           }
@@ -738,7 +787,6 @@ export function IFCModel({ modelData, outlineLayer }: IFCModelProps) {
         if (!selectedElement) {
           setElementProperties(null);
         }
-        setAvailableProperties([]);
         console.log(
           `IFCModel (${modelData.id}) - Property Fetch (Full Approach): Aborting due to missing selection, API, or modelID mismatch.`,
           {
@@ -893,13 +941,14 @@ export function IFCModel({ modelData, outlineLayer }: IFCModelProps) {
                     else
                       propValue = propToProcess.type
                         ? `(Type is ${typeOfPropType}: ${String(
-                          propToProcess.type
-                        )})`
+                            propToProcess.type
+                          )})`
                         : `(Unknown Type)`;
                   }
                   targetPSetData[propToProcess.Name.value] = propValue;
                   console.log(
-                    `      [${psetNameForLogging}] Successfully processed Property '${propToProcess.Name.value
+                    `      [${psetNameForLogging}] Successfully processed Property '${
+                      propToProcess.Name.value
                     }': ${JSON.stringify(propValue)}`
                   );
                 } else {
@@ -967,7 +1016,8 @@ export function IFCModel({ modelData, outlineLayer }: IFCModelProps) {
             true
           );
           console.log(
-            `  Found ${psetsFromApi?.length || 0
+            `  Found ${
+              psetsFromApi?.length || 0
             } PSet definitions via getPropertySets()`
           );
           if (psetsFromApi && psetsFromApi.length > 0) {
@@ -1115,7 +1165,8 @@ export function IFCModel({ modelData, outlineLayer }: IFCModelProps) {
             true
           );
           console.log(
-            `  Found ${typeObjects?.length || 0
+            `  Found ${
+              typeObjects?.length || 0
             } Type definitions via getTypeProperties()`
           );
           if (typeObjects && typeObjects.length > 0) {
@@ -1276,7 +1327,8 @@ export function IFCModel({ modelData, outlineLayer }: IFCModelProps) {
             true
           );
           console.log(
-            `  Found ${materials?.length || 0
+            `  Found ${
+              materials?.length || 0
             } Material definitions via getMaterialsProperties()`
           );
           if (materials && materials.length > 0) {
@@ -1388,13 +1440,14 @@ export function IFCModel({ modelData, outlineLayer }: IFCModelProps) {
           const group = psetsData[groupName];
           for (const key in group) {
             if (Object.prototype.hasOwnProperty.call(group, key)) {
-              const full = groupName === "Element Attributes" ? key : `${groupName}.${key}`;
+              const full =
+                groupName === "Element Attributes"
+                  ? key
+                  : `${groupName}.${key}`;
               collectedProps.add(full);
             }
           }
         }
-        setAvailableProperties(Array.from(collectedProps).sort());
-
         setElementProperties(allProperties);
         console.log(
           `IFCModel (${modelData.id}): Properties set (Full Approach) for ${currentSelectedExpressID}`,
@@ -1406,7 +1459,6 @@ export function IFCModel({ modelData, outlineLayer }: IFCModelProps) {
           error
         );
         setElementProperties(null);
-        setAvailableProperties([]);
       }
       console.timeEnd(
         `fetchProps-full-${currentSelectedExpressID}-m${currentModelID}`

--- a/components/ifc-model.tsx
+++ b/components/ifc-model.tsx
@@ -1434,20 +1434,7 @@ export function IFCModel({ modelData, outlineLayer }: IFCModelProps) {
           propertySets: psetsData,
         };
 
-        const collectedProps = new Set<string>();
-        collectedProps.add("ifcType");
-        for (const groupName of Object.keys(psetsData)) {
-          const group = psetsData[groupName];
-          for (const key in group) {
-            if (Object.prototype.hasOwnProperty.call(group, key)) {
-              const full =
-                groupName === "Element Attributes"
-                  ? key
-                  : `${groupName}.${key}`;
-              collectedProps.add(full);
-            }
-          }
-        }
+// (The unused `collectedProps` block has been removed)
         setElementProperties(allProperties);
         console.log(
           `IFCModel (${modelData.id}): Properties set (Full Approach) for ${currentSelectedExpressID}`,

--- a/components/ifc-model.tsx
+++ b/components/ifc-model.tsx
@@ -182,6 +182,7 @@ export function IFCModel({ modelData, outlineLayer }: IFCModelProps) {
     highlightedClassificationCode,
     setModelIDForLoadedModel,
     setAvailableCategoriesForModel,
+    setAvailableProperties,
     classifications,
     showAllClassificationColors,
     userHiddenElements,
@@ -734,7 +735,10 @@ export function IFCModel({ modelData, outlineLayer }: IFCModelProps) {
         internalApiIdForEffects === null ||
         selectedElement.modelID !== internalApiIdForEffects
       ) {
-        if (!selectedElement) setElementProperties(null);
+        if (!selectedElement) {
+          setElementProperties(null);
+        }
+        setAvailableProperties([]);
         console.log(
           `IFCModel (${modelData.id}) - Property Fetch (Full Approach): Aborting due to missing selection, API, or modelID mismatch.`,
           {
@@ -1378,6 +1382,19 @@ export function IFCModel({ modelData, outlineLayer }: IFCModelProps) {
           propertySets: psetsData,
         };
 
+        const collectedProps = new Set<string>();
+        collectedProps.add("ifcType");
+        for (const groupName of Object.keys(psetsData)) {
+          const group = psetsData[groupName];
+          for (const key in group) {
+            if (Object.prototype.hasOwnProperty.call(group, key)) {
+              const full = groupName === "Element Attributes" ? key : `${groupName}.${key}`;
+              collectedProps.add(full);
+            }
+          }
+        }
+        setAvailableProperties(Array.from(collectedProps).sort());
+
         setElementProperties(allProperties);
         console.log(
           `IFCModel (${modelData.id}): Properties set (Full Approach) for ${currentSelectedExpressID}`,
@@ -1389,6 +1406,7 @@ export function IFCModel({ modelData, outlineLayer }: IFCModelProps) {
           error
         );
         setElementProperties(null);
+        setAvailableProperties([]);
       }
       console.timeEnd(
         `fetchProps-full-${currentSelectedExpressID}-m${currentModelID}`

--- a/components/rule-panel.tsx
+++ b/components/rule-panel.tsx
@@ -34,17 +34,6 @@ import {
 import { Badge } from "@/components/ui/badge";
 import { Plus, Trash2, Edit, Play, Settings2, PlayCircle, CheckCircle2, XCircle, Tag } from "lucide-react";
 
-// Define a more specific type for what a rule property could be.
-// This might come from your IFC model's available properties/categories.
-const availableRuleProperties = [
-  { value: "ifcType", label: "IFC Type (e.g., IFCWALL)" },
-  { value: "name", label: "Name" },
-  { value: "Pset_WallCommon.IsExternal", label: "IsExternal (Wall)" },
-  { value: "Pset_WallCommon.IsLoadBearing", label: "IsLoadBearing (Wall)" },
-  { value: "Pset_BuildingStorey.Name", label: "Building Storey Name" },
-  // Add more relevant properties here
-];
-
 const availableOperators = [
   { value: "equals", label: "Equals" },
   { value: "notEquals", label: "Not Equals" },
@@ -54,11 +43,16 @@ const availableOperators = [
 ];
 
 export function RulePanel() {
-  const { rules, addRule, removeRule, updateRule, classifications, previewRuleHighlight, previewingRuleId } =
+  const { rules, addRule, removeRule, updateRule, classifications, previewRuleHighlight, previewingRuleId, availableProperties } =
     useIFCContext();
   const [isRuleDialogOpen, setIsRuleDialogOpen] = useState(false);
   const [currentRule, setCurrentRule] = useState<Rule | null>(null);
   const [editingRule, setEditingRule] = useState<Partial<Rule> | null>(null);
+
+  const propertyOptions =
+    availableProperties && availableProperties.length > 0
+      ? availableProperties.map((p) => ({ value: p, label: p }))
+      : [{ value: "ifcType", label: "ifcType" }];
 
   const openNewRuleDialog = () => {
     setEditingRule({
@@ -67,7 +61,7 @@ export function RulePanel() {
       description: "",
       conditions: [
         {
-          property: availableRuleProperties[0].value,
+          property: propertyOptions[0].value,
           operator: "equals",
           value: "",
         },
@@ -119,7 +113,7 @@ export function RulePanel() {
         conditions: [
           ...editingRule.conditions,
           {
-            property: availableRuleProperties[0].value,
+            property: propertyOptions[0].value,
             operator: "equals",
             value: "",
           },
@@ -238,7 +232,7 @@ export function RulePanel() {
                             className="flex flex-nowrap items-baseline gap-x-2 p-1 bg-muted/30 rounded text-xs"
                           >
                             <span className="font-medium text-foreground/90 whitespace-nowrap">
-                              {availableRuleProperties.find(
+                            {propertyOptions.find(
                                 (p) => p.value === condition.property
                               )?.label || condition.property}
                             </span>
@@ -325,7 +319,7 @@ export function RulePanel() {
                             <SelectValue placeholder="Select property" />
                           </SelectTrigger>
                           <SelectContent>
-                            {availableRuleProperties.map((prop) => (
+                            {propertyOptions.map((prop) => (
                               <SelectItem key={prop.value} value={prop.value}>
                                 {prop.label}
                               </SelectItem>

--- a/components/rule-panel.tsx
+++ b/components/rule-panel.tsx
@@ -24,6 +24,10 @@ import {
 } from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
 import {
+  CreatableCombobox,
+  ComboboxOption,
+} from "@/components/ui/creatable-combobox";
+import {
   Table,
   TableBody,
   TableCell,
@@ -32,7 +36,17 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { Badge } from "@/components/ui/badge";
-import { Plus, Trash2, Edit, Play, Settings2, PlayCircle, CheckCircle2, XCircle, Tag } from "lucide-react";
+import {
+  Plus,
+  Trash2,
+  Edit,
+  Play,
+  Settings2,
+  PlayCircle,
+  CheckCircle2,
+  XCircle,
+  Tag,
+} from "lucide-react";
 
 const availableOperators = [
   { value: "equals", label: "Equals" },
@@ -43,8 +57,16 @@ const availableOperators = [
 ];
 
 export function RulePanel() {
-  const { rules, addRule, removeRule, updateRule, classifications, previewRuleHighlight, previewingRuleId, availableProperties } =
-    useIFCContext();
+  const {
+    rules,
+    addRule,
+    removeRule,
+    updateRule,
+    classifications,
+    previewRuleHighlight,
+    previewingRuleId,
+    availableProperties,
+  } = useIFCContext();
   const [isRuleDialogOpen, setIsRuleDialogOpen] = useState(false);
   const [currentRule, setCurrentRule] = useState<Rule | null>(null);
   const [editingRule, setEditingRule] = useState<Partial<Rule> | null>(null);
@@ -152,7 +174,8 @@ export function RulePanel() {
       ) : (
         <div className="space-y-4">
           {rules.map((rule) => {
-            const targetClassification = classifications[rule.classificationCode];
+            const targetClassification =
+              classifications[rule.classificationCode];
             return (
               <div
                 key={rule.id}
@@ -166,7 +189,9 @@ export function RulePanel() {
                       ) : (
                         <XCircle className="h-5 w-5 text-muted-foreground flex-shrink-0" />
                       )}
-                      <h4 className="font-semibold text-lg text-foreground truncate">{rule.name}</h4>
+                      <h4 className="font-semibold text-lg text-foreground truncate">
+                        {rule.name}
+                      </h4>
                     </div>
                     {rule.description && (
                       <p className="text-sm text-muted-foreground truncate">
@@ -177,7 +202,9 @@ export function RulePanel() {
                       <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
                         <Tag className="h-3.5 w-3.5" />
                         <span
-                          style={{ color: targetClassification.color || 'inherit' }}
+                          style={{
+                            color: targetClassification.color || "inherit",
+                          }}
                           className="font-medium"
                         >
                           {targetClassification.name || rule.classificationCode}
@@ -191,7 +218,11 @@ export function RulePanel() {
                       size="icon"
                       className="h-8 w-8 text-blue-500 hover:text-blue-600 hover:bg-blue-500/10"
                       onClick={() => previewRuleHighlight(rule.id)}
-                      title={previewingRuleId === rule.id ? "Clear Preview" : "Preview Rule Impact"}
+                      title={
+                        previewingRuleId === rule.id
+                          ? "Clear Preview"
+                          : "Preview Rule Impact"
+                      }
                     >
                       {previewingRuleId === rule.id ? (
                         <PlayCircle className="h-5 w-5" />
@@ -232,7 +263,7 @@ export function RulePanel() {
                             className="flex flex-nowrap items-baseline gap-x-2 p-1 bg-muted/30 rounded text-xs"
                           >
                             <span className="font-medium text-foreground/90 whitespace-nowrap">
-                            {propertyOptions.find(
+                              {propertyOptions.find(
                                 (p) => p.value === condition.property
                               )?.label || condition.property}
                             </span>
@@ -309,23 +340,16 @@ export function RulePanel() {
                       className="grid grid-cols-12 gap-2 items-center"
                     >
                       <div className="col-span-4">
-                        <Select
+                        <CreatableCombobox
+                          options={propertyOptions}
                           value={condition.property}
-                          onValueChange={(value) =>
+                          onChange={(value) =>
                             handleConditionChange(index, "property", value)
                           }
-                        >
-                          <SelectTrigger>
-                            <SelectValue placeholder="Select property" />
-                          </SelectTrigger>
-                          <SelectContent>
-                            {propertyOptions.map((prop) => (
-                              <SelectItem key={prop.value} value={prop.value}>
-                                {prop.label}
-                              </SelectItem>
-                            ))}
-                          </SelectContent>
-                        </Select>
+                          placeholder="Select or create property..."
+                          searchPlaceholder="Search properties..."
+                          emptyResultText="No property found. Type to create."
+                        />
                       </div>
                       <div className="col-span-3">
                         <Select
@@ -335,7 +359,7 @@ export function RulePanel() {
                           }
                         >
                           <SelectTrigger>
-                            <SelectValue placeholder="Operator" />
+                            <SelectValue placeholder="Select operator" />
                           </SelectTrigger>
                           <SelectContent>
                             {availableOperators.map((op) => (
@@ -346,19 +370,20 @@ export function RulePanel() {
                           </SelectContent>
                         </Select>
                       </div>
-                      <div className="col-span-4">
-                        <Input
-                          value={String(condition.value)}
-                          onChange={(e) =>
-                            handleConditionChange(
-                              index,
-                              "value",
-                              e.target.value
-                            )
-                          }
-                          placeholder="Value"
-                        />
-                      </div>
+                      <Input
+                        id={`condition-value-${index}`}
+                        value={String(condition.value)}
+                        onChange={(e) =>
+                          handleConditionChange(index, "value", e.target.value)
+                        }
+                        placeholder={
+                          condition.property.toLowerCase().includes("is") ||
+                          condition.property.toLowerCase().includes("has")
+                            ? "e.g., true, false, yes, no"
+                            : "Value"
+                        }
+                        className="col-span-3"
+                      />
                       <div className="col-span-1">
                         <Button
                           variant="ghost"

--- a/components/ui/creatable-combobox.tsx
+++ b/components/ui/creatable-combobox.tsx
@@ -1,0 +1,230 @@
+"use client";
+
+import * as React from "react";
+import { Check, ChevronsUpDown, PlusCircle } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+
+export interface ComboboxOption {
+  value: string;
+  label: string;
+}
+
+interface CreatableComboboxProps {
+  options: ComboboxOption[];
+  value?: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+  searchPlaceholder?: string;
+  emptyResultText?: string;
+  createText?: (value: string) => string;
+  className?: string;
+  popoverClassName?: string;
+}
+
+export function CreatableCombobox({
+  options,
+  value,
+  onChange,
+  placeholder = "Select an option...",
+  searchPlaceholder = "Search or create...",
+  emptyResultText = "No results found.",
+  createText = (searchValue) => `Create "${searchValue}"`,
+  className,
+  popoverClassName,
+}: CreatableComboboxProps) {
+  const [open, setOpen] = React.useState(false);
+  const [inputValue, setInputValue] = React.useState("");
+  const [selectedOption, setSelectedOption] =
+    React.useState<ComboboxOption | null>(() => {
+      const initialOption = options.find((option) => option.value === value);
+      if (initialOption) {
+        return initialOption;
+      }
+      if (value) {
+        return { value: value, label: value };
+      }
+      return null;
+    });
+
+  React.useEffect(() => {
+    const foundOption = options.find((option) => option.value === value);
+    if (foundOption) {
+      setSelectedOption(foundOption);
+    } else if (value) {
+      setSelectedOption({ value: value, label: value });
+    } else {
+      setSelectedOption(null);
+    }
+  }, [value, options]);
+
+  const handleSelectOption = (currentValue: string) => {
+    const option = options.find(
+      (opt) => opt.value.toLowerCase() === currentValue.toLowerCase()
+    );
+    if (option) {
+      onChange(option.value);
+      setSelectedOption(option);
+      setInputValue("");
+    } else {
+      onChange(currentValue);
+      setSelectedOption({ value: currentValue, label: currentValue });
+      setInputValue("");
+    }
+    setOpen(false);
+  };
+
+  const filteredOptions = React.useMemo(() => {
+    if (!inputValue) {
+      return options;
+    }
+    return options.filter((option) =>
+      option.label.toLowerCase().includes(inputValue.toLowerCase())
+    );
+  }, [options, inputValue]);
+
+  const showCreateOption =
+    inputValue &&
+    !filteredOptions.some(
+      (option) => option.label.toLowerCase() === inputValue.toLowerCase()
+    ) &&
+    !options.some(
+      (option) => option.value.toLowerCase() === inputValue.toLowerCase()
+    );
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          variant="outline"
+          role="combobox"
+          aria-expanded={open}
+          className={cn("w-full justify-between", className)}
+        >
+          {selectedOption ? selectedOption.label : placeholder}
+          <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent
+        className={cn(
+          "p-0",
+          "min-w-[--radix-popover-trigger-width]",
+          "w-[300px]",
+          "sm:w-[350px]",
+          "max-w-[calc(100vw-2rem)]",
+          "sm:max-w-sm",
+          "md:max-w-md",
+          popoverClassName
+        )}
+        align="center"
+        side="right"
+        sideOffset={8}
+        sticky="partial"
+        collisionPadding={10}
+      >
+        <Command shouldFilter={false}>
+          <CommandInput
+            placeholder={searchPlaceholder}
+            value={inputValue}
+            onValueChange={setInputValue}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                if (inputValue && !open) {
+                  setOpen(true);
+                } else if (open && inputValue) {
+                  e.preventDefault();
+                  const exactMatch = filteredOptions.find(
+                    (opt) =>
+                      opt.label.toLowerCase() === inputValue.toLowerCase()
+                  );
+                  if (exactMatch) {
+                    handleSelectOption(exactMatch.value);
+                  } else {
+                    handleSelectOption(inputValue);
+                  }
+                }
+              }
+            }}
+            className="h-10"
+          />
+          <CommandList className="max-h-[80vh] beautiful-scrollbar">
+            <CommandEmpty>{!showCreateOption && emptyResultText}</CommandEmpty>
+            <CommandGroup>
+              {filteredOptions.map((option) => (
+                <CommandItem
+                  key={option.value}
+                  value={option.value}
+                  onSelect={() => {
+                    handleSelectOption(option.value);
+                  }}
+                  className="cursor-pointer"
+                >
+                  <Check
+                    className={cn(
+                      "mr-2 h-4 w-4",
+                      selectedOption?.value === option.value
+                        ? "opacity-100"
+                        : "opacity-0"
+                    )}
+                  />
+                  {option.label}
+                </CommandItem>
+              ))}
+              {showCreateOption && (
+                <CommandItem
+                  key="__create__"
+                  value={inputValue}
+                  onSelect={() => {
+                    handleSelectOption(inputValue);
+                  }}
+                  className="text-muted-foreground italic cursor-pointer"
+                >
+                  <PlusCircle className="mr-2 h-4 w-4" />
+                  {createText(inputValue)}
+                </CommandItem>
+              )}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+/*
+.beautiful-scrollbar::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+.beautiful-scrollbar::-webkit-scrollbar-thumb {
+  background-color: hsl(var(--muted)); 
+  border-radius: 10px;
+  border: 2px solid transparent;
+  background-clip: content-box;
+}
+.beautiful-scrollbar::-webkit-scrollbar-thumb:hover {
+  background-color: hsl(var(--muted-foreground)); 
+}
+.beautiful-scrollbar::-webkit-scrollbar-track {
+  background: transparent; 
+  border-radius: 10px;
+}
+.beautiful-scrollbar {
+  scrollbar-width: thin;
+  scrollbar-color: hsl(var(--muted)) transparent; 
+}
+*/

--- a/context/ifc-context.tsx
+++ b/context/ifc-context.tsx
@@ -70,6 +70,8 @@ interface IFCContextType {
   showAllClassificationColors: boolean; // Added for global classification colors visibility
   previewingRuleId: string | null; // Added to track active rule preview
   userHiddenElements: SelectedElementInfo[]; // New state for user-hidden elements
+  availableProperties: string[]; // Collected property names for rule building
+  setAvailableProperties: (props: string[]) => void;
 
   replaceIFCModel: (
     url: string,
@@ -130,6 +132,7 @@ export function IFCContextProvider({ children }: { children: ReactNode }) {
   const [showAllClassificationColors, setShowAllClassificationColors] = useState<boolean>(false);
   const [previewingRuleId, setPreviewingRuleId] = useState<string | null>(null); // Added state
   const [userHiddenElements, setUserHiddenElements] = useState<SelectedElementInfo[]>([]); // New state
+  const [availableProperties, setAvailablePropertiesInternal] = useState<string[]>([]);
 
   // Initialize classifications with a default entry
   const [classifications, setClassifications] = useState<Record<string, any>>({
@@ -479,6 +482,10 @@ export function IFCContextProvider({ children }: { children: ReactNode }) {
     setElementPropertiesInternal(properties);
   }, [setElementPropertiesInternal]);
 
+  const setAvailableProperties = useCallback((props: string[]) => {
+    setAvailablePropertiesInternal(props);
+  }, [setAvailablePropertiesInternal]);
+
   const setAvailableCategoriesForModel = useCallback((modelID: number, cats: string[]) => {
     setAvailableCategoriesInternal((prev) => ({ ...prev, [modelID]: cats }));
   }, [setAvailableCategoriesInternal]);
@@ -584,6 +591,7 @@ export function IFCContextProvider({ children }: { children: ReactNode }) {
         showAllClassificationColors,
         previewingRuleId,
         userHiddenElements,
+        availableProperties,
         replaceIFCModel,
         addIFCModel,
         removeIFCModel,
@@ -594,6 +602,7 @@ export function IFCContextProvider({ children }: { children: ReactNode }) {
         toggleClassificationHighlight,
         setElementProperties,
         setAvailableCategoriesForModel,
+        setAvailableProperties,
         setIfcApi,
         toggleShowAllClassificationColors,
         addClassification,

--- a/context/ifc-context.tsx
+++ b/context/ifc-context.tsx
@@ -124,15 +124,23 @@ export function IFCContextProvider({ children }: { children: ReactNode }) {
   const [highlightedElements, setHighlightedElements] = useState<
     SelectedElementInfo[]
   >([]);
-  const [elementProperties, setElementPropertiesInternal] = useState<any | null>(null);
+  const [elementProperties, setElementPropertiesInternal] = useState<
+    any | null
+  >(null);
   const [availableCategories, setAvailableCategoriesInternal] = useState<
     Record<number, string[]>
   >({});
-  const [highlightedClassificationCode, setHighlightedClassificationCode] = useState<string | null>(null);
-  const [showAllClassificationColors, setShowAllClassificationColors] = useState<boolean>(false);
+  const [highlightedClassificationCode, setHighlightedClassificationCode] =
+    useState<string | null>(null);
+  const [showAllClassificationColors, setShowAllClassificationColors] =
+    useState<boolean>(false);
   const [previewingRuleId, setPreviewingRuleId] = useState<string | null>(null); // Added state
-  const [userHiddenElements, setUserHiddenElements] = useState<SelectedElementInfo[]>([]); // New state
-  const [availableProperties, setAvailablePropertiesInternal] = useState<string[]>([]);
+  const [userHiddenElements, setUserHiddenElements] = useState<
+    SelectedElementInfo[]
+  >([]); // New state
+  const [availableProperties, setAvailablePropertiesInternal] = useState<
+    string[]
+  >([]);
 
   // Initialize classifications with a default entry
   const [classifications, setClassifications] = useState<Record<string, any>>({
@@ -148,88 +156,506 @@ export function IFCContextProvider({ children }: { children: ReactNode }) {
   const [rules, setRules] = useState<Rule[]>([]);
   const [ifcApiInternal, setIfcApiInternal] = useState<IfcAPI | null>(null);
 
-  // Helper to get all elements from a spatial tree structure
-  const getAllElementsFromSpatialTreeNodesRecursive = useCallback((nodes: SpatialStructureNode[]): SpatialStructureNode[] => {
-    let elements: SpatialStructureNode[] = [];
-    for (const node of nodes) {
-      elements.push(node);
-      if (node.children && node.children.length > 0) {
-        elements = elements.concat(getAllElementsFromSpatialTreeNodesRecursive(node.children));
-      }
-    }
-    return elements;
-  }, []);
+  // Effect to collect and set available properties from all loaded models
+  useEffect(() => {
+    const fetchAllProperties = async () => {
+      if (!ifcApiInternal) return;
 
-  const matchesAllConditionsCallback = useCallback(async (
-    elementNode: SpatialStructureNode,
-    conditions: RuleCondition[],
-    modelID: number,
-    api: IfcAPI // Passed explicitly, not from context state directly in this func
-  ): Promise<boolean> => {
-    for (const condition of conditions) {
-      let elementValue: any;
-      const ruleValue = condition.value;
-      if (condition.property === "ifcType") {
-        elementValue = elementNode.type;
-      } else if (condition.property === "name") {
-        elementValue = elementNode.Name?.value || elementNode.Name;
-        if (elementValue === undefined && elementNode.expressID && api) {
-          try {
-            const props = await api.GetLine(modelID, elementNode.expressID);
-            elementValue = props.Name?.value;
-          } catch (e) { console.warn('Error fetching name for ' + elementNode.expressID + ':', e); return false; }
-        }
-      } else if (condition.property.startsWith("Pset_") && api && api.properties) {
-        const [psetName, propName] = condition.property.split(".");
-        if (!psetName || !propName) { console.warn("Invalid Pset property format:", condition.property); return false; }
+      if (!ifcApiInternal.properties) {
         try {
-          const psets = await api.properties.getPropertySets(modelID, elementNode.expressID, true);
-          const targetPset = psets.find((pset: any) => pset.Name?.value === psetName);
-          if (targetPset) {
-            const targetProp = targetPset.HasProperties?.find((prop: any) => prop.Name?.value === propName);
-            if (targetProp) {
-              elementValue = targetProp.NominalValue?.value !== undefined ? targetProp.NominalValue.value : targetProp.NominalValue;
+          ifcApiInternal.properties = new Properties(ifcApiInternal);
+        } catch (e) {
+          console.error(
+            "IFCContext: Failed to initialize ifcApi.properties",
+            e
+          );
+          return;
+        }
+      }
+
+      const allProps = new Set<string>();
+      // Add common/direct properties (instance or type)
+      allProps.add("Ifc Class"); // Renamed from ifcType, refers to entity type like IFCWALL
+      allProps.add("Name");
+      allProps.add("GlobalId");
+      allProps.add("Description");
+      allProps.add("ObjectType");
+      allProps.add("Tag");
+      allProps.add("PredefinedType"); // Common for many IfcElementType entities
+
+      for (const model of loadedModels) {
+        // Ensure modelID is present and the model is actually open with the current API instance
+        if (
+          model.modelID === null ||
+          !ifcApiInternal ||
+          !ifcApiInternal.IsModelOpen(model.modelID)
+        ) {
+          continue;
+        }
+
+        if (ifcApiInternal.properties) {
+          // Ensure properties helper is available on the API instance
+          try {
+            // 1. Get Property Sets (including those from types)
+            const psets = await ifcApiInternal.properties.getPropertySets(
+              model.modelID,
+              0, // Get for all elements/types in the model
+              true, // Recursive
+              true // Include type properties
+            );
+            psets.forEach((pset: any) => {
+              if (pset.Name?.value && pset.HasProperties) {
+                const psetName = pset.Name.value;
+                pset.HasProperties.forEach((prop: any) => {
+                  if (prop.Name?.value) {
+                    allProps.add(`${psetName}.${prop.Name.value}`);
+                  }
+                });
+              }
+            });
+
+            // 2. Get Type Properties (for attributes not in Psets on types)
+            const typeObjects =
+              await ifcApiInternal.properties.getTypeProperties(
+                model.modelID,
+                0, // Get all type objects
+                true // Recursive for their properties
+              );
+            typeObjects.forEach((typeObj: any) => {
+              // Add direct properties of the type object itself if they are simple
+              // (e.g. if ObjectType, Tag are directly on the type)
+              // This might be duplicative of the initial set but ensures capture.
+              if (typeObj.Name?.value) allProps.add("Name"); // Name of the type
+              if (typeObj.GlobalId?.value) allProps.add("GlobalId");
+              if (typeObj.Description?.value) allProps.add("Description");
+              if (typeObj.ObjectType?.value) allProps.add("ObjectType");
+              if (typeObj.Tag?.value) allProps.add("Tag");
+              if (typeObj.PredefinedType?.value) allProps.add("PredefinedType");
+
+              // If type objects themselves have property sets (common for IfcElementType)
+              if (typeObj.HasPropertySets) {
+                typeObj.HasPropertySets.forEach((pset: any) => {
+                  if (pset.Name?.value && pset.HasProperties) {
+                    const psetName = pset.Name.value;
+                    pset.HasProperties.forEach((prop: any) => {
+                      if (prop.Name?.value) {
+                        // To distinguish from instance psets, could prefix, but web-ifc might already handle this
+                        // by returning them via getPropertySets with includeTypeProperties=true.
+                        // For now, just add them; duplicates are handled by the Set.
+                        allProps.add(`${psetName}.${prop.Name.value}`);
+                      }
+                    });
+                  }
+                });
+              }
+            });
+          } catch (error) {
+            console.error(
+              `Error fetching properties for model ${model.modelID}:`,
+              error
+            );
+          }
+        }
+      }
+      const sortedProps = Array.from(allProps).sort();
+      setAvailablePropertiesInternal(sortedProps);
+      if (sortedProps.length > 0) {
+        console.log(
+          "IFCContext: Updated available properties for rule creation:",
+          sortedProps
+        );
+      }
+    };
+
+    fetchAllProperties();
+  }, [loadedModels, ifcApiInternal]); // Re-run when models or API instance changes
+
+  // Helper to get all elements from a spatial tree structure
+  const getAllElementsFromSpatialTreeNodesRecursive = useCallback(
+    (nodes: SpatialStructureNode[]): SpatialStructureNode[] => {
+      let elements: SpatialStructureNode[] = [];
+      for (const node of nodes) {
+        elements.push(node);
+        if (node.children && node.children.length > 0) {
+          elements = elements.concat(
+            getAllElementsFromSpatialTreeNodesRecursive(node.children)
+          );
+        }
+      }
+      return elements;
+    },
+    []
+  );
+
+  const matchesAllConditionsCallback = useCallback(
+    async (
+      elementNode: SpatialStructureNode,
+      conditions: RuleCondition[],
+      modelID: number,
+      api: IfcAPI // Passed explicitly, not from context state directly in this func
+    ): Promise<boolean> => {
+      if (!api.properties) {
+        console.warn(
+          "API properties not initialized in matchesAllConditionsCallback"
+        );
+        return false;
+      }
+
+      let itemProps: any = null; // To store properties fetched for the element
+
+      for (const condition of conditions) {
+        let elementValue: any;
+        const ruleValue = condition.value;
+
+        if (condition.property === "Ifc Class") {
+          elementValue = elementNode.type;
+        } else {
+          // Fetch all item properties once if not already fetched for this element
+          if (itemProps === null && elementNode.expressID) {
+            try {
+              itemProps = await api.properties.getItemProperties(
+                modelID,
+                elementNode.expressID,
+                true
+              );
+            } catch (e) {
+              console.warn(
+                `Error fetching item properties for ${elementNode.expressID}:`,
+                e
+              );
+              return false; // If properties can't be fetched, condition can't be reliably checked
             }
           }
-        } catch (e) { console.warn('Error fetching Pset ' + condition.property + ' for ' + elementNode.expressID + ':', e); /* Continue trying other conditions or rules */ }
-      } else { console.warn("Unsupported property:", condition.property); return false; }
 
-      const normElementValue = typeof elementValue === "string" ? elementValue.toLowerCase() : elementValue;
-      const normRuleValue = typeof ruleValue === "string" ? ruleValue.toLowerCase() : ruleValue;
-      let conditionMet = false;
-      switch (condition.operator) {
-        case "equals":
-          conditionMet = normElementValue === (typeof normElementValue === 'boolean' && typeof normRuleValue === 'string' ? (normRuleValue === 'true') : normRuleValue);
-          break;
-        case "notEquals":
-          conditionMet = normElementValue !== (typeof normElementValue === 'boolean' && typeof normRuleValue === 'string' ? (normRuleValue === 'true') : normRuleValue);
-          break;
-        case "contains":
-          conditionMet = typeof normElementValue === "string" && typeof normRuleValue === "string" && normElementValue.includes(normRuleValue);
-          break;
-        default: console.warn("Unsupported operator:", condition.operator); return false;
+          if (!itemProps) {
+            // Should not happen if expressID is valid and getItemProperties was called
+            console.warn(
+              `No itemProps available for ${elementNode.expressID} to check ${condition.property}`
+            );
+            return false;
+          }
+
+          if (condition.property.includes(".")) {
+            // Handle PSet properties (e.g., "Pset_WallCommon.Reference")
+            const [psetName, propName] = condition.property.split(".");
+            if (!psetName || !propName) {
+              console.warn("Invalid Pset property format:", condition.property);
+              return false;
+            }
+
+            // Revised PSet lookup
+            let psetObject: any = undefined;
+            if (itemProps && itemProps[psetName]) {
+              psetObject = itemProps[psetName];
+            } else if (itemProps && Array.isArray(itemProps.PropertySets)) {
+              psetObject = itemProps.PropertySets.find(
+                (ps: any) => ps.Name?.value === psetName
+              );
+            } else if (itemProps) {
+              for (const key in itemProps) {
+                if (
+                  Object.prototype.hasOwnProperty.call(itemProps, key) &&
+                  typeof itemProps[key] === "object" &&
+                  itemProps[key] !== null &&
+                  itemProps[key].Name?.value === psetName &&
+                  itemProps[key].HasProperties // Check if it looks like a PSet
+                ) {
+                  psetObject = itemProps[key];
+                  break;
+                }
+              }
+            }
+
+            // 4. If PSet still not found, try fetching from Type Properties
+            if (!psetObject && elementNode.expressID) {
+              if (condition.property === "Pset_WallCommon.IsExternal") {
+                // Debug for this specific property
+                console.log(
+                  `[DEBUG RULE TRACE - Type Fetch] Element ID: ${elementNode.expressID}, PSet ${psetName} not in itemProps. Attempting type property fetch.`
+                );
+              }
+              try {
+                const typeObjects = await api.properties.getTypeProperties(
+                  modelID,
+                  elementNode.expressID,
+                  true
+                );
+                for (const typeObj of typeObjects) {
+                  if (
+                    typeObj.HasPropertySets &&
+                    Array.isArray(typeObj.HasPropertySets)
+                  ) {
+                    const foundPsetInType = typeObj.HasPropertySets.find(
+                      (ps: any) => ps.Name?.value === psetName
+                    );
+                    if (foundPsetInType) {
+                      psetObject = foundPsetInType;
+                      if (condition.property === "Pset_WallCommon.IsExternal") {
+                        console.log(
+                          `[DEBUG RULE TRACE - Type Fetch] Element ID: ${elementNode.expressID}, Found PSet ${psetName} in Type Object:`,
+                          psetObject
+                            ? JSON.parse(JSON.stringify(psetObject))
+                            : "undefined"
+                        );
+                      }
+                      break; // Found the PSet in a type object
+                    }
+                  }
+                }
+              } catch (e) {
+                console.warn(
+                  `[RULE ENGINE] Error fetching type properties for ${elementNode.expressID} while looking for PSet ${psetName}:`,
+                  e
+                );
+              }
+            }
+
+            if (psetObject && psetObject.HasProperties) {
+              const targetProp = psetObject.HasProperties.find(
+                (p: any) => p.Name?.value === propName
+              );
+              if (targetProp) {
+                elementValue =
+                  targetProp.NominalValue?.value !== undefined
+                    ? targetProp.NominalValue.value
+                    : targetProp.NominalValue;
+              }
+              // DEBUG LOGGING START
+              if (condition.property === "Pset_WallCommon.IsExternal") {
+                console.log(
+                  `[DEBUG RULE TRACE] Element ID: ${elementNode.expressID}, Property: ${condition.property}`
+                );
+                console.log(
+                  `[DEBUG RULE TRACE] PSet Object (itemProps["${psetName}"]):`,
+                  psetObject
+                    ? JSON.parse(JSON.stringify(psetObject))
+                    : "undefined"
+                );
+                console.log(
+                  `[DEBUG RULE TRACE] Target Prop (${propName}):`,
+                  targetProp
+                    ? JSON.parse(JSON.stringify(targetProp))
+                    : "undefined"
+                );
+                console.log(
+                  `[DEBUG RULE TRACE] Raw elementValue:`,
+                  elementValue,
+                  `(type: ${typeof elementValue})`
+                );
+              }
+              // DEBUG LOGGING END
+            } else {
+              // Fallback checks if PSet not directly under itemProps[psetName]
+              // ... (existing fallback logic) ...
+              // DEBUG LOGGING START for fallback path
+              if (condition.property === "Pset_WallCommon.IsExternal") {
+                console.log(
+                  `[DEBUG RULE TRACE - Fallback] Element ID: ${elementNode.expressID}, Property: ${condition.property}`
+                );
+                console.log(
+                  `[DEBUG RULE TRACE - Fallback] itemProps keys:`,
+                  itemProps ? Object.keys(itemProps) : "itemProps undefined"
+                );
+                console.log(
+                  `[DEBUG RULE TRACE - Fallback] PSet Object for ${psetName} was not found directly or lacked HasProperties.`
+                );
+              }
+              // DEBUG LOGGING END for fallback path
+            }
+          } else {
+            // Handle direct attributes (e.g., "Name", "GlobalId", "Description")
+            const directPropValue = itemProps[condition.property];
+            if (directPropValue !== undefined) {
+              if (directPropValue?.hasOwnProperty("value")) {
+                elementValue = directPropValue.value;
+              } else {
+                elementValue = directPropValue;
+              }
+            } else if (elementNode[condition.property]) {
+              // Fallback to spatial tree node properties if direct attribute not in itemProps
+              // (e.g. Name might be on spatial tree node itself)
+              const nodeProp = elementNode[condition.property];
+              if (nodeProp?.hasOwnProperty("value")) {
+                elementValue = nodeProp.value;
+              } else {
+                elementValue = nodeProp;
+              }
+            }
+          }
+        }
+
+        // Existing normalization and comparison logic
+        const normElementValue =
+          typeof elementValue === "string"
+            ? elementValue.toLowerCase()
+            : elementValue;
+        const normRuleValue =
+          typeof ruleValue === "string" ? ruleValue.toLowerCase() : ruleValue;
+        let conditionMet = false;
+
+        const convertToBoolean = (val: any): boolean | undefined => {
+          if (typeof val === "boolean") return val;
+          if (typeof val === "number") {
+            if (val === 1) return true;
+            if (val === 0) return false;
+          }
+          if (typeof val === "string") {
+            if (["true", "yes", "1"].includes(val)) return true;
+            if (["false", "no", "0"].includes(val)) return false;
+          }
+          return undefined;
+        };
+
+        const valFromElement = convertToBoolean(normElementValue);
+        const valFromRule = convertToBoolean(normRuleValue); // normRuleValue is effectively always string from UI
+
+        // DEBUG LOGGING START (after value processing, before switch)
+        if (condition.property === "Pset_WallCommon.IsExternal") {
+          console.log(
+            `[DEBUG RULE TRACE] normElementValue:`,
+            normElementValue,
+            `(type: ${typeof normElementValue})`
+          );
+          console.log(
+            `[DEBUG RULE TRACE] valFromElement (boolean):`,
+            valFromElement
+          );
+          console.log(
+            `[DEBUG RULE TRACE] normRuleValue (user input):`,
+            normRuleValue
+          );
+          console.log(`[DEBUG RULE TRACE] valFromRule (boolean):`, valFromRule);
+        }
+        // DEBUG LOGGING END
+
+        switch (condition.operator) {
+          case "equals":
+            if (valFromElement !== undefined && valFromRule !== undefined) {
+              conditionMet = valFromElement === valFromRule;
+            } else if (
+              valFromElement !== undefined &&
+              valFromRule === undefined
+            ) {
+              // Element is bool, rule is "cat"
+              conditionMet = false;
+            } else if (
+              valFromElement === undefined &&
+              valFromRule !== undefined
+            ) {
+              // Element is "dog", rule is "true"
+              conditionMet = false;
+            } else {
+              // Both undefined as booleans, e.g. "dog" === "cat"
+              conditionMet = normElementValue === normRuleValue;
+            }
+            // DEBUG LOGGING START (inside switch, after conditionMet is set)
+            if (condition.property === "Pset_WallCommon.IsExternal") {
+              console.log(
+                `[DEBUG RULE TRACE] Final conditionMet for ${condition.operator}:`,
+                conditionMet
+              );
+            }
+            // DEBUG LOGGING END
+            break;
+          case "notEquals":
+            if (valFromElement !== undefined && valFromRule !== undefined) {
+              conditionMet = valFromElement !== valFromRule;
+            } else if (
+              valFromElement !== undefined &&
+              valFromRule === undefined
+            ) {
+              // Element is bool, rule is "cat" -> they are not equal
+              conditionMet = true;
+            } else if (
+              valFromElement === undefined &&
+              valFromRule !== undefined
+            ) {
+              // Element is "dog", rule is "true" -> they are not equal
+              conditionMet = true;
+            } else {
+              // Both undefined as booleans, e.g. "dog" !== "cat"
+              conditionMet = normElementValue !== normRuleValue;
+            }
+            // DEBUG LOGGING START (inside switch, after conditionMet is set)
+            if (condition.property === "Pset_WallCommon.IsExternal") {
+              console.log(
+                `[DEBUG RULE TRACE] Final conditionMet for ${condition.operator}:`,
+                conditionMet
+              );
+            }
+            // DEBUG LOGGING END
+            break;
+          case "contains":
+            conditionMet =
+              typeof normElementValue === "string" &&
+              typeof normRuleValue === "string" &&
+              normElementValue.includes(normRuleValue);
+            // DEBUG LOGGING START (inside switch, after conditionMet is set)
+            if (condition.property === "Pset_WallCommon.IsExternal") {
+              console.log(
+                `[DEBUG RULE TRACE] Final conditionMet for ${condition.operator}:`,
+                conditionMet
+              );
+            }
+            // DEBUG LOGGING END
+            break;
+          case "greaterThan":
+            {
+              const numElementValue = parseFloat(String(normElementValue));
+              const numRuleValue = parseFloat(String(normRuleValue));
+              if (!isNaN(numElementValue) && !isNaN(numRuleValue)) {
+                conditionMet = numElementValue > numRuleValue;
+              } else {
+                conditionMet = false;
+              }
+            }
+            break;
+          case "lessThan":
+            {
+              const numElementValue = parseFloat(String(normElementValue));
+              const numRuleValue = parseFloat(String(normRuleValue));
+              if (!isNaN(numElementValue) && !isNaN(numRuleValue)) {
+                conditionMet = numElementValue < numRuleValue;
+              } else {
+                conditionMet = false;
+              }
+            }
+            break;
+          default:
+            console.warn("Unsupported operator:", condition.operator);
+            return false;
+        }
+        if (!conditionMet) return false;
       }
-      if (!conditionMet) return false;
-    }
-    return true;
-  }, []);
+      return true;
+    },
+    []
+  );
 
   const applyAllActiveRules = useCallback(async () => {
     if (!ifcApiInternal) {
-      console.log("IFC API not available, skipping rule application that might need it.");
+      console.log(
+        "IFC API not available, skipping rule application that might need it."
+      );
       // Only clear elements if there are no models. Definitions should persist.
       if (loadedModels.length === 0) {
-        setClassifications(prevClassifications => {
+        setClassifications((prevClassifications) => {
           const newCleared = { ...prevClassifications };
           let actuallyClearedSomething = false;
           for (const code in newCleared) {
-            if (newCleared[code] && newCleared[code].elements && newCleared[code].elements.length > 0) {
+            if (
+              newCleared[code] &&
+              newCleared[code].elements &&
+              newCleared[code].elements.length > 0
+            ) {
               newCleared[code] = { ...newCleared[code], elements: [] };
               actuallyClearedSomething = true;
             }
           }
           if (actuallyClearedSomething) {
-            console.log("IFCContext: IFC API not available & no models: Ensured all classification elements are empty.");
+            console.log(
+              "IFCContext: IFC API not available & no models: Ensured all classification elements are empty."
+            );
           }
           return newCleared;
         });
@@ -242,27 +668,39 @@ export function IFCContextProvider({ children }: { children: ReactNode }) {
       try {
         ifcApiInternal.properties = new Properties(ifcApiInternal);
       } catch (e) {
-        console.error("IFCContext: Failed to initialize ifcApi.properties in applyAllActiveRules", e);
+        console.error(
+          "IFCContext: Failed to initialize ifcApi.properties in applyAllActiveRules",
+          e
+        );
         return; // Cannot proceed without properties
       }
     }
 
     console.log("IFCContext: Applying all active rules...");
 
-    // If no models are fully ready (have modelID and spatialTree), 
+    // If no models are fully ready (have modelID and spatialTree),
     // just ensure all classification elements are empty and then return.
-    if (loadedModels.filter(m => m.modelID != null && m.spatialTree != null).length === 0) {
-      setClassifications(prevClassifications => {
+    if (
+      loadedModels.filter((m) => m.modelID != null && m.spatialTree != null)
+        .length === 0
+    ) {
+      setClassifications((prevClassifications) => {
         const newCleared = { ...prevClassifications };
         let actuallyClearedSomething = false;
         for (const code in newCleared) {
-          if (newCleared[code] && newCleared[code].elements && newCleared[code].elements.length > 0) {
+          if (
+            newCleared[code] &&
+            newCleared[code].elements &&
+            newCleared[code].elements.length > 0
+          ) {
             newCleared[code] = { ...newCleared[code], elements: [] };
             actuallyClearedSomething = true;
           }
         }
         if (actuallyClearedSomething) {
-          console.log("IFCContext: No models ready, ensured rule-based elements from classifications are empty.");
+          console.log(
+            "IFCContext: No models ready, ensured rule-based elements from classifications are empty."
+          );
         }
         // else {
         //      console.log("IFCContext: No models ready, classifications elements were already empty or no classifications.");
@@ -274,18 +712,27 @@ export function IFCContextProvider({ children }: { children: ReactNode }) {
 
     // Proceed with rule application if models are ready
     const currentClassificationsForProcessing = classifications;
-    const currentClassificationCodes = Object.keys(currentClassificationsForProcessing);
-    const newElementsPerClassification: Record<string, SelectedElementInfo[]> = {};
+    const currentClassificationCodes = Object.keys(
+      currentClassificationsForProcessing
+    );
+    const newElementsPerClassification: Record<string, SelectedElementInfo[]> =
+      {};
 
     for (const classCode of currentClassificationCodes) {
       newElementsPerClassification[classCode] = [];
     }
 
-    const activeRules = rules.filter(rule => rule.active && currentClassificationsForProcessing[rule.classificationCode]);
+    const activeRules = rules.filter(
+      (rule) =>
+        rule.active &&
+        currentClassificationsForProcessing[rule.classificationCode]
+    );
 
     for (const model of loadedModels) {
       if (model.modelID == null || !model.spatialTree) continue;
-      const allModelElements = getAllElementsFromSpatialTreeNodesRecursive(model.spatialTree ? [model.spatialTree] : []);
+      const allModelElements = getAllElementsFromSpatialTreeNodesRecursive(
+        model.spatialTree ? [model.spatialTree] : []
+      );
       for (const rule of activeRules) {
         if (!newElementsPerClassification[rule.classificationCode]) {
           // This should not happen if initialized above, but as a safeguard
@@ -294,208 +741,415 @@ export function IFCContextProvider({ children }: { children: ReactNode }) {
         for (const elementNode of allModelElements) {
           if (elementNode.expressID === undefined) continue;
           try {
-            const matches = await matchesAllConditionsCallback(elementNode, rule.conditions, model.modelID, ifcApiInternal);
+            const matches = await matchesAllConditionsCallback(
+              elementNode,
+              rule.conditions,
+              model.modelID,
+              ifcApiInternal
+            );
             if (matches) {
-              const elementInfo: SelectedElementInfo = { modelID: model.modelID, expressID: elementNode.expressID };
+              const elementInfo: SelectedElementInfo = {
+                modelID: model.modelID,
+                expressID: elementNode.expressID,
+              };
               // Ensure no duplicates
-              if (!newElementsPerClassification[rule.classificationCode].some(el => el.modelID === elementInfo.modelID && el.expressID === elementInfo.expressID)) {
-                newElementsPerClassification[rule.classificationCode].push(elementInfo);
+              if (
+                !newElementsPerClassification[rule.classificationCode].some(
+                  (el) =>
+                    el.modelID === elementInfo.modelID &&
+                    el.expressID === elementInfo.expressID
+                )
+              ) {
+                newElementsPerClassification[rule.classificationCode].push(
+                  elementInfo
+                );
               }
             }
           } catch (error) {
-            console.error('IFCContext: Error processing element ' + elementNode.expressID + ' for rule ' + rule.name + ':', error);
+            console.error(
+              "IFCContext: Error processing element " +
+                elementNode.expressID +
+                " for rule " +
+                rule.name +
+                ":",
+              error
+            );
           }
         }
       }
     }
 
     // Update classifications state with new elements, only if changed
-    setClassifications(prevClassifications => {
+    setClassifications((prevClassifications) => {
       const updatedClassifications = { ...prevClassifications };
       let changed = false;
       for (const code of Object.keys(updatedClassifications)) {
         const newElements = newElementsPerClassification[code] || [];
-        if (JSON.stringify(updatedClassifications[code].elements || []) !== JSON.stringify(newElements)) {
-          updatedClassifications[code] = { ...updatedClassifications[code], elements: newElements };
+        if (
+          JSON.stringify(updatedClassifications[code].elements || []) !==
+          JSON.stringify(newElements)
+        ) {
+          updatedClassifications[code] = {
+            ...updatedClassifications[code],
+            elements: newElements,
+          };
           changed = true;
         }
       }
       if (changed) {
-        console.log("IFCContext: Finished applying all active rules. Classifications updated.");
+        console.log(
+          "IFCContext: Finished applying all active rules. Classifications updated."
+        );
       } else {
-        console.log("IFCContext: Finished applying all active rules. No changes to classifications elements.");
+        console.log(
+          "IFCContext: Finished applying all active rules. No changes to classifications elements."
+        );
       }
       return updatedClassifications;
     });
-
   }, [
     ifcApiInternal,
     loadedModels,
     rules,
     getAllElementsFromSpatialTreeNodesRecursive,
-    matchesAllConditionsCallback
+    matchesAllConditionsCallback,
   ]);
 
-  const classificationCodesKey = useMemo(() => Object.keys(classifications).sort().join(','), [classifications]);
-  const rulesKey = useMemo(() => JSON.stringify(rules.map(r => ({ id: r.id, active: r.active, conditions: r.conditions, classificationCode: r.classificationCode }))), [rules]);
-  const modelsReadyKey = useMemo(() => loadedModels.filter(m => m.modelID !== null && m.spatialTree !== null).length, [loadedModels]);
+  const classificationCodesKey = useMemo(
+    () => Object.keys(classifications).sort().join(","),
+    [classifications]
+  );
+  const rulesKey = useMemo(
+    () =>
+      JSON.stringify(
+        rules.map((r) => ({
+          id: r.id,
+          active: r.active,
+          conditions: r.conditions,
+          classificationCode: r.classificationCode,
+        }))
+      ),
+    [rules]
+  );
+  const modelsReadyKey = useMemo(
+    () =>
+      loadedModels.filter((m) => m.modelID !== null && m.spatialTree !== null)
+        .length,
+    [loadedModels]
+  );
 
   useEffect(() => {
-    console.log("Main effect for applyAllActiveRules triggered by changes in models, rules, or classification codes.");
+    console.log(
+      "Main effect for applyAllActiveRules triggered by changes in models, rules, or classification codes."
+    );
     applyAllActiveRules();
   }, [modelsReadyKey, rulesKey, classificationCodesKey, applyAllActiveRules]);
 
-  const previewRuleHighlight = useCallback(async (ruleId: string) => {
-    if (!ifcApiInternal) return;
+  const previewRuleHighlight = useCallback(
+    async (ruleId: string) => {
+      if (!ifcApiInternal) return;
 
-    if (previewingRuleId === ruleId) {
-      // Clicking active preview again: toggle off
-      setPreviewingRuleId(null);
-      setHighlightedClassificationCode(null);
-      setHighlightedElements([]);
-      console.log('Cleared preview for rule: ' + ruleId);
-      return;
-    }
-
-    // Activating a new preview or switching
-    if (ifcApiInternal && !ifcApiInternal.properties) {
-      try {
-        ifcApiInternal.properties = new Properties(ifcApiInternal);
-      } catch (e) { console.error("Failed to init properties in preview", e); return; }
-    }
-    const rule = rules.find(r => r.id === ruleId);
-    if (!rule) {
-      console.warn("Rule not found for preview:", ruleId);
-      setPreviewingRuleId(null); // Clear if rule not found
-      setHighlightedClassificationCode(null);
-      setHighlightedElements([]);
-      return;
-    }
-    const matchingElements: SelectedElementInfo[] = [];
-    for (const model of loadedModels) {
-      if (model.modelID == null || !model.spatialTree) continue;
-      const allModelElements = getAllElementsFromSpatialTreeNodesRecursive(model.spatialTree ? [model.spatialTree] : []);
-      for (const elementNode of allModelElements) {
-        if (elementNode.expressID === undefined) continue;
-        try {
-          const matches = await matchesAllConditionsCallback(elementNode, rule.conditions, model.modelID, ifcApiInternal);
-          if (matches) {
-            matchingElements.push({ modelID: model.modelID, expressID: elementNode.expressID });
-          }
-        } catch (error) { console.error('Error previewing element ' + elementNode.expressID + ' for rule ' + rule.name + ':', error); }
-      }
-    }
-    setPreviewingRuleId(ruleId); // Set this rule as actively previewing
-    setHighlightedClassificationCode(rule.classificationCode);
-    setHighlightedElements(matchingElements);
-    setShowAllClassificationColors(false);
-    console.log('Previewing rule "' + rule.name + '". Found ' + matchingElements.length + ' elements.');
-  }, [ifcApiInternal, loadedModels, rules, getAllElementsFromSpatialTreeNodesRecursive, matchesAllConditionsCallback, previewingRuleId, setHighlightedClassificationCode, setHighlightedElements, setShowAllClassificationColors]); // Added previewingRuleId to deps
-
-  const generateFileId = useCallback(() => `model-${Date.now()}-${Math.random().toString(36).substring(2, 7)}`, []);
-  const commonLoadLogic = useCallback((url: string, name: string, fileIdToUse?: string): LoadedModelData => {
-    const id = fileIdToUse || generateFileId();
-    setSelectedElement(null);
-    setElementPropertiesInternal(null);
-    setHighlightedElements([]);
-    return { id, name, url, modelID: null, spatialTree: null, rawBuffer: null };
-  }, [generateFileId, setSelectedElement, setElementPropertiesInternal, setHighlightedElements]);
-
-  const addIFCModel = useCallback(async (url: string, name: string, fileId?: string): Promise<number | null> => {
-    setLoadedModels((prev) => [...prev, commonLoadLogic(url, name, fileId)]);
-    return null;
-  }, [commonLoadLogic]);
-
-  const replaceIFCModel = useCallback(async (url: string, name: string, fileId?: string): Promise<number | null> => {
-    setLoadedModels([commonLoadLogic(url, name, fileId)]);
-    return null;
-  }, [commonLoadLogic]);
-
-  const removeIFCModel = useCallback((id: string) => {
-    setLoadedModels((prev) =>
-      prev.filter((m) => {
-        if (m.id === id && m.modelID !== null && ifcApiInternal) {
-          try { ifcApiInternal.CloseModel(m.modelID); } catch (e) { console.error('Error closing model:', e); }
-          setAvailableCategoriesInternal((prevCats) => { const newCats = { ...prevCats }; if (m.modelID) delete newCats[m.modelID]; return newCats; });
-        }
-        return m.id !== id;
-      })
-    );
-    if (selectedElement && loadedModels.find((m) => m.id === id)?.modelID === selectedElement.modelID) {
-      setSelectedElement(null);
-      setElementPropertiesInternal(null);
-    }
-  }, [ifcApiInternal, selectedElement, loadedModels, setLoadedModels, setAvailableCategoriesInternal, setSelectedElement, setElementPropertiesInternal]);
-
-  const setModelIDForLoadedModel = useCallback((loadedModelId: string, ifcModelId: number) => {
-    setLoadedModels((prev) => prev.map((m) => (m.id === loadedModelId ? { ...m, modelID: ifcModelId } : m)));
-  }, [setLoadedModels]);
-
-  const setSpatialTreeForModel = useCallback((modelID: number, tree: SpatialStructureNode | null) => {
-    setLoadedModels((prevModels) => prevModels.map((m) => (m.modelID === modelID ? { ...m, spatialTree: tree } : m)));
-  }, [setLoadedModels]);
-
-  const setRawBufferForModel = useCallback((id: string, buffer: ArrayBuffer) => {
-    setLoadedModels((prevModels) =>
-      prevModels.map((m) => (m.id === id ? { ...m, rawBuffer: buffer } : m))
-    );
-  }, []);
-
-  const selectElement = useCallback((selection: SelectedElementInfo | null) => {
-    setSelectedElement(selection);
-    setHighlightedElements([]);
-    setHighlightedClassificationCode(null);
-    setShowAllClassificationColors(false);
-    setPreviewingRuleId(null); // Clear active rule preview
-    if (!selection) {
-      setElementPropertiesInternal(null);
-    } else {
-      // Properties will be fetched by IFCModel's useEffect based on selectedElement change
-      // So, we don't necessarily need to set them to null here if a new selection is made.
-      // However, if the old selectedElement was different, its props should be cleared.
-      // For simplicity, if we are selecting something new (or null), clear old props.
-      setElementPropertiesInternal(null); // Clear old props before new ones are fetched
-    }
-  }, [setSelectedElement, setHighlightedElements, setHighlightedClassificationCode, setShowAllClassificationColors, setElementPropertiesInternal, setPreviewingRuleId]);
-
-  const toggleClassificationHighlight = useCallback((classificationCode: string) => {
-    if (highlightedClassificationCode === classificationCode && !previewingRuleId) { // Only toggle off if not a rule preview
-      setHighlightedClassificationCode(null);
-      setHighlightedElements([]);
-      // setPreviewingRuleId(null); // Rule preview is already off or handled by its own toggle
-    } else {
-      const classification = classifications[classificationCode];
-      if (classification && classification.elements) {
-        setHighlightedClassificationCode(classificationCode);
-        setHighlightedElements(classification.elements);
-        setShowAllClassificationColors(false);
-        setPreviewingRuleId(null); // Clear rule preview if activating classification highlight
-      } else {
+      if (previewingRuleId === ruleId) {
+        // Clicking active preview again: toggle off
+        setPreviewingRuleId(null);
         setHighlightedClassificationCode(null);
         setHighlightedElements([]);
-        console.warn('Classification ' + classificationCode + ' or its elements not found for highlight.');
+        console.log("Cleared preview for rule: " + ruleId);
+        return;
       }
-    }
-  }, [classifications, highlightedClassificationCode, setHighlightedClassificationCode, setHighlightedElements, setShowAllClassificationColors, previewingRuleId, setPreviewingRuleId]);
 
-  const setElementProperties = useCallback((properties: any | null) => {
-    setElementPropertiesInternal(properties);
-  }, [setElementPropertiesInternal]);
+      // Activating a new preview or switching
+      if (ifcApiInternal && !ifcApiInternal.properties) {
+        try {
+          ifcApiInternal.properties = new Properties(ifcApiInternal);
+        } catch (e) {
+          console.error("Failed to init properties in preview", e);
+          return;
+        }
+      }
+      const rule = rules.find((r) => r.id === ruleId);
+      if (!rule) {
+        console.warn("Rule not found for preview:", ruleId);
+        setPreviewingRuleId(null); // Clear if rule not found
+        setHighlightedClassificationCode(null);
+        setHighlightedElements([]);
+        return;
+      }
+      const matchingElements: SelectedElementInfo[] = [];
+      for (const model of loadedModels) {
+        if (model.modelID == null || !model.spatialTree) continue;
+        const allModelElements = getAllElementsFromSpatialTreeNodesRecursive(
+          model.spatialTree ? [model.spatialTree] : []
+        );
+        for (const elementNode of allModelElements) {
+          if (elementNode.expressID === undefined) continue;
+          try {
+            const matches = await matchesAllConditionsCallback(
+              elementNode,
+              rule.conditions,
+              model.modelID,
+              ifcApiInternal
+            );
+            if (matches) {
+              matchingElements.push({
+                modelID: model.modelID,
+                expressID: elementNode.expressID,
+              });
+            }
+          } catch (error) {
+            console.error(
+              "Error previewing element " +
+                elementNode.expressID +
+                " for rule " +
+                rule.name +
+                ":",
+              error
+            );
+          }
+        }
+      }
+      setPreviewingRuleId(ruleId); // Set this rule as actively previewing
+      setHighlightedClassificationCode(rule.classificationCode);
+      setHighlightedElements(matchingElements);
+      setShowAllClassificationColors(false);
+      console.log(
+        'Previewing rule "' +
+          rule.name +
+          '". Found ' +
+          matchingElements.length +
+          " elements."
+      );
+    },
+    [
+      ifcApiInternal,
+      loadedModels,
+      rules,
+      getAllElementsFromSpatialTreeNodesRecursive,
+      matchesAllConditionsCallback,
+      previewingRuleId,
+      setHighlightedClassificationCode,
+      setHighlightedElements,
+      setShowAllClassificationColors,
+    ]
+  ); // Added previewingRuleId to deps
 
-  const setAvailableProperties = useCallback((props: string[]) => {
-    setAvailablePropertiesInternal(props);
-  }, [setAvailablePropertiesInternal]);
+  const generateFileId = useCallback(
+    () => `model-${Date.now()}-${Math.random().toString(36).substring(2, 7)}`,
+    []
+  );
+  const commonLoadLogic = useCallback(
+    (url: string, name: string, fileIdToUse?: string): LoadedModelData => {
+      const id = fileIdToUse || generateFileId();
+      setSelectedElement(null);
+      setElementPropertiesInternal(null);
+      setHighlightedElements([]);
+      return {
+        id,
+        name,
+        url,
+        modelID: null,
+        spatialTree: null,
+        rawBuffer: null,
+      };
+    },
+    [
+      generateFileId,
+      setSelectedElement,
+      setElementPropertiesInternal,
+      setHighlightedElements,
+    ]
+  );
 
-  const setAvailableCategoriesForModel = useCallback((modelID: number, cats: string[]) => {
-    setAvailableCategoriesInternal((prev) => ({ ...prev, [modelID]: cats }));
-  }, [setAvailableCategoriesInternal]);
+  const addIFCModel = useCallback(
+    async (
+      url: string,
+      name: string,
+      fileId?: string
+    ): Promise<number | null> => {
+      setLoadedModels((prev) => [...prev, commonLoadLogic(url, name, fileId)]);
+      return null;
+    },
+    [commonLoadLogic]
+  );
 
-  const setIfcApi = useCallback((api: IfcAPI | null) => {
-    setIfcApiInternal(api);
-  }, [setIfcApiInternal]);
+  const replaceIFCModel = useCallback(
+    async (
+      url: string,
+      name: string,
+      fileId?: string
+    ): Promise<number | null> => {
+      setLoadedModels([commonLoadLogic(url, name, fileId)]);
+      return null;
+    },
+    [commonLoadLogic]
+  );
+
+  const removeIFCModel = useCallback(
+    (id: string) => {
+      setLoadedModels((prev) =>
+        prev.filter((m) => {
+          if (m.id === id && m.modelID !== null && ifcApiInternal) {
+            try {
+              ifcApiInternal.CloseModel(m.modelID);
+            } catch (e) {
+              console.error("Error closing model:", e);
+            }
+            setAvailableCategoriesInternal((prevCats) => {
+              const newCats = { ...prevCats };
+              if (m.modelID) delete newCats[m.modelID];
+              return newCats;
+            });
+          }
+          return m.id !== id;
+        })
+      );
+      if (
+        selectedElement &&
+        loadedModels.find((m) => m.id === id)?.modelID ===
+          selectedElement.modelID
+      ) {
+        setSelectedElement(null);
+        setElementPropertiesInternal(null);
+      }
+    },
+    [
+      ifcApiInternal,
+      selectedElement,
+      loadedModels,
+      setLoadedModels,
+      setAvailableCategoriesInternal,
+      setSelectedElement,
+      setElementPropertiesInternal,
+    ]
+  );
+
+  const setModelIDForLoadedModel = useCallback(
+    (loadedModelId: string, ifcModelId: number) => {
+      setLoadedModels((prev) =>
+        prev.map((m) =>
+          m.id === loadedModelId ? { ...m, modelID: ifcModelId } : m
+        )
+      );
+    },
+    [setLoadedModels]
+  );
+
+  const setSpatialTreeForModel = useCallback(
+    (modelID: number, tree: SpatialStructureNode | null) => {
+      setLoadedModels((prevModels) =>
+        prevModels.map((m) =>
+          m.modelID === modelID ? { ...m, spatialTree: tree } : m
+        )
+      );
+    },
+    [setLoadedModels]
+  );
+
+  const setRawBufferForModel = useCallback(
+    (id: string, buffer: ArrayBuffer) => {
+      setLoadedModels((prevModels) =>
+        prevModels.map((m) => (m.id === id ? { ...m, rawBuffer: buffer } : m))
+      );
+    },
+    []
+  );
+
+  const selectElement = useCallback(
+    (selection: SelectedElementInfo | null) => {
+      setSelectedElement(selection);
+      setHighlightedElements([]);
+      setHighlightedClassificationCode(null);
+      setShowAllClassificationColors(false);
+      setPreviewingRuleId(null); // Clear active rule preview
+      if (!selection) {
+        setElementPropertiesInternal(null);
+      } else {
+        // Properties will be fetched by IFCModel's useEffect based on selectedElement change
+        // So, we don't necessarily need to set them to null here if a new selection is made.
+        // However, if the old selectedElement was different, its props should be cleared.
+        // For simplicity, if we are selecting something new (or null), clear old props.
+        setElementPropertiesInternal(null); // Clear old props before new ones are fetched
+      }
+    },
+    [
+      setSelectedElement,
+      setHighlightedElements,
+      setHighlightedClassificationCode,
+      setShowAllClassificationColors,
+      setElementPropertiesInternal,
+      setPreviewingRuleId,
+    ]
+  );
+
+  const toggleClassificationHighlight = useCallback(
+    (classificationCode: string) => {
+      if (
+        highlightedClassificationCode === classificationCode &&
+        !previewingRuleId
+      ) {
+        // Only toggle off if not a rule preview
+        setHighlightedClassificationCode(null);
+        setHighlightedElements([]);
+        // setPreviewingRuleId(null); // Rule preview is already off or handled by its own toggle
+      } else {
+        const classification = classifications[classificationCode];
+        if (classification && classification.elements) {
+          setHighlightedClassificationCode(classificationCode);
+          setHighlightedElements(classification.elements);
+          setShowAllClassificationColors(false);
+          setPreviewingRuleId(null); // Clear rule preview if activating classification highlight
+        } else {
+          setHighlightedClassificationCode(null);
+          setHighlightedElements([]);
+          console.warn(
+            "Classification " +
+              classificationCode +
+              " or its elements not found for highlight."
+          );
+        }
+      }
+    },
+    [
+      classifications,
+      highlightedClassificationCode,
+      setHighlightedClassificationCode,
+      setHighlightedElements,
+      setShowAllClassificationColors,
+      previewingRuleId,
+      setPreviewingRuleId,
+    ]
+  );
+
+  const setElementProperties = useCallback(
+    (properties: any | null) => {
+      setElementPropertiesInternal(properties);
+    },
+    [setElementPropertiesInternal]
+  );
+
+  const setAvailableProperties = useCallback(
+    (props: string[]) => {
+      setAvailablePropertiesInternal(props);
+    },
+    [setAvailablePropertiesInternal]
+  );
+
+  const setAvailableCategoriesForModel = useCallback(
+    (modelID: number, cats: string[]) => {
+      setAvailableCategoriesInternal((prev) => ({ ...prev, [modelID]: cats }));
+    },
+    [setAvailableCategoriesInternal]
+  );
+
+  const setIfcApi = useCallback(
+    (api: IfcAPI | null) => {
+      setIfcApiInternal(api);
+    },
+    [setIfcApiInternal]
+  );
 
   const toggleShowAllClassificationColors = useCallback(() => {
-    setShowAllClassificationColors(prev => {
+    setShowAllClassificationColors((prev) => {
       const newShowAllState = !prev;
       if (newShowAllState) {
         setHighlightedClassificationCode(null);
@@ -505,57 +1159,111 @@ export function IFCContextProvider({ children }: { children: ReactNode }) {
       // If turning off showAll, we don't automatically re-enable a specific preview or highlight.
       return newShowAllState;
     });
-  }, [setShowAllClassificationColors, setHighlightedClassificationCode, setHighlightedElements, setPreviewingRuleId]);
+  }, [
+    setShowAllClassificationColors,
+    setHighlightedClassificationCode,
+    setHighlightedElements,
+    setPreviewingRuleId,
+  ]);
 
-  const addClassification = useCallback((classificationItem: any) => {
-    setClassifications((prev) => ({ ...prev, [classificationItem.code]: classificationItem }));
-  }, [setClassifications]);
+  const addClassification = useCallback(
+    (classificationItem: any) => {
+      setClassifications((prev) => ({
+        ...prev,
+        [classificationItem.code]: classificationItem,
+      }));
+    },
+    [setClassifications]
+  );
 
-  const removeClassification = useCallback((code: string) => {
-    setClassifications((prev) => { const updated = { ...prev }; delete updated[code]; return updated; });
-  }, [setClassifications]);
+  const removeClassification = useCallback(
+    (code: string) => {
+      setClassifications((prev) => {
+        const updated = { ...prev };
+        delete updated[code];
+        return updated;
+      });
+    },
+    [setClassifications]
+  );
 
-  const updateClassification = useCallback((code: string, classificationItem: any) => {
-    setClassifications((prev) => ({ ...prev, [code]: classificationItem }));
-  }, [setClassifications]);
+  const updateClassification = useCallback(
+    (code: string, classificationItem: any) => {
+      setClassifications((prev) => ({ ...prev, [code]: classificationItem }));
+    },
+    [setClassifications]
+  );
 
-  const addRule = useCallback((ruleItem: Rule) => {
-    setRules((prev) => [...prev, ruleItem]);
-  }, [setRules]);
+  const addRule = useCallback(
+    (ruleItem: Rule) => {
+      setRules((prev) => [...prev, ruleItem]);
+    },
+    [setRules]
+  );
 
-  const removeRule = useCallback((id: string) => {
-    setRules((prev) => prev.filter((r) => r.id !== id));
-  }, [setRules]);
+  const removeRule = useCallback(
+    (id: string) => {
+      setRules((prev) => prev.filter((r) => r.id !== id));
+    },
+    [setRules]
+  );
 
-  const updateRule = useCallback((updatedRuleItem: Rule) => {
-    setRules((prev) => prev.map((r) => (r.id === updatedRuleItem.id ? updatedRuleItem : r)));
-  }, [setRules]);
-
-  const toggleUserHideElement = useCallback((elementToToggle: SelectedElementInfo) => {
-    console.log("IFCContext: toggleUserHideElement called for", elementToToggle);
-    setUserHiddenElements((prevHidden) => {
-      const isAlreadyHidden = prevHidden.some(
-        (el) => el.modelID === elementToToggle.modelID && el.expressID === elementToToggle.expressID
+  const updateRule = useCallback(
+    (updatedRuleItem: Rule) => {
+      setRules((prev) =>
+        prev.map((r) => (r.id === updatedRuleItem.id ? updatedRuleItem : r))
       );
-      if (isAlreadyHidden) {
-        console.log("IFCContext: Element was hidden, now showing:", elementToToggle);
-        return prevHidden.filter(
-          (el) => !(el.modelID === elementToToggle.modelID && el.expressID === elementToToggle.expressID)
+    },
+    [setRules]
+  );
+
+  const toggleUserHideElement = useCallback(
+    (elementToToggle: SelectedElementInfo) => {
+      console.log(
+        "IFCContext: toggleUserHideElement called for",
+        elementToToggle
+      );
+      setUserHiddenElements((prevHidden) => {
+        const isAlreadyHidden = prevHidden.some(
+          (el) =>
+            el.modelID === elementToToggle.modelID &&
+            el.expressID === elementToToggle.expressID
         );
-      } else {
-        console.log("IFCContext: Element was visible, now hiding:", elementToToggle);
-        // Check if the element being hidden is the currently selected element
-        if (selectedElement &&
-          selectedElement.modelID === elementToToggle.modelID &&
-          selectedElement.expressID === elementToToggle.expressID) {
-          console.log("IFCContext: Deselecting element because it is now hidden.");
-          setSelectedElement(null); // Deselect
-          setElementPropertiesInternal(null); // Clear its properties
+        if (isAlreadyHidden) {
+          console.log(
+            "IFCContext: Element was hidden, now showing:",
+            elementToToggle
+          );
+          return prevHidden.filter(
+            (el) =>
+              !(
+                el.modelID === elementToToggle.modelID &&
+                el.expressID === elementToToggle.expressID
+              )
+          );
+        } else {
+          console.log(
+            "IFCContext: Element was visible, now hiding:",
+            elementToToggle
+          );
+          // Check if the element being hidden is the currently selected element
+          if (
+            selectedElement &&
+            selectedElement.modelID === elementToToggle.modelID &&
+            selectedElement.expressID === elementToToggle.expressID
+          ) {
+            console.log(
+              "IFCContext: Deselecting element because it is now hidden."
+            );
+            setSelectedElement(null); // Deselect
+            setElementPropertiesInternal(null); // Clear its properties
+          }
+          return [...prevHidden, elementToToggle];
         }
-        return [...prevHidden, elementToToggle];
-      }
-    });
-  }, [selectedElement, setSelectedElement, setElementPropertiesInternal]);
+      });
+    },
+    [selectedElement, setSelectedElement, setElementPropertiesInternal]
+  );
 
   const unhideLastElement = useCallback(() => {
     console.log("IFCContext: unhideLastElement called.");
@@ -565,7 +1273,10 @@ export function IFCContextProvider({ children }: { children: ReactNode }) {
         return prevHidden;
       }
       const newHidden = prevHidden.slice(0, -1); // Remove the last element
-      console.log("IFCContext: Unhid last element. Remaining hidden:", newHidden.length);
+      console.log(
+        "IFCContext: Unhid last element. Remaining hidden:",
+        newHidden.length
+      );
       return newHidden;
     });
   }, []);


### PR DESCRIPTION
## Summary
- add `availableProperties` state and setter in IFCContext
- supply element properties to the rule panel via context
- gather all attribute and Pset keys when selecting an element
- populate rule dialog dropdown from these collected properties

## Testing
- `npm run lint` *(fails: `next: not found`)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The list of available properties for rule creation is now dynamically generated based on loaded IFC models, offering more relevant and comprehensive options.
  - Added a new creatable combobox component allowing users to select from existing properties or create new ones dynamically in rule conditions.
- **Improvements**
  - Enhanced rule condition evaluation with improved property fetching, support for additional operators, and better boolean handling.
  - Property selection UI updated with contextual placeholders and improved usability.
  - Automatic updating of available properties when models load or change, ensuring accurate and synchronized rule building options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->