### PR TITLE
Add manual classification tools

### DIFF
--- a/components/classification-panel.tsx
+++ b/components/classification-panel.tsx
@@ -65,6 +65,10 @@ export function ClassificationPanel() {
     showAllClassificationColors,
     toggleShowAllClassificationColors,
     loadedModels,
+    selectedElement,
+    assignClassificationToElement,
+    unassignClassificationFromElement,
+    unassignElementFromAllClassifications,
   } = useIFCContext()
   const [isAddDialogOpen, setIsAddDialogOpen] = useState(false)
   const [newClassification, setNewClassification] = useState({
@@ -298,6 +302,24 @@ export function ClassificationPanel() {
       updateClassification(currentClassificationForEdit.code, currentClassificationForEdit)
       setIsEditDialogOpen(false)
       setCurrentClassificationForEdit(null)
+    }
+  }
+
+  const handleAssignSelected = () => {
+    if (selectedElement && highlightedClassificationCode) {
+      assignClassificationToElement(highlightedClassificationCode, selectedElement)
+    }
+  }
+
+  const handleUnassignSelected = () => {
+    if (selectedElement && highlightedClassificationCode) {
+      unassignClassificationFromElement(highlightedClassificationCode, selectedElement)
+    }
+  }
+
+  const handleClearSelected = () => {
+    if (selectedElement) {
+      unassignElementFromAllClassifications(selectedElement)
     }
   }
 
@@ -709,6 +731,20 @@ export function ClassificationPanel() {
               </div>
             )}
           </div>
+        </div>
+      )}
+
+      {selectedElement && (
+        <div className="mt-4 space-y-2 border-t pt-4">
+          {highlightedClassificationCode ? (
+            <>
+              <Button className="w-full" onClick={handleAssignSelected}>Assign Selected Element</Button>
+              <Button className="w-full" variant="outline" onClick={handleUnassignSelected}>Remove Selected from Classification</Button>
+            </>
+          ) : (
+            <p className="text-sm text-muted-foreground">Highlight a classification to assign.</p>
+          )}
+          <Button className="w-full" variant="outline" onClick={handleClearSelected}>Clear from All Classifications</Button>
         </div>
       )}
 


### PR DESCRIPTION
## Summary
- enable manual element classification and removal in context
- expose new APIs from context
- add manual assignment controls to classification panel UI

## Testing
- `npm run lint` *(fails: next not found)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to assign and unassign classifications to the currently selected IFC element directly from the classification panel.
  - Introduced new controls in the classification panel for managing element-classification assignments, including options to clear all classifications from the selected element.
  - Buttons for assignment actions are enabled only when a classification is highlighted, providing clear user guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->