### PR TITLE
Add rule management menu

### DIFF
--- a/context/ifc-context.tsx
+++ b/context/ifc-context.tsx
@@ -128,6 +128,9 @@ interface IFCContextType {
 
   exportClassificationsAsJson: () => string;
   importClassificationsFromJson: (json: string) => void;
+  exportRulesAsJson: () => string;
+  importRulesFromJson: (json: string) => void;
+  removeAllRules: () => void;
 
   assignClassificationToElement: (
     classificationCode: string,
@@ -1416,6 +1419,30 @@ export function IFCContextProvider({ children }: { children: ReactNode }) {
     [setClassifications]
   );
 
+  const exportRulesAsJson = useCallback((): string => {
+    return JSON.stringify(rules, null, 2);
+  }, [rules]);
+
+  const importRulesFromJson = useCallback(
+    (json: string) => {
+      try {
+        const parsed = JSON.parse(json) as Rule[];
+        if (!Array.isArray(parsed)) {
+          console.error("Rules JSON is not an array");
+          return;
+        }
+        setRules(parsed);
+      } catch (e) {
+        console.error("Failed to import rules", e);
+      }
+    },
+    [setRules]
+  );
+
+  const removeAllRules = useCallback(() => {
+    setRules([]);
+  }, [setRules]);
+
   const toggleUserHideElement = useCallback(
     (elementToToggle: SelectedElementInfo) => {
       console.log(
@@ -1528,6 +1555,9 @@ export function IFCContextProvider({ children }: { children: ReactNode }) {
         previewRuleHighlight,
         exportClassificationsAsJson,
         importClassificationsFromJson,
+        exportRulesAsJson,
+        importRulesFromJson,
+        removeAllRules,
         toggleUserHideElement,
         unhideLastElement,
         unhideAllElements,


### PR DESCRIPTION
## Summary
- add rule import/export helpers in context
- update provider return signature
- extend RulePanel with dropdown menu and actions
- add ability to copy existing rules when creating new rules
- add quick add button and confirmation dialog for clearing rules

## Testing
- `npm run lint` *(fails: `next` not found)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added the ability to import and export rules as JSON files.
	- Introduced a dropdown menu for rule management, including options to add, export, import, and remove all rules.
	- Enabled duplication of existing rules with a "Copy Rule" button.
	- Added a floating "Add Rule" button for quick access.

- **UI Improvements**
	- Improved rule management interface with confirmation dialogs for bulk actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->