### PR TITLE
Add footer with links

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,6 +5,7 @@ import { ThemeProvider } from "@/app/theme-provider";
 import { IFCContextProvider } from "@/context/ifc-context";
 import Script from 'next/script';
 import Menubar from "@/components/layout/Menubar";
+import Footer from "@/components/layout/Footer";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -43,6 +44,7 @@ export default function RootLayout({
             <div className="flex flex-col h-full">
               <Menubar />
               <main className="flex-1 overflow-hidden">{children}</main>
+              <Footer />
             </div>
           </ThemeProvider>
         </IFCContextProvider>

--- a/components/layout/Footer.tsx
+++ b/components/layout/Footer.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import Link from "next/link";
+import { Github, Sparkles } from "lucide-react";
+
+export default function Footer() {
+  return (
+    <footer className="border-t border-border/15 bg-background/70 backdrop-blur-sm text-sm">
+      <div className="max-w-7xl mx-auto px-4 py-2 flex items-center justify-between">
+        <div className="flex items-center space-x-2">
+          <Sparkles className="h-4 w-4 text-primary animate-pulse" />
+          <span>
+            <Link href="https://www.lt.plus" className="hover:text-primary underline">
+              lt.plus
+            </Link>
+            {" — "}Licensed under AGPL3
+          </span>
+        </div>
+        <Link
+          href="https://github.com/louistrue/ifc-classifier"
+          className="flex items-center space-x-1 hover:text-primary"
+        >
+          <Github className="h-4 w-4" />
+          <span>GitHub</span>
+        </Link>
+      </div>
+    </footer>
+  );
+}


### PR DESCRIPTION
## Summary
- create `Footer` component with GitHub and website links
- include footer in the main layout

## Testing
- `npx next lint` *(fails: connect EHOSTUNREACH)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a footer at the bottom of all pages, featuring links to the project website, license information, and the GitHub repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->