### PR TITLE
Add default eBKP‑H rule set

### DIFF
--- a/public/data/ebkph_rules.json
+++ b/public/data/ebkph_rules.json
@@ -1,0 +1,54 @@
+[
+  {
+    "id": "rule-external-wall",
+    "name": "External Walls",
+    "description": "Classify external walls",
+    "classificationCode": "C02.01",
+    "active": true,
+    "conditions": [
+      { "property": "Ifc Class", "operator": "equals", "value": "IFCWALL" },
+      { "property": "Pset_WallCommon.IsExternal", "operator": "equals", "value": "true" }
+    ]
+  },
+  {
+    "id": "rule-internal-wall",
+    "name": "Internal Walls",
+    "description": "Classify internal walls",
+    "classificationCode": "C02.02",
+    "active": true,
+    "conditions": [
+      { "property": "Ifc Class", "operator": "equals", "value": "IFCWALL" },
+      { "property": "Pset_WallCommon.IsExternal", "operator": "notEquals", "value": "true" }
+    ]
+  },
+  {
+    "id": "rule-windows",
+    "name": "Windows",
+    "description": "Classify windows",
+    "classificationCode": "E03.01",
+    "active": true,
+    "conditions": [
+      { "property": "Ifc Class", "operator": "equals", "value": "IFCWINDOW" }
+    ]
+  },
+  {
+    "id": "rule-doors",
+    "name": "Doors",
+    "description": "Classify doors",
+    "classificationCode": "E03.02",
+    "active": true,
+    "conditions": [
+      { "property": "Ifc Class", "operator": "equals", "value": "IFCDOOR" }
+    ]
+  },
+  {
+    "id": "rule-roofs",
+    "name": "Roofs",
+    "description": "Classify roof elements",
+    "classificationCode": "F01.03",
+    "active": true,
+    "conditions": [
+      { "property": "Ifc Class", "operator": "equals", "value": "IFCROOF" }
+    ]
+  }
+]


### PR DESCRIPTION
## Summary
- add default classification rules for eBKP‑H
- allow rule panel to load the default eBKP‑H rules

## Testing
- `npm run lint` *(fails: next not found)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to load and manage a default set of eBKP-H classification rules directly within the rule management panel.
  - Introduced a new dropdown section for loading default rules, with clear loading indicators and error handling.

- **Chores**
  - Added a new dataset of eBKP-H rules for building element classification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->