### PR TITLE
Add classification JSON import/export

### DIFF
--- a/context/ifc-context.tsx
+++ b/context/ifc-context.tsx
@@ -57,6 +57,13 @@ export interface SelectedElementInfo {
   expressID: number;
 }
 
+export interface ClassificationItem {
+  code: string;
+  name: string;
+  color: string;
+  elements?: SelectedElementInfo[];
+}
+
 interface IFCContextType {
   loadedModels: LoadedModelData[]; // Array of loaded models
   selectedElement: SelectedElementInfo | null;
@@ -112,6 +119,7 @@ interface IFCContextType {
   // Classification and Rule methods (can remain global or be refactored later if needed per model)
   addClassification: (classification: any) => void;
   removeClassification: (code: string) => void;
+  removeAllClassifications: () => void;
   updateClassification: (code: string, classification: any) => void;
   addRule: (rule: Rule) => void;
   removeRule: (id: string) => void;
@@ -127,6 +135,9 @@ interface IFCContextType {
     element: SelectedElementInfo
   ) => void;
   unassignElementFromAllClassifications: (element: SelectedElementInfo) => void;
+
+  exportClassificationsAsJson: () => string;
+  importClassificationsFromJson: (json: string) => void;
 
   toggleUserHideElement: (element: SelectedElementInfo) => void; // New function
   unhideLastElement: () => void; // New function
@@ -1273,6 +1284,10 @@ export function IFCContextProvider({ children }: { children: ReactNode }) {
     [setClassifications]
   );
 
+  const removeAllClassifications = useCallback(() => {
+    setClassifications({});
+  }, [setClassifications]);
+
   const updateClassification = useCallback(
     (code: string, classificationItem: any) => {
       setClassifications((prev) => ({ ...prev, [code]: classificationItem }));
@@ -1370,6 +1385,35 @@ export function IFCContextProvider({ children }: { children: ReactNode }) {
       );
     },
     [setRules]
+  );
+
+  const exportClassificationsAsJson = useCallback((): string => {
+    const arr = Object.values(classifications);
+    return JSON.stringify(arr, null, 2);
+  }, [classifications]);
+
+  const importClassificationsFromJson = useCallback(
+    (json: string) => {
+      try {
+        const parsed = JSON.parse(json) as ClassificationItem[];
+        if (!Array.isArray(parsed)) {
+          console.error("Classification JSON is not an array");
+          return;
+        }
+        setClassifications((prev) => {
+          const updated = { ...prev };
+          parsed.forEach((item) => {
+            if (item.code) {
+              updated[item.code] = { ...item, elements: item.elements || [] };
+            }
+          });
+          return updated;
+        });
+      } catch (e) {
+        console.error("Failed to import classifications", e);
+      }
+    },
+    [setClassifications]
   );
 
   const toggleUserHideElement = useCallback(
@@ -1473,6 +1517,7 @@ export function IFCContextProvider({ children }: { children: ReactNode }) {
         toggleShowAllClassificationColors,
         addClassification,
         removeClassification,
+        removeAllClassifications,
         updateClassification,
         assignClassificationToElement,
         unassignClassificationFromElement,
@@ -1481,6 +1526,8 @@ export function IFCContextProvider({ children }: { children: ReactNode }) {
         removeRule,
         updateRule,
         previewRuleHighlight,
+        exportClassificationsAsJson,
+        importClassificationsFromJson,
         toggleUserHideElement,
         unhideLastElement,
         unhideAllElements,


### PR DESCRIPTION
## Summary
- allow exporting classification list to JSON
- allow importing classification list from JSON via file dialog
- centralize classification management in dropdown with add, import, export, remove all
- add confirmation dialogs for removing single or all classifications
- support `removeAllClassifications` in context API

## Testing
- `npm run build` *(fails: next not found)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added options to import and export classifications as JSON files.
  - Introduced a bulk removal feature to clear all classifications at once.
  - Updated the interface with a "Manage" dropdown for easier access to classification management actions.
  - Added confirmation dialogs for both single and bulk classification removals to prevent accidental deletion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->