### PR TITLE
Add persistent default classification setting

### DIFF
--- a/components/classification-panel.tsx
+++ b/components/classification-panel.tsx
@@ -131,6 +131,7 @@ export function ClassificationPanel() {
   const [errorLoadingEBKPH, setErrorLoadingEBKPH] = useState<string | null>(
     null
   );
+  const [hasAutoLoaded, setHasAutoLoaded] = useState(false);
 
   const [sortConfig, setSortConfig] = useState<{
     key: SortableKey;
@@ -366,6 +367,46 @@ export function ClassificationPanel() {
       return false;
     return defaultEBKPH.every((defClass) => !!classifications[defClass.code]);
   };
+
+  // Auto load default classifications based on stored settings
+  useEffect(() => {
+    if (hasAutoLoaded) return;
+    const stored = localStorage.getItem("appSettings");
+    if (!stored) return;
+    try {
+      const { defaultClassification, alwaysLoad } = JSON.parse(stored);
+      if (!alwaysLoad) return;
+      if (
+        defaultClassification === "uniclass" &&
+        !isLoadingUniclass &&
+        !errorLoadingUniclass &&
+        defaultUniclassPr.length > 0 &&
+        !areAllUniclassAdded()
+      ) {
+        handleAddAllUniclassPr();
+        setHasAutoLoaded(true);
+      } else if (
+        defaultClassification === "ebkph" &&
+        !isLoadingEBKPH &&
+        !errorLoadingEBKPH &&
+        defaultEBKPH.length > 0 &&
+        !areAlleBKPHAdded()
+      ) {
+        handleAddAlleBKPH();
+        setHasAutoLoaded(true);
+      }
+    } catch (err) {
+      console.error("Failed to auto load classifications", err);
+    }
+  }, [
+    isLoadingUniclass,
+    isLoadingEBKPH,
+    defaultUniclassPr,
+    defaultEBKPH,
+    errorLoadingUniclass,
+    errorLoadingEBKPH,
+    hasAutoLoaded,
+  ]);
 
   const handleAddClassification = () => {
     if (newClassification.code && newClassification.name) {

--- a/components/ifc-viewer.tsx
+++ b/components/ifc-viewer.tsx
@@ -15,6 +15,7 @@ import { OrbitControls, Environment } from "@react-three/drei";
 import { IFCModel } from "@/components/ifc-model";
 import { ClassificationPanel } from "@/components/classification-panel";
 import { RulePanel } from "@/components/rule-panel";
+import { SettingsPanel } from "@/components/settings-panel";
 import { Button } from "@/components/ui/button";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
@@ -1076,10 +1077,7 @@ function ViewerContent() {
               value="settings"
               className="p-4 flex-grow overflow-y-auto"
             >
-              <h3 className="text-lg font-medium">Settings</h3>
-              <p className="text-sm text-muted-foreground">
-                Settings for the application will go here.
-              </p>
+              <SettingsPanel />
             </TabsContent>
           </Tabs>
         </Panel>

--- a/components/settings-panel.tsx
+++ b/components/settings-panel.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
+
+interface AppSettings {
+  defaultClassification: string;
+  alwaysLoad: boolean;
+}
+
+const SETTINGS_KEY = "appSettings";
+
+export function SettingsPanel() {
+  const [defaultClassification, setDefaultClassification] = useState<string>("");
+  const [alwaysLoad, setAlwaysLoad] = useState<boolean>(false);
+
+  // Load settings from localStorage on mount
+  useEffect(() => {
+    const stored = localStorage.getItem(SETTINGS_KEY);
+    if (stored) {
+      try {
+        const parsed: AppSettings = JSON.parse(stored);
+        setDefaultClassification(parsed.defaultClassification || "");
+        setAlwaysLoad(parsed.alwaysLoad || false);
+      } catch (err) {
+        console.error("Failed to parse stored settings", err);
+      }
+    }
+  }, []);
+
+  // Persist settings whenever they change
+  useEffect(() => {
+    const toStore: AppSettings = { defaultClassification, alwaysLoad };
+    localStorage.setItem(SETTINGS_KEY, JSON.stringify(toStore));
+  }, [defaultClassification, alwaysLoad]);
+
+  return (
+    <div className="space-y-6">
+      <h3 className="text-lg font-medium">Application Settings</h3>
+      <div className="grid gap-4">
+        <div className="grid grid-cols-4 items-center gap-4">
+          <Label htmlFor="default-classification" className="text-right">
+            Default Classification
+          </Label>
+          <Select
+            value={defaultClassification}
+            onValueChange={setDefaultClassification}
+          >
+            <SelectTrigger id="default-classification" className="col-span-3">
+              <SelectValue placeholder="None" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="">None</SelectItem>
+              <SelectItem value="uniclass">Uniclass Pr</SelectItem>
+              <SelectItem value="ebkph">eBKP-H</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+        <div className="grid grid-cols-4 items-center gap-4">
+          <Label htmlFor="autoload" className="text-right">
+            Always load on start
+          </Label>
+          <div className="col-span-3">
+            <Switch
+              id="autoload"
+              checked={alwaysLoad}
+              onCheckedChange={setAlwaysLoad}
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add SettingsPanel component for storing user preferences
- integrate SettingsPanel into viewer tabs
- auto-load default classification set based on user setting

## Testing
- `npm run lint` *(fails: `next` not found)*