### PR TITLE
Add model URL settings with demo models

### DIFF
--- a/components/settings-panel.tsx
+++ b/components/settings-panel.tsx
@@ -16,6 +16,9 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Trash2, Check, Plus, Library } from "lucide-react";
 
 interface ModelSource {
   name: string;
@@ -154,103 +157,95 @@ export function SettingsPanel({ onSettingsChanged }: SettingsPanelProps) {
             </div>
           </div>
           <div className="p-4 rounded-lg bg-muted/30 space-y-4">
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Label className="block mb-2 cursor-help">Model URLs</Label>
-              </TooltipTrigger>
-              <TooltipContent>
-                <p>Manage a list of IFC model URLs. You can add custom URLs or use the demo models.</p>
-              </TooltipContent>
-            </Tooltip>
-            {modelUrls.length > 0 && (
-              <ul className="space-y-1">
-                {modelUrls.map((m, idx) => (
-                  <li key={idx} className="flex items-center justify-between">
-                    <span className="truncate mr-2" title={m.url}>
-                      {m.name}
-                    </span>
-                    <button
-                      onClick={() =>
-                        setModelUrls(modelUrls.filter((_, i) => i !== idx))
-                      }
-                      className="text-destructive hover:underline text-sm"
-                    >
-                      remove
-                    </button>
-                  </li>
-                ))}
-              </ul>
-            )}
-            <div className="grid grid-cols-3 gap-2">
+            <div className="flex justify-between items-center mb-2">
               <Tooltip>
                 <TooltipTrigger asChild>
-                  <input
-                    className="col-span-1 border rounded px-2 py-1 text-sm cursor-help"
-                    placeholder="Name"
-                    value={newModelName}
-                    onChange={(e) => setNewModelName(e.target.value)}
-                  />
+                  <Label className="cursor-help">Model URLs</Label>
                 </TooltipTrigger>
                 <TooltipContent>
-                  <p>Enter a descriptive name for the model URL.</p>
-                </TooltipContent>
-              </Tooltip>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <input
-                    className="col-span-2 border rounded px-2 py-1 text-sm cursor-help"
-                    placeholder="URL"
-                    value={newModelUrl}
-                    onChange={(e) => setNewModelUrl(e.target.value)}
-                  />
-                </TooltipTrigger>
-                <TooltipContent>
-                  <p>Enter the direct URL to an IFC model file (.ifc).</p>
-                </TooltipContent>
-              </Tooltip>
-            </div>
-            <div className="flex gap-2 justify-end">
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <button
-                    className="text-sm underline cursor-help"
-                    onClick={() => {
-                      if (!newModelName || !newModelUrl) return;
-                      setModelUrls([...modelUrls, { name: newModelName, url: newModelUrl }]);
-                      setNewModelName("");
-                      setNewModelUrl("");
-                    }}
-                  >
-                    add
-                  </button>
-                </TooltipTrigger>
-                <TooltipContent>
-                  <p>Add the specified name and URL to your list of models.</p>
+                  <p>Manage a list of IFC model URLs. You can add custom URLs or use the demo models.</p>
                 </TooltipContent>
               </Tooltip>
               {demoModels.length > 0 && (
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <button
-                      className="text-sm underline cursor-help"
-                      onClick={() => {
-                        const combined = [...modelUrls];
-                        demoModels.forEach((d) => {
-                          if (!combined.find((m) => m.url === d.url)) {
-                            combined.push(d);
-                          }
-                        });
-                        setModelUrls(combined);
-                      }}
-                    >
-                      add demo models
-                    </button>
-                  </TooltipTrigger>
-                  <TooltipContent>
-                    <p>Add a predefined set of demo models to your list. Duplicates will be ignored.</p>
-                  </TooltipContent>
-                </Tooltip>
+                <Button
+                  variant="link"
+                  size="sm"
+                  className="p-0 h-auto text-muted-foreground hover:text-primary"
+                  onClick={() => {
+                    const combined = [...modelUrls];
+                    demoModels.forEach((d) => {
+                      if (!combined.find((mU) => mU.url === d.url && mU.name === d.name)) {
+                        combined.push(d);
+                      }
+                    });
+                    setModelUrls(combined);
+                  }}
+                >
+                  <Library className="h-4 w-4 mr-1" />
+                  Demo Models
+                </Button>
               )}
+            </div>
+            {modelUrls.length > 0 && (
+              <ul className="space-y-2">
+                {modelUrls.map((m, idx) => {
+                  const isCustom = !demoModels.some(dm => dm.url === m.url && dm.name === m.name);
+                  return (
+                    <li key={idx} className="flex items-center justify-between p-2.5 rounded-md bg-background/50 hover:bg-muted/40 transition-colors shadow-sm border">
+                      <div className="flex items-center overflow-hidden">
+                        {isCustom && <Check className="h-5 w-5 mr-2 text-green-500 flex-shrink-0" />}
+                        {!isCustom && <Library className="h-5 w-5 mr-2 text-blue-500 flex-shrink-0" />}
+                        <div className="flex flex-col overflow-hidden">
+                          <span className="font-medium truncate" title={m.name}>{m.name}</span>
+                          <span className="text-xs text-muted-foreground truncate" title={m.url}>{m.url}</span>
+                        </div>
+                      </div>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        className="text-destructive hover:text-destructive/80 ml-2 flex-shrink-0"
+                        onClick={() =>
+                          setModelUrls(modelUrls.filter((_, i) => i !== idx))
+                        }
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </Button>
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+            {/* Inputs for adding a new URL - combined with inline add button */}
+            <div className="grid grid-cols-3 items-end gap-2 pt-2">
+              <Input
+                placeholder="Name"
+                value={newModelName}
+                onChange={(e) => setNewModelName(e.target.value)}
+                className="col-span-1"
+              />
+              {/* Wrapper for URL input and inline Add button */}
+              <div className="col-span-2 flex items-center gap-2">
+                <Input
+                  placeholder="URL"
+                  value={newModelUrl}
+                  onChange={(e) => setNewModelUrl(e.target.value)}
+                  className="flex-grow" // Input takes available space
+                />
+                <Button
+                  variant="outline"
+                  size="icon"
+                  onClick={() => {
+                    if (!newModelName || !newModelUrl) return;
+                    setModelUrls([...modelUrls, { name: newModelName, url: newModelUrl }]);
+                    setNewModelName("");
+                    setNewModelUrl("");
+                  }}
+                  disabled={!newModelName || !newModelUrl} // Disable if inputs are empty
+                  title="Add this URL"
+                >
+                  <Check className="h-4 w-4" />
+                </Button>
+              </div>
             </div>
           </div>
         </div>

--- a/components/settings-panel.tsx
+++ b/components/settings-panel.tsx
@@ -141,7 +141,7 @@ export function SettingsPanel({ onSettingsChanged }: SettingsPanelProps) {
                   </Label>
                 </TooltipTrigger>
                 <TooltipContent>
-                  <p>If enabled, the selected 'Default Classification' will be automatically applied on load.</p>
+                  <p>If enabled, the selected &apos;Default Classification&apos; will be automatically applied on load.</p>
                 </TooltipContent>
               </Tooltip>
               <div className="col-span-2">

--- a/components/settings-panel.tsx
+++ b/components/settings-panel.tsx
@@ -10,6 +10,12 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 interface ModelSource {
   name: string;
@@ -20,6 +26,11 @@ interface AppSettings {
   defaultClassification: string;
   alwaysLoad: boolean;
   modelUrls: ModelSource[];
+}
+
+// Define props for SettingsPanel
+interface SettingsPanelProps {
+  onSettingsChanged: () => void;
 }
 
 const SETTINGS_KEY = "appSettings";
@@ -50,7 +61,7 @@ const getInitialSettings = (): AppSettings => {
   return { defaultClassification: "", alwaysLoad: false, modelUrls: [] };
 };
 
-export function SettingsPanel() {
+export function SettingsPanel({ onSettingsChanged }: SettingsPanelProps) {
   // Initialize state directly from localStorage
   const [defaultClassification, setDefaultClassification] = useState<string>(
     () => getInitialSettings().defaultClassification
@@ -88,112 +99,162 @@ export function SettingsPanel() {
       modelUrls,
     };
     localStorage.setItem(SETTINGS_KEY, JSON.stringify(toStore));
-  }, [defaultClassification, alwaysLoad, modelUrls]);
+    onSettingsChanged(); // Call the callback after settings are saved
+  }, [defaultClassification, alwaysLoad, modelUrls, onSettingsChanged]);
 
   return (
-    <div className="space-y-6">
-      <h3 className="text-lg font-medium mb-6">Application Settings</h3>
-      <div className="space-y-4">
-        <div className="p-4 rounded-lg bg-muted/30">
-          <div className="grid grid-cols-3 items-center gap-4">
-            <Label htmlFor="default-classification" className="col-span-1">
-              Default Classification
-            </Label>
-            <Select
-              value={defaultClassification}
-              onValueChange={setDefaultClassification}
-            >
-              <SelectTrigger id="default-classification" className="col-span-2">
-                <SelectValue placeholder="None" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="none">None</SelectItem>
-                <SelectItem value="uniclass">Uniclass Pr</SelectItem>
-                <SelectItem value="ebkph">eBKP-H</SelectItem>
-              </SelectContent>
-            </Select>
+    <TooltipProvider>
+      <div className="space-y-6">
+        <h3 className="text-lg font-medium mb-6">Application Settings</h3>
+        <div className="space-y-4">
+          <div className="p-4 rounded-lg bg-muted/30 space-y-4">
+            <div className="grid grid-cols-3 items-center gap-4">
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Label htmlFor="default-classification" className="col-span-1 cursor-help">
+                    Default Classification
+                  </Label>
+                </TooltipTrigger>
+                <TooltipContent>
+                  <p>Sets the default classification system.</p>
+                </TooltipContent>
+              </Tooltip>
+              <Select
+                value={defaultClassification}
+                onValueChange={setDefaultClassification}
+              >
+                <SelectTrigger id="default-classification" className="col-span-2">
+                  <SelectValue placeholder="None" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="none">None</SelectItem>
+                  <SelectItem value="uniclass">Uniclass Pr</SelectItem>
+                  <SelectItem value="ebkph">eBKP-H</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="grid grid-cols-3 items-center gap-4">
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Label htmlFor="autoload" className="col-span-1 cursor-help">
+                    Always apply on load
+                  </Label>
+                </TooltipTrigger>
+                <TooltipContent>
+                  <p>If enabled, the selected 'Default Classification' will be automatically applied on load.</p>
+                </TooltipContent>
+              </Tooltip>
+              <div className="col-span-2">
+                <Switch
+                  id="autoload"
+                  checked={alwaysLoad}
+                  onCheckedChange={setAlwaysLoad}
+                />
+              </div>
+            </div>
           </div>
-        </div>
-        <div className="p-4 rounded-lg bg-muted/30">
-          <div className="grid grid-cols-3 items-center gap-4">
-            <Label htmlFor="autoload" className="col-span-1">
-              Always load on start
-            </Label>
-            <div className="col-span-2">
-              <Switch
-                id="autoload"
-                checked={alwaysLoad}
-                onCheckedChange={setAlwaysLoad}
-              />
+          <div className="p-4 rounded-lg bg-muted/30 space-y-4">
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Label className="block mb-2 cursor-help">Model URLs</Label>
+              </TooltipTrigger>
+              <TooltipContent>
+                <p>Manage a list of IFC model URLs. You can add custom URLs or use the demo models.</p>
+              </TooltipContent>
+            </Tooltip>
+            {modelUrls.length > 0 && (
+              <ul className="space-y-1">
+                {modelUrls.map((m, idx) => (
+                  <li key={idx} className="flex items-center justify-between">
+                    <span className="truncate mr-2" title={m.url}>
+                      {m.name}
+                    </span>
+                    <button
+                      onClick={() =>
+                        setModelUrls(modelUrls.filter((_, i) => i !== idx))
+                      }
+                      className="text-destructive hover:underline text-sm"
+                    >
+                      remove
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            )}
+            <div className="grid grid-cols-3 gap-2">
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <input
+                    className="col-span-1 border rounded px-2 py-1 text-sm cursor-help"
+                    placeholder="Name"
+                    value={newModelName}
+                    onChange={(e) => setNewModelName(e.target.value)}
+                  />
+                </TooltipTrigger>
+                <TooltipContent>
+                  <p>Enter a descriptive name for the model URL.</p>
+                </TooltipContent>
+              </Tooltip>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <input
+                    className="col-span-2 border rounded px-2 py-1 text-sm cursor-help"
+                    placeholder="URL"
+                    value={newModelUrl}
+                    onChange={(e) => setNewModelUrl(e.target.value)}
+                  />
+                </TooltipTrigger>
+                <TooltipContent>
+                  <p>Enter the direct URL to an IFC model file (.ifc).</p>
+                </TooltipContent>
+              </Tooltip>
+            </div>
+            <div className="flex gap-2 justify-end">
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    className="text-sm underline cursor-help"
+                    onClick={() => {
+                      if (!newModelName || !newModelUrl) return;
+                      setModelUrls([...modelUrls, { name: newModelName, url: newModelUrl }]);
+                      setNewModelName("");
+                      setNewModelUrl("");
+                    }}
+                  >
+                    add
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent>
+                  <p>Add the specified name and URL to your list of models.</p>
+                </TooltipContent>
+              </Tooltip>
+              {demoModels.length > 0 && (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <button
+                      className="text-sm underline cursor-help"
+                      onClick={() => {
+                        const combined = [...modelUrls];
+                        demoModels.forEach((d) => {
+                          if (!combined.find((m) => m.url === d.url)) {
+                            combined.push(d);
+                          }
+                        });
+                        setModelUrls(combined);
+                      }}
+                    >
+                      add demo models
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    <p>Add a predefined set of demo models to your list. Duplicates will be ignored.</p>
+                  </TooltipContent>
+                </Tooltip>
+              )}
             </div>
           </div>
         </div>
-        <div className="p-4 rounded-lg bg-muted/30 space-y-4">
-          <Label className="block mb-2">Model URLs</Label>
-          {modelUrls.length > 0 && (
-            <ul className="space-y-1">
-              {modelUrls.map((m, idx) => (
-                <li key={idx} className="flex items-center justify-between">
-                  <span className="truncate mr-2" title={m.url}>
-                    {m.name}
-                  </span>
-                  <button
-                    onClick={() =>
-                      setModelUrls(modelUrls.filter((_, i) => i !== idx))
-                    }
-                    className="text-destructive hover:underline text-sm"
-                  >
-                    remove
-                  </button>
-                </li>
-              ))}
-            </ul>
-          )}
-          <div className="grid grid-cols-3 gap-2">
-            <input
-              className="col-span-1 border rounded px-2 py-1 text-sm"
-              placeholder="Name"
-              value={newModelName}
-              onChange={(e) => setNewModelName(e.target.value)}
-            />
-            <input
-              className="col-span-2 border rounded px-2 py-1 text-sm"
-              placeholder="URL"
-              value={newModelUrl}
-              onChange={(e) => setNewModelUrl(e.target.value)}
-            />
-          </div>
-          <div className="flex gap-2 justify-end">
-            <button
-              className="text-sm underline"
-              onClick={() => {
-                if (!newModelName || !newModelUrl) return;
-                setModelUrls([...modelUrls, { name: newModelName, url: newModelUrl }]);
-                setNewModelName("");
-                setNewModelUrl("");
-              }}
-            >
-              add
-            </button>
-            {demoModels.length > 0 && (
-              <button
-                className="text-sm underline"
-                onClick={() => {
-                  const combined = [...modelUrls];
-                  demoModels.forEach((d) => {
-                    if (!combined.find((m) => m.url === d.url)) {
-                      combined.push(d);
-                    }
-                  });
-                  setModelUrls(combined);
-                }}
-              >
-                add demo models
-              </button>
-            )}
-          </div>
-        </div>
       </div>
-    </div>
+    </TooltipProvider>
   );
 }

--- a/public/data/demo_models.json
+++ b/public/data/demo_models.json
@@ -1,0 +1,22 @@
+[
+  {
+    "name": "Building Architecture",
+    "url": "https://raw.githubusercontent.com/buildingSMART/Sample-Test-Files/main/IFC%204.3.2.0%20(IFC4X3_ADD2)/PCERT-Sample-Scene/Building-Architecture.ifc"
+  },
+  {
+    "name": "Building HVAC",
+    "url": "https://raw.githubusercontent.com/buildingSMART/Sample-Test-Files/main/IFC%204.3.2.0%20(IFC4X3_ADD2)/PCERT-Sample-Scene/Building-Hvac.ifc"
+  },
+  {
+    "name": "Building Landscaping",
+    "url": "https://raw.githubusercontent.com/buildingSMART/Sample-Test-Files/main/IFC%204.3.2.0%20(IFC4X3_ADD2)/PCERT-Sample-Scene/Building-Landscaping.ifc"
+  },
+  {
+    "name": "Building Structural",
+    "url": "https://raw.githubusercontent.com/buildingSMART/Sample-Test-Files/main/IFC%204.3.2.0%20(IFC4X3_ADD2)/PCERT-Sample-Scene/Building-Structural.ifc"
+  },
+  {
+    "name": "Infra Bridge",
+    "url": "https://raw.githubusercontent.com/buildingSMART/Sample-Test-Files/main/IFC%204.3.2.0%20(IFC4X3_ADD2)/PCERT-Sample-Scene/Infra-Bridge.ifc"
+  }
+]

--- a/public/data/demo_models.json
+++ b/public/data/demo_models.json
@@ -1,22 +1,22 @@
 [
   {
     "name": "Building Architecture",
-    "url": "https://raw.githubusercontent.com/buildingSMART/Sample-Test-Files/main/IFC%204.3.2.0%20(IFC4X3_ADD2)/PCERT-Sample-Scene/Building-Architecture.ifc"
+    "url": "https://raw.githubusercontent.com/buildingSMART/Sample-Test-Files/main/IFC%204.0.2.1%20(IFC%204)/PCERT-Sample-Scene/Building-Architecture.ifc"
   },
   {
     "name": "Building HVAC",
-    "url": "https://raw.githubusercontent.com/buildingSMART/Sample-Test-Files/main/IFC%204.3.2.0%20(IFC4X3_ADD2)/PCERT-Sample-Scene/Building-Hvac.ifc"
+    "url": "https://raw.githubusercontent.com/buildingSMART/Sample-Test-Files/main/IFC%204.0.2.1%20(IFC%204)/PCERT-Sample-Scene/Building-Hvac.ifc"
   },
   {
     "name": "Building Landscaping",
-    "url": "https://raw.githubusercontent.com/buildingSMART/Sample-Test-Files/main/IFC%204.3.2.0%20(IFC4X3_ADD2)/PCERT-Sample-Scene/Building-Landscaping.ifc"
+    "url": "https://raw.githubusercontent.com/buildingSMART/Sample-Test-Files/main/IFC%204.0.2.1%20(IFC%204)/PCERT-Sample-Scene/Building-Landscaping.ifc"
   },
   {
     "name": "Building Structural",
-    "url": "https://raw.githubusercontent.com/buildingSMART/Sample-Test-Files/main/IFC%204.3.2.0%20(IFC4X3_ADD2)/PCERT-Sample-Scene/Building-Structural.ifc"
+    "url": "https://raw.githubusercontent.com/buildingSMART/Sample-Test-Files/main/IFC%204.0.2.1%20(IFC%204)/PCERT-Sample-Scene/Building-Structural.ifc"
   },
   {
     "name": "Infra Bridge",
-    "url": "https://raw.githubusercontent.com/buildingSMART/Sample-Test-Files/main/IFC%204.3.2.0%20(IFC4X3_ADD2)/PCERT-Sample-Scene/Infra-Bridge.ifc"
+    "url": "https://raw.githubusercontent.com/buildingSMART/Sample-Test-Files/main/IFC%204.0.2.1%20(IFC%204)/PCERT-Sample-Scene/Infra-Bridge.ifc"
   }
 ]


### PR DESCRIPTION
## Summary
- allow configuring model URLs in settings
- auto-load configured URLs on startup
- add dropdown for loading saved or demo models
- include sample scenes from buildingSMART

## Testing
- `npm run lint` *(fails: `next` not found)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced automatic loading of previously saved IFC models on startup.
  - Added a dropdown menu for model upload, allowing users to upload new files, select from saved models, or choose from a list of demo models.
  - Enhanced settings panel to manage a list of model URLs, including adding, removing, and bulk-adding demo models.
  - Added a selection of demo models sourced from a new demo models list.

- **User Interface**
  - Replaced the single upload button with a dropdown menu for easier model selection and upload.
  - Updated prompts and UI elements to reflect new model selection options.
  - Added tooltips in the settings panel for better user guidance on model URL management and other settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->