### PR TITLE
Fix classification assignment types

### DIFF
--- a/components/classification-panel.tsx
+++ b/components/classification-panel.tsx
@@ -36,7 +36,10 @@ interface ClassificationItem {
   code: string;
   name: string;
   color: string;
-  elements: SelectedElementInfo[]; // Use SelectedElementInfo for stricter typing
+  elements: SelectedElementInfo[]; // Final elements (rule + manual)
+  ruleElements?: SelectedElementInfo[];
+  manualAssignments?: SelectedElementInfo[];
+  manualUnassignments?: SelectedElementInfo[];
 }
 
 // Helper function to compare two arrays of SelectedElementInfo (order-independent)
@@ -268,6 +271,9 @@ export function ClassificationPanel() {
       addClassification({
         ...newClassification,
         elements: [],
+        ruleElements: [],
+        manualAssignments: [],
+        manualUnassignments: [],
       } as ClassificationItem)
       setNewClassification({
         code: "",
@@ -285,7 +291,13 @@ export function ClassificationPanel() {
       // Optionally, provide feedback to the user (e.g., toast notification)
       return
     }
-    addClassification(defaultClassification)
+    addClassification({
+      ...defaultClassification,
+      elements: [],
+      ruleElements: [],
+      manualAssignments: [],
+      manualUnassignments: [],
+    })
   }
 
   const handleOpenEditDialog = (classificationToEdit: ClassificationItem) => {

--- a/components/ifc-viewer.tsx
+++ b/components/ifc-viewer.tsx
@@ -15,6 +15,7 @@ import { OrbitControls, Environment } from "@react-three/drei";
 import { IFCModel } from "@/components/ifc-model";
 import { ClassificationPanel } from "@/components/classification-panel";
 import { RulePanel } from "@/components/rule-panel";
+import { SelectionClassificationPanel } from "@/components/selection-classification-panel";
 import { Button } from "@/components/ui/button";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
@@ -1021,6 +1022,9 @@ function ViewerContent() {
                 onZoomSelected={handleZoomSelected}
                 isElementSelected={!!selectedElement}
               />
+            )}
+            {ifcEngineReady && !webGLContextLost && (
+              <SelectionClassificationPanel />
             )}
           </div>
         </Panel>

--- a/components/selection-classification-panel.tsx
+++ b/components/selection-classification-panel.tsx
@@ -1,0 +1,92 @@
+"use client"
+
+import { useState, useEffect } from "react"
+import { useIFCContext, type SelectedElementInfo } from "@/context/ifc-context"
+import { Button } from "@/components/ui/button"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { Badge } from "@/components/ui/badge"
+
+export function SelectionClassificationPanel() {
+  const {
+    selectedElement,
+    classifications,
+    assignClassificationToElement,
+    unassignClassificationFromElement,
+  } = useIFCContext()
+
+  const classificationCodes = Object.keys(classifications)
+  const [selectedCode, setSelectedCode] = useState<string>("")
+
+  useEffect(() => {
+    if (classificationCodes.length > 0) {
+      if (!selectedCode || !classifications[selectedCode]) {
+        setSelectedCode(classificationCodes[0])
+      }
+    } else {
+      setSelectedCode("")
+    }
+  }, [classificationCodes, classifications, selectedCode])
+
+  if (!selectedElement) return null
+
+  const elementMatches = (el: SelectedElementInfo) =>
+    el.modelID === selectedElement.modelID && el.expressID === selectedElement.expressID
+
+  const assignedCodes = classificationCodes.filter(code =>
+    (classifications[code].elements || []).some(elementMatches)
+  )
+
+  const handleAssign = () => {
+    if (selectedCode) {
+      assignClassificationToElement(selectedCode, selectedElement)
+    }
+  }
+
+  const handleUnassign = () => {
+    if (selectedCode) {
+      unassignClassificationFromElement(selectedCode, selectedElement)
+    }
+  }
+
+  const isSelectedAssigned = assignedCodes.includes(selectedCode)
+
+  return (
+    <div className="absolute bottom-4 right-4 z-20 pointer-events-auto">
+      <div className="p-3 bg-background/80 border border-border rounded-lg shadow-lg space-y-2">
+        <div className="flex items-center gap-2">
+          <Select value={selectedCode} onValueChange={setSelectedCode}>
+            <SelectTrigger className="w-40">
+              <SelectValue placeholder="Classification" />
+            </SelectTrigger>
+            <SelectContent>
+              {classificationCodes.map(code => {
+                const cls = classifications[code]
+                return (
+                  <SelectItem key={code} value={code}>
+                    {cls.name || code}
+                  </SelectItem>
+                )
+              })}
+            </SelectContent>
+          </Select>
+          <Button size="sm" onClick={isSelectedAssigned ? handleUnassign : handleAssign}>
+            {isSelectedAssigned ? "Unassign" : "Assign"}
+          </Button>
+        </div>
+        {assignedCodes.length > 0 && (
+          <div className="flex flex-wrap gap-1">
+            {assignedCodes.map(code => {
+              const cls = classifications[code]
+              return (
+                <Badge key={code} style={{ backgroundColor: cls.color, color: "white" }}>
+                  {cls.name || code}
+                </Badge>
+              )
+            })}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+

--- a/context/ifc-context.tsx
+++ b/context/ifc-context.tsx
@@ -118,6 +118,15 @@ interface IFCContextType {
   updateRule: (rule: Rule) => void;
   previewRuleHighlight: (ruleId: string) => Promise<void>;
 
+  assignClassificationToElement: (
+    code: string,
+    element: SelectedElementInfo
+  ) => void;
+  unassignClassificationFromElement: (
+    code: string,
+    element: SelectedElementInfo
+  ) => void;
+
   toggleUserHideElement: (element: SelectedElementInfo) => void; // New function
   unhideLastElement: () => void; // New function
   unhideAllElements: () => void; // New function
@@ -715,26 +724,22 @@ export function IFCContextProvider({ children }: { children: ReactNode }) {
       );
       // Only clear elements if there are no models. Definitions should persist.
       if (loadedModels.length === 0) {
-        setClassifications((prevClassifications) => {
-          const newCleared = { ...prevClassifications };
-          let actuallyClearedSomething = false;
-          for (const code in newCleared) {
-            if (
-              newCleared[code] &&
-              newCleared[code].elements &&
-              newCleared[code].elements.length > 0
-            ) {
-              newCleared[code] = { ...newCleared[code], elements: [] };
-              actuallyClearedSomething = true;
+        setClassifications((prev) => {
+          const updated = { ...prev }
+          for (const code in updated) {
+            const current = updated[code]
+            updated[code] = {
+              ...current,
+              ruleElements: [],
+              elements: computeFinalElements(
+                [],
+                (current.manualAssignments || []) as SelectedElementInfo[],
+                (current.manualUnassignments || []) as SelectedElementInfo[]
+              ),
             }
           }
-          if (actuallyClearedSomething) {
-            console.log(
-              "IFCContext: IFC API not available & no models: Ensured all classification elements are empty."
-            );
-          }
-          return newCleared;
-        });
+          return updated
+        })
       }
       return;
     }
@@ -760,30 +765,23 @@ export function IFCContextProvider({ children }: { children: ReactNode }) {
       loadedModels.filter((m) => m.modelID != null && m.spatialTree != null)
         .length === 0
     ) {
-      setClassifications((prevClassifications) => {
-        const newCleared = { ...prevClassifications };
-        let actuallyClearedSomething = false;
-        for (const code in newCleared) {
-          if (
-            newCleared[code] &&
-            newCleared[code].elements &&
-            newCleared[code].elements.length > 0
-          ) {
-            newCleared[code] = { ...newCleared[code], elements: [] };
-            actuallyClearedSomething = true;
+      setClassifications((prev) => {
+        const updated = { ...prev }
+        for (const code in updated) {
+          const current = updated[code]
+          updated[code] = {
+            ...current,
+            ruleElements: [],
+            elements: computeFinalElements(
+              [],
+              (current.manualAssignments || []) as SelectedElementInfo[],
+              (current.manualUnassignments || []) as SelectedElementInfo[]
+            ),
           }
         }
-        if (actuallyClearedSomething) {
-          console.log(
-            "IFCContext: No models ready, ensured rule-based elements from classifications are empty."
-          );
-        }
-        // else {
-        //      console.log("IFCContext: No models ready, classifications elements were already empty or no classifications.");
-        // }
-        return newCleared;
-      });
-      return;
+        return updated
+      })
+      return
     }
 
     // Proceed with rule application if models are ready
@@ -855,34 +853,43 @@ export function IFCContextProvider({ children }: { children: ReactNode }) {
       }
     }
 
-    // Update classifications state with new elements, only if changed
+    // Update classifications state with new elements and apply manual overrides
     setClassifications((prevClassifications) => {
-      const updatedClassifications = { ...prevClassifications };
-      let changed = false;
+      const updatedClassifications = { ...prevClassifications }
+      let changed = false
       for (const code of Object.keys(updatedClassifications)) {
-        const newElements = newElementsPerClassification[code] || [];
+        const ruleEls = newElementsPerClassification[code] || []
+        const current = updatedClassifications[code]
+        const manualAdd: SelectedElementInfo[] =
+          current.manualAssignments || []
+        const manualRemove: SelectedElementInfo[] =
+          current.manualUnassignments || []
+        const finalEls = computeFinalElements(ruleEls, manualAdd, manualRemove)
         if (
-          JSON.stringify(updatedClassifications[code].elements || []) !==
-          JSON.stringify(newElements)
+          JSON.stringify(current.elements || []) !==
+            JSON.stringify(finalEls) ||
+          JSON.stringify(current.ruleElements || []) !==
+            JSON.stringify(ruleEls)
         ) {
           updatedClassifications[code] = {
-            ...updatedClassifications[code],
-            elements: newElements,
-          };
-          changed = true;
+            ...current,
+            ruleElements: ruleEls,
+            elements: finalEls,
+          }
+          changed = true
         }
       }
       if (changed) {
         console.log(
           "IFCContext: Finished applying all active rules. Classifications updated."
-        );
+        )
       } else {
         console.log(
           "IFCContext: Finished applying all active rules. No changes to classifications elements."
-        );
+        )
       }
-      return updatedClassifications;
-    });
+      return updatedClassifications
+    })
   }, [
     ifcApiInternal,
     loadedModels,
@@ -1246,7 +1253,13 @@ export function IFCContextProvider({ children }: { children: ReactNode }) {
     (classificationItem: any) => {
       setClassifications((prev) => ({
         ...prev,
-        [classificationItem.code]: classificationItem,
+        [classificationItem.code]: {
+          ...classificationItem,
+          elements: [],
+          ruleElements: [],
+          manualAssignments: [],
+          manualUnassignments: [],
+        },
       }));
     },
     [setClassifications]
@@ -1265,7 +1278,10 @@ export function IFCContextProvider({ children }: { children: ReactNode }) {
 
   const updateClassification = useCallback(
     (code: string, classificationItem: any) => {
-      setClassifications((prev) => ({ ...prev, [code]: classificationItem }));
+      setClassifications((prev) => ({
+        ...prev,
+        [code]: { ...prev[code], ...classificationItem },
+      }));
     },
     [setClassifications]
   );
@@ -1292,6 +1308,93 @@ export function IFCContextProvider({ children }: { children: ReactNode }) {
     },
     [setRules]
   );
+
+  const elementsEqual = (
+    a: SelectedElementInfo,
+    b: SelectedElementInfo
+  ) => a.modelID === b.modelID && a.expressID === b.expressID
+
+  const computeFinalElements = (
+    ruleEls: SelectedElementInfo[],
+    manualAdd: SelectedElementInfo[],
+    manualRemove: SelectedElementInfo[]
+  ): SelectedElementInfo[] => {
+    const final: SelectedElementInfo[] = []
+    for (const el of ruleEls) {
+      if (!manualRemove.some((m) => elementsEqual(m, el))) {
+        final.push(el)
+      }
+    }
+    for (const el of manualAdd) {
+      if (!final.some((f) => elementsEqual(f, el))) final.push(el)
+    }
+    return final
+  }
+
+  const assignClassificationToElement = useCallback(
+    (code: string, element: SelectedElementInfo) => {
+      setClassifications((prev) => {
+        const current = prev[code]
+        if (!current) return prev
+        const manualAdd: SelectedElementInfo[] =
+          current.manualAssignments || []
+        const manualRemove: SelectedElementInfo[] =
+          current.manualUnassignments || []
+        if (!manualAdd.some((e: SelectedElementInfo) => elementsEqual(e, element))) {
+          manualAdd.push(element)
+        }
+        const filteredRemove = manualRemove.filter(
+          (e: SelectedElementInfo) => !elementsEqual(e, element)
+        )
+        const final = computeFinalElements(
+          current.ruleElements || [],
+          manualAdd,
+          filteredRemove
+        )
+        return {
+          ...prev,
+          [code]: {
+            ...current,
+            manualAssignments: manualAdd,
+            manualUnassignments: filteredRemove,
+            elements: final,
+          },
+        }
+      })
+    },
+    [setClassifications]
+  )
+
+  const unassignClassificationFromElement = useCallback(
+    (code: string, element: SelectedElementInfo) => {
+      setClassifications((prev) => {
+        const current = prev[code]
+        if (!current) return prev
+        const manualAdd: SelectedElementInfo[] = (current.manualAssignments || [])
+          .filter((e: SelectedElementInfo) => !elementsEqual(e, element))
+        const manualRemove: SelectedElementInfo[] =
+          current.manualUnassignments || []
+        if (!manualRemove.some((e: SelectedElementInfo) => elementsEqual(e, element))) {
+          manualRemove.push(element)
+        }
+        const final = computeFinalElements(
+          current.ruleElements || [],
+          manualAdd,
+          manualRemove
+        )
+        return {
+          ...prev,
+          [code]: {
+            ...current,
+            manualAssignments: manualAdd,
+            manualUnassignments: manualRemove,
+            elements: final,
+          },
+        }
+      })
+    },
+    [setClassifications]
+  )
 
   const toggleUserHideElement = useCallback(
     (elementToToggle: SelectedElementInfo) => {
@@ -1399,6 +1502,8 @@ export function IFCContextProvider({ children }: { children: ReactNode }) {
         removeRule,
         updateRule,
         previewRuleHighlight,
+        assignClassificationToElement,
+        unassignClassificationFromElement,
         toggleUserHideElement,
         unhideLastElement,
         unhideAllElements,


### PR DESCRIPTION
## Summary
- type arrays used for manual classification overrides to avoid implicit `any`

## Testing
- `tsc --noEmit` *(fails: cannot find type definition files)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a panel for managing classification assignments directly from the viewer interface.
  - Users can now manually assign or unassign classifications to selected elements, in addition to existing rule-based assignments.
  - Visual badges display all classifications currently assigned to a selected element.

- **Improvements**
  - Classification assignments now distinguish between rule-based and manual changes, providing greater control and transparency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->