### PR TITLE
Add classification JSON import/export

### DIFF
--- a/components/classification-panel.tsx
+++ b/components/classification-panel.tsx
@@ -1,8 +1,13 @@
 "use client"
 
-import { useState, useEffect, useRef, useMemo } from "react"
+import React, { useState, useEffect, useRef, useMemo } from "react"
 import { FixedSizeList as List } from "react-window"; // Import react-window
-import { useIFCContext, type SelectedElementInfo, type LoadedModelData } from "@/context/ifc-context"
+import {
+  useIFCContext,
+  type SelectedElementInfo,
+  type LoadedModelData,
+  type ClassificationItem,
+} from "@/context/ifc-context"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
@@ -30,14 +35,6 @@ import {
   type ExportClassificationData
 } from "@/services/ifc-export-service"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
-
-// Define an interface for our classification structure
-interface ClassificationItem {
-  code: string;
-  name: string;
-  color: string;
-  elements: SelectedElementInfo[]; // Use SelectedElementInfo for stricter typing
-}
 
 // Helper function to compare two arrays of SelectedElementInfo (order-independent)
 function areElementArraysEqual(arr1: any[], arr2: any[]): boolean {
@@ -69,6 +66,8 @@ export function ClassificationPanel() {
     assignClassificationToElement,
     unassignClassificationFromElement,
     unassignElementFromAllClassifications,
+    exportClassificationsAsJson,
+    importClassificationsFromJson,
   } = useIFCContext()
   const [isAddDialogOpen, setIsAddDialogOpen] = useState(false)
   const [newClassification, setNewClassification] = useState({
@@ -109,6 +108,29 @@ export function ClassificationPanel() {
   const exportableModels = useMemo(() => {
     return loadedModels.filter(model => model.rawBuffer && model.modelID !== null)
   }, [loadedModels])
+
+  const fileInputRef = useRef<HTMLInputElement>(null)
+
+  const handleExportJson = () => {
+    const json = exportClassificationsAsJson()
+    downloadFile(json, 'classifications.json', 'application/json')
+  }
+
+  const triggerImport = () => fileInputRef.current?.click()
+
+  const handleImportJson = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    if (!file) return
+    const reader = new FileReader()
+    reader.onload = ev => {
+      const text = ev.target?.result
+      if (typeof text === 'string') {
+        importClassificationsFromJson(text)
+      }
+    }
+    reader.readAsText(file)
+    e.target.value = ''
+  }
 
   // Effect to manage the default selected model for export
   useEffect(() => {
@@ -565,7 +587,7 @@ export function ClassificationPanel() {
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
               <Button size="sm" variant="outline" className="whitespace-nowrap">
-                Add Default
+                Manage
                 <ChevronDown className="w-4 h-4 ml-2 flex-shrink-0" />
               </Button>
             </DropdownMenuTrigger>
@@ -592,7 +614,11 @@ export function ClassificationPanel() {
               {!isLoadingEBKPH && !errorLoadingEBKPH && defaultEBKPH.length === 0 && (
                 <DropdownMenuItem disabled>No eBKP-H items found.</DropdownMenuItem>
               )}
+              <DropdownMenuSeparator />
+              <DropdownMenuItem onClick={handleExportJson}>Export Classifications</DropdownMenuItem>
+              <DropdownMenuItem onSelect={(e) => { e.preventDefault(); triggerImport(); }}>Import Classifications</DropdownMenuItem>
             </DropdownMenuContent>
+            <input type="file" accept="application/json" ref={fileInputRef} onChange={handleImportJson} className="hidden" />
           </DropdownMenu>
         </div>
       </div>

--- a/context/ifc-context.tsx
+++ b/context/ifc-context.tsx
@@ -57,6 +57,13 @@ export interface SelectedElementInfo {
   expressID: number;
 }
 
+export interface ClassificationItem {
+  code: string;
+  name: string;
+  color: string;
+  elements?: SelectedElementInfo[];
+}
+
 interface IFCContextType {
   loadedModels: LoadedModelData[]; // Array of loaded models
   selectedElement: SelectedElementInfo | null;
@@ -118,6 +125,9 @@ interface IFCContextType {
   updateRule: (rule: Rule) => void;
   previewRuleHighlight: (ruleId: string) => Promise<void>;
 
+  exportClassificationsAsJson: () => string;
+  importClassificationsFromJson: (json: string) => void;
+
   assignClassificationToElement: (
     classificationCode: string,
     element: SelectedElementInfo
@@ -127,6 +137,9 @@ interface IFCContextType {
     element: SelectedElementInfo
   ) => void;
   unassignElementFromAllClassifications: (element: SelectedElementInfo) => void;
+
+  exportClassificationsAsJson: () => string;
+  importClassificationsFromJson: (json: string) => void;
 
   toggleUserHideElement: (element: SelectedElementInfo) => void; // New function
   unhideLastElement: () => void; // New function
@@ -1372,6 +1385,35 @@ export function IFCContextProvider({ children }: { children: ReactNode }) {
     [setRules]
   );
 
+  const exportClassificationsAsJson = useCallback((): string => {
+    const arr = Object.values(classifications);
+    return JSON.stringify(arr, null, 2);
+  }, [classifications]);
+
+  const importClassificationsFromJson = useCallback(
+    (json: string) => {
+      try {
+        const parsed = JSON.parse(json) as ClassificationItem[];
+        if (!Array.isArray(parsed)) {
+          console.error("Classification JSON is not an array");
+          return;
+        }
+        setClassifications((prev) => {
+          const updated = { ...prev };
+          parsed.forEach((item) => {
+            if (item.code) {
+              updated[item.code] = { ...item, elements: item.elements || [] };
+            }
+          });
+          return updated;
+        });
+      } catch (e) {
+        console.error("Failed to import classifications", e);
+      }
+    },
+    [setClassifications]
+  );
+
   const toggleUserHideElement = useCallback(
     (elementToToggle: SelectedElementInfo) => {
       console.log(
@@ -1481,6 +1523,8 @@ export function IFCContextProvider({ children }: { children: ReactNode }) {
         removeRule,
         updateRule,
         previewRuleHighlight,
+        exportClassificationsAsJson,
+        importClassificationsFromJson,
         toggleUserHideElement,
         unhideLastElement,
         unhideAllElements,


### PR DESCRIPTION
## Summary
- allow exporting classification list to JSON
- allow importing classification list from JSON via file dialog
- rename "Add Default" dropdown to "Manage" and integrate export/import options
- support classification import/export in context API

## Testing
- `npm ci --ignore-scripts` *(fails: EHOSTUNREACH)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added options to export and import classification data as JSON files from the user interface, allowing users to back up or restore their classifications.
  - Updated the dropdown menu with a new "Manage" label and additional actions for exporting and importing classifications.

- **User Interface**
  - Enhanced the classification panel with new controls for managing classification data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->