### PR TITLE
Add manual classification assignment panel

### DIFF
--- a/components/classification-panel.tsx
+++ b/components/classification-panel.tsx
@@ -36,7 +36,10 @@ interface ClassificationItem {
   code: string;
   name: string;
   color: string;
-  elements: SelectedElementInfo[]; // Use SelectedElementInfo for stricter typing
+  elements: SelectedElementInfo[]; // Final elements (rule + manual)
+  ruleElements?: SelectedElementInfo[];
+  manualAssignments?: SelectedElementInfo[];
+  manualUnassignments?: SelectedElementInfo[];
 }
 
 // Helper function to compare two arrays of SelectedElementInfo (order-independent)
@@ -268,6 +271,9 @@ export function ClassificationPanel() {
       addClassification({
         ...newClassification,
         elements: [],
+        ruleElements: [],
+        manualAssignments: [],
+        manualUnassignments: [],
       } as ClassificationItem)
       setNewClassification({
         code: "",
@@ -285,7 +291,13 @@ export function ClassificationPanel() {
       // Optionally, provide feedback to the user (e.g., toast notification)
       return
     }
-    addClassification(defaultClassification)
+    addClassification({
+      ...defaultClassification,
+      elements: [],
+      ruleElements: [],
+      manualAssignments: [],
+      manualUnassignments: [],
+    })
   }
 
   const handleOpenEditDialog = (classificationToEdit: ClassificationItem) => {

--- a/components/ifc-viewer.tsx
+++ b/components/ifc-viewer.tsx
@@ -15,6 +15,7 @@ import { OrbitControls, Environment } from "@react-three/drei";
 import { IFCModel } from "@/components/ifc-model";
 import { ClassificationPanel } from "@/components/classification-panel";
 import { RulePanel } from "@/components/rule-panel";
+import { SelectionClassificationPanel } from "@/components/selection-classification-panel";
 import { Button } from "@/components/ui/button";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
@@ -1021,6 +1022,9 @@ function ViewerContent() {
                 onZoomSelected={handleZoomSelected}
                 isElementSelected={!!selectedElement}
               />
+            )}
+            {ifcEngineReady && !webGLContextLost && (
+              <SelectionClassificationPanel />
             )}
           </div>
         </Panel>

--- a/components/selection-classification-panel.tsx
+++ b/components/selection-classification-panel.tsx
@@ -1,0 +1,92 @@
+"use client"
+
+import { useState, useEffect } from "react"
+import { useIFCContext, type SelectedElementInfo } from "@/context/ifc-context"
+import { Button } from "@/components/ui/button"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { Badge } from "@/components/ui/badge"
+
+export function SelectionClassificationPanel() {
+  const {
+    selectedElement,
+    classifications,
+    assignClassificationToElement,
+    unassignClassificationFromElement,
+  } = useIFCContext()
+
+  const classificationCodes = Object.keys(classifications)
+  const [selectedCode, setSelectedCode] = useState<string>("")
+
+  useEffect(() => {
+    if (classificationCodes.length > 0) {
+      if (!selectedCode || !classifications[selectedCode]) {
+        setSelectedCode(classificationCodes[0])
+      }
+    } else {
+      setSelectedCode("")
+    }
+  }, [classificationCodes, classifications, selectedCode])
+
+  if (!selectedElement) return null
+
+  const elementMatches = (el: SelectedElementInfo) =>
+    el.modelID === selectedElement.modelID && el.expressID === selectedElement.expressID
+
+  const assignedCodes = classificationCodes.filter(code =>
+    (classifications[code].elements || []).some(elementMatches)
+  )
+
+  const handleAssign = () => {
+    if (selectedCode) {
+      assignClassificationToElement(selectedCode, selectedElement)
+    }
+  }
+
+  const handleUnassign = () => {
+    if (selectedCode) {
+      unassignClassificationFromElement(selectedCode, selectedElement)
+    }
+  }
+
+  const isSelectedAssigned = assignedCodes.includes(selectedCode)
+
+  return (
+    <div className="absolute bottom-4 right-4 z-20 pointer-events-auto">
+      <div className="p-3 bg-background/80 border border-border rounded-lg shadow-lg space-y-2">
+        <div className="flex items-center gap-2">
+          <Select value={selectedCode} onValueChange={setSelectedCode}>
+            <SelectTrigger className="w-40">
+              <SelectValue placeholder="Classification" />
+            </SelectTrigger>
+            <SelectContent>
+              {classificationCodes.map(code => {
+                const cls = classifications[code]
+                return (
+                  <SelectItem key={code} value={code}>
+                    {cls.name || code}
+                  </SelectItem>
+                )
+              })}
+            </SelectContent>
+          </Select>
+          <Button size="sm" onClick={isSelectedAssigned ? handleUnassign : handleAssign}>
+            {isSelectedAssigned ? "Unassign" : "Assign"}
+          </Button>
+        </div>
+        {assignedCodes.length > 0 && (
+          <div className="flex flex-wrap gap-1">
+            {assignedCodes.map(code => {
+              const cls = classifications[code]
+              return (
+                <Badge key={code} style={{ backgroundColor: cls.color, color: "white" }}>
+                  {cls.name || code}
+                </Badge>
+              )
+            })}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+


### PR DESCRIPTION
## Summary
- allow manual assignment/unassignment of classifications
- keep manual overrides separate from rule-based assignments
- add floating SelectionClassificationPanel overlay in viewer
- show classification dropdown and assign/unassign buttons

## Testing
- `npm run lint` *(fails: `next: not found`)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a panel for assigning or unassigning classifications to selected elements within the viewer.
  - Added manual assignment and unassignment of classifications, allowing users to override rule-based classifications for individual elements.
- **Improvements**
  - Classifications now consistently track rule-based, manually assigned, and manually unassigned elements for greater flexibility and transparency in classification management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->