### PR TITLE
Add classification JSON import/export

### DIFF
--- a/context/ifc-context.tsx
+++ b/context/ifc-context.tsx
@@ -57,6 +57,13 @@ export interface SelectedElementInfo {
   expressID: number;
 }
 
+export interface ClassificationItem {
+  code: string;
+  name: string;
+  color: string;
+  elements?: SelectedElementInfo[];
+}
+
 interface IFCContextType {
   loadedModels: LoadedModelData[]; // Array of loaded models
   selectedElement: SelectedElementInfo | null;
@@ -117,6 +124,10 @@ interface IFCContextType {
   removeRule: (id: string) => void;
   updateRule: (rule: Rule) => void;
   previewRuleHighlight: (ruleId: string) => Promise<void>;
+
+  exportClassificationsAsJson: () => string;
+  importClassificationsFromJson: (json: string) => void;
+  removeAllClassifications: () => void;
 
   assignClassificationToElement: (
     classificationCode: string,
@@ -1273,6 +1284,10 @@ export function IFCContextProvider({ children }: { children: ReactNode }) {
     [setClassifications]
   );
 
+  const removeAllClassifications = useCallback(() => {
+    setClassifications({});
+  }, [setClassifications]);
+
   const updateClassification = useCallback(
     (code: string, classificationItem: any) => {
       setClassifications((prev) => ({ ...prev, [code]: classificationItem }));
@@ -1370,6 +1385,35 @@ export function IFCContextProvider({ children }: { children: ReactNode }) {
       );
     },
     [setRules]
+  );
+
+  const exportClassificationsAsJson = useCallback((): string => {
+    const arr = Object.values(classifications);
+    return JSON.stringify(arr, null, 2);
+  }, [classifications]);
+
+  const importClassificationsFromJson = useCallback(
+    (json: string) => {
+      try {
+        const parsed = JSON.parse(json) as ClassificationItem[];
+        if (!Array.isArray(parsed)) {
+          console.error("Classification JSON is not an array");
+          return;
+        }
+        setClassifications((prev) => {
+          const updated = { ...prev };
+          parsed.forEach((item) => {
+            if (item.code) {
+              updated[item.code] = { ...item, elements: item.elements || [] };
+            }
+          });
+          return updated;
+        });
+      } catch (e) {
+        console.error("Failed to import classifications", e);
+      }
+    },
+    [setClassifications]
   );
 
   const toggleUserHideElement = useCallback(
@@ -1473,6 +1517,7 @@ export function IFCContextProvider({ children }: { children: ReactNode }) {
         toggleShowAllClassificationColors,
         addClassification,
         removeClassification,
+        removeAllClassifications,
         updateClassification,
         assignClassificationToElement,
         unassignClassificationFromElement,
@@ -1481,6 +1526,8 @@ export function IFCContextProvider({ children }: { children: ReactNode }) {
         removeRule,
         updateRule,
         previewRuleHighlight,
+        exportClassificationsAsJson,
+        importClassificationsFromJson,
         toggleUserHideElement,
         unhideLastElement,
         unhideAllElements,


### PR DESCRIPTION
## Summary
- allow exporting classification list to JSON
- allow importing classification list from JSON via file dialog
- rename "Add Default" dropdown to "Manage" and integrate export/import options
- support classification import/export in context API
- manage classifications in one dropdown, including remove all option

## Testing
- `npm ci --ignore-scripts` *(fails: EHOSTUNREACH)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to export classifications as a JSON file.
  - Added support for importing classifications from a JSON file.
  - Introduced a bulk removal option to clear all classifications at once.
  - Consolidated classification management actions into a new "Manage" dropdown menu for easier access.

- **UI Improvements**
  - Streamlined the interface by moving classification management options into a single dropdown, improving organization and usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->