### PR TITLE
Add Excel rule import

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ IFC Classifier helps you classify IFC elements without needing expert knowledge 
   - Based on properties like: `IsExternal`, `LoadBearing`, etc.
   - Example: "Put all external, non-load bearing walls (except basement) into category C02.01"
   - See rule results live on your model
+  - Import rules from JSON or Excel for easy setup
 
 - **✍️ Export Your Work:**
 
@@ -69,6 +70,10 @@ IFC Classifier helps you classify IFC elements without needing expert knowledge 
 - Added functionality to import and export classifications as JSON files.
 - Added favicons for better cross-browser compatibility.
 - Enhanced property extraction and rendering from IFC models.
+
+**May 21, 2025:**
+
+- Added ability to import rule definitions from Excel (.xlsx) files.
 
 **May 19, 2025:**
 

--- a/components/rule-panel.tsx
+++ b/components/rule-panel.tsx
@@ -82,12 +82,14 @@ export function RulePanel() {
     availableProperties,
     exportRulesAsJson,
     importRulesFromJson,
+    importRulesFromExcel,
     removeAllRules,
   } = useIFCContext();
   const [isRuleDialogOpen, setIsRuleDialogOpen] = useState(false);
   const [currentRule, setCurrentRule] = useState<Rule | null>(null);
   const [editingRule, setEditingRule] = useState<Partial<Rule> | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const excelInputRef = useRef<HTMLInputElement>(null);
   const [isConfirmRemoveAllOpen, setIsConfirmRemoveAllOpen] = useState(false);
 
   const [isConfirmRemoveRuleOpen, setIsConfirmRemoveRuleOpen] = useState(false);
@@ -130,6 +132,7 @@ export function RulePanel() {
   };
 
   const triggerImport = () => fileInputRef.current?.click();
+  const triggerExcelImport = () => excelInputRef.current?.click();
 
   const handleImportJson = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
@@ -142,6 +145,13 @@ export function RulePanel() {
       }
     };
     reader.readAsText(file);
+    e.target.value = "";
+  };
+
+  const handleImportExcel = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    importRulesFromExcel(file);
     e.target.value = "";
   };
 
@@ -232,7 +242,15 @@ export function RulePanel() {
                   triggerImport();
                 }}
               >
-                <ArchiveRestore className="mr-2 h-4 w-4" /> Load Rules
+                <ArchiveRestore className="mr-2 h-4 w-4" /> Load Rules (JSON)
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                onSelect={(e) => {
+                  e.preventDefault();
+                  triggerExcelImport();
+                }}
+              >
+                <ArchiveRestore className="mr-2 h-4 w-4" /> Load from Excel
               </DropdownMenuItem>
               <DropdownMenuSeparator />
               <DropdownMenuItem
@@ -660,6 +678,13 @@ export function RulePanel() {
         accept="application/json"
         ref={fileInputRef}
         onChange={handleImportJson}
+        className="hidden"
+      />
+      <input
+        type="file"
+        accept=".xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+        ref={excelInputRef}
+        onChange={handleImportExcel}
         className="hidden"
       />
     </div>

--- a/context/ifc-context.tsx
+++ b/context/ifc-context.tsx
@@ -11,6 +11,7 @@ import React, {
 } from "react";
 import type { IfcAPI } from "web-ifc"; // Import IfcAPI type
 import { Properties } from "web-ifc"; // Ensure Properties is imported
+import { parseRulesFromExcel } from "@/services/rule-import-service";
 
 // Define types for Rules
 export interface RuleCondition {
@@ -132,6 +133,7 @@ interface IFCContextType {
   importClassificationsFromJson: (json: string) => void;
   exportRulesAsJson: () => string;
   importRulesFromJson: (json: string) => void;
+  importRulesFromExcel: (file: File) => Promise<void>;
   removeAllRules: () => void;
 
   assignClassificationToElement: (
@@ -1458,6 +1460,18 @@ export function IFCContextProvider({ children }: { children: ReactNode }) {
     [setRules]
   );
 
+  const importRulesFromExcel = useCallback(
+    async (file: File) => {
+      try {
+        const parsed = await parseRulesFromExcel(file);
+        setRules(parsed);
+      } catch (e) {
+        console.error("Failed to import rules from Excel", e);
+      }
+    },
+    [setRules]
+  );
+
   const removeAllRules = useCallback(() => {
     setRules([]);
   }, [setRules]);
@@ -1618,6 +1632,7 @@ export function IFCContextProvider({ children }: { children: ReactNode }) {
         importClassificationsFromJson,
         exportRulesAsJson,
         importRulesFromJson,
+        importRulesFromExcel,
         removeAllRules,
         toggleUserHideElement,
         hideElements,

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,8 @@
         "tailwind-merge": "^2.2.0",
         "tailwindcss-animate": "^1.0.7",
         "three": "^0.160.0",
-        "web-ifc": "^0.0.46"
+        "web-ifc": "^0.0.46",
+        "xlsx": "^0.18.5"
       },
       "devDependencies": {
         "@types/node": "^20",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "tailwind-merge": "^2.2.0",
     "tailwindcss-animate": "^1.0.7",
     "three": "^0.160.0",
-    "web-ifc": "^0.0.46"
+    "web-ifc": "^0.0.46",
+    "xlsx": "^0.18.5"
   },
   "devDependencies": {
     "@types/node": "^20",

--- a/services/rule-import-service.ts
+++ b/services/rule-import-service.ts
@@ -1,0 +1,62 @@
+import * as XLSX from "xlsx";
+import { Rule, RuleCondition } from "@/context/ifc-context";
+
+/**
+ * Parse an Excel file into Rule objects.
+ *
+ * Expected format (header row in first sheet):
+ * id | name | description | classificationCode | active | property1 | operator1 | value1 | property2 | operator2 | value2 | ...
+ *
+ * Each rule can contain multiple conditions. Additional sets of
+ * property/operator/value columns will be read until no more columns exist.
+ */
+export async function parseRulesFromExcel(file: File): Promise<Rule[]> {
+  const buffer = await file.arrayBuffer();
+  const workbook = XLSX.read(buffer, { type: "array" });
+  const sheet = workbook.Sheets[workbook.SheetNames[0]];
+  const rows: any[][] = XLSX.utils.sheet_to_json(sheet, { header: 1 });
+  if (rows.length < 2) return [];
+
+  const header: string[] = rows[0].map((h) => String(h).trim());
+  const idx = (name: string) => header.indexOf(name);
+
+  const rules: Rule[] = [];
+  for (let i = 1; i < rows.length; i++) {
+    const row = rows[i];
+    if (!row || row.length === 0) continue;
+
+    const id = String(row[idx("id")] ?? `rule-${Date.now()}-${i}`);
+    const name = String(row[idx("name")] ?? "");
+    if (!name) continue; // skip empty rows
+    const description = String(row[idx("description")] ?? "");
+    const classificationCode = String(row[idx("classificationCode")] ?? "");
+    const activeRaw = row[idx("active")];
+    const active = String(activeRaw).toLowerCase() !== "false" && activeRaw !== 0;
+
+    const start = idx("active") + 1;
+    const conditions: RuleCondition[] = [];
+    for (let col = start; col < header.length; col += 3) {
+      const property = row[col];
+      const operator = row[col + 1];
+      const value = row[col + 2];
+      if (property !== undefined && property !== "") {
+        conditions.push({
+          property: String(property),
+          operator: String(operator ?? ""),
+          value: value ?? "",
+        });
+      }
+    }
+
+    rules.push({
+      id,
+      name,
+      description,
+      classificationCode,
+      active,
+      conditions,
+    });
+  }
+
+  return rules;
+}


### PR DESCRIPTION
## Summary
- add xlsx dependency
- support importing rule definitions from Excel
- expose new import API via context
- extend rule panel UI for Excel uploads
- document Excel rule imports in README

## Testing
- `npm run lint` *(fails: next not found)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for importing rule definitions from Excel (.xlsx) files, making it easier to set up rules alongside existing JSON import options.
- **Documentation**
  - Updated the README to reflect the new Excel import capability and documented the recent update.
- **Chores**
  - Added the xlsx library as a new dependency to enable Excel file parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->