### PR TITLE
Add Excel export for rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ IFC Classifier helps you classify IFC elements without needing expert knowledge 
   - Example: "Put all external, non-load bearing walls (except basement) into category C02.01"
   - See rule results live on your model
   - Import rules from JSON or Excel for easy setup
+  - Export rules to JSON or Excel for sharing
 
 - **✍️ Export Your Work:**
 
@@ -74,6 +75,7 @@ IFC Classifier helps you classify IFC elements without needing expert knowledge 
 **May 21, 2025:**
 
 - Added ability to import rule definitions from Excel (.xlsx) files.
+- Added ability to export rules to Excel for easier sharing.
 
 **May 19, 2025:**
 

--- a/components/rule-panel.tsx
+++ b/components/rule-panel.tsx
@@ -48,6 +48,7 @@ import {
   Tag,
   MoreHorizontal,
   FileOutput,
+  FileSpreadsheet,
   ArchiveRestore,
   AlertTriangle,
   CopyPlus,
@@ -81,6 +82,7 @@ export function RulePanel() {
     previewingRuleId,
     availableProperties,
     exportRulesAsJson,
+    exportRulesAsExcel,
     importRulesFromJson,
     importRulesFromExcel,
     removeAllRules,
@@ -158,6 +160,11 @@ export function RulePanel() {
   const handleExportJson = () => {
     const json = exportRulesAsJson();
     downloadFile(json, "rules.json", "application/json");
+  };
+
+  const handleExportExcel = () => {
+    const wbBinary = exportRulesAsExcel();
+    downloadFile(wbBinary, "rules.xlsx", "application/octet-stream");
   };
 
   const triggerImport = () => fileInputRef.current?.click();
@@ -319,6 +326,9 @@ export function RulePanel() {
               </DropdownMenuLabel>
               <DropdownMenuItem onClick={handleExportJson}>
                 <FileOutput className="mr-2 h-4 w-4" /> Export Rules
+              </DropdownMenuItem>
+              <DropdownMenuItem onClick={handleExportExcel}>
+                <FileSpreadsheet className="mr-2 h-4 w-4" /> Export to Excel
               </DropdownMenuItem>
               <DropdownMenuItem
                 onSelect={(e) => {

--- a/context/ifc-context.tsx
+++ b/context/ifc-context.tsx
@@ -12,6 +12,7 @@ import React, {
 import type { IfcAPI } from "web-ifc"; // Import IfcAPI type
 import { Properties } from "web-ifc"; // Ensure Properties is imported
 import { parseRulesFromExcel } from "@/services/rule-import-service";
+import { exportRulesToExcel } from "@/services/rule-export-service";
 
 // Define types for Rules
 export interface RuleCondition {
@@ -132,6 +133,7 @@ interface IFCContextType {
   exportClassificationsAsJson: () => string;
   importClassificationsFromJson: (json: string) => void;
   exportRulesAsJson: () => string;
+  exportRulesAsExcel: () => string;
   importRulesFromJson: (json: string) => void;
   importRulesFromExcel: (file: File) => Promise<void>;
   removeAllRules: () => void;
@@ -1444,6 +1446,10 @@ export function IFCContextProvider({ children }: { children: ReactNode }) {
     return JSON.stringify(rules, null, 2);
   }, [rules]);
 
+  const exportRulesAsExcel = useCallback((): string => {
+    return exportRulesToExcel(rules);
+  }, [rules]);
+
   const importRulesFromJson = useCallback(
     (json: string) => {
       try {
@@ -1631,6 +1637,7 @@ export function IFCContextProvider({ children }: { children: ReactNode }) {
         exportClassificationsAsJson,
         importClassificationsFromJson,
         exportRulesAsJson,
+        exportRulesAsExcel,
         importRulesFromJson,
         importRulesFromExcel,
         removeAllRules,

--- a/services/rule-export-service.ts
+++ b/services/rule-export-service.ts
@@ -1,0 +1,58 @@
+import * as XLSX from "xlsx";
+import { Rule } from "@/context/ifc-context";
+
+/**
+ * Convert an array of rules to an Excel workbook and return
+ * the workbook binary string. The format matches what
+ * `parseRulesFromExcel` expects during import.
+ */
+export function exportRulesToExcel(rules: Rule[]): string {
+  const maxConditions = rules.reduce(
+    (max, r) => Math.max(max, r.conditions.length),
+    0
+  );
+
+  const header = [
+    "id",
+    "name",
+    "description",
+    "classificationCode",
+    "active",
+  ];
+  for (let i = 1; i <= maxConditions; i++) {
+    header.push(`property${i}`);
+    header.push(`operator${i}`);
+    header.push(`value${i}`);
+  }
+
+  const rows: any[][] = [header];
+
+  for (const rule of rules) {
+    const row: any[] = [
+      rule.id,
+      rule.name,
+      rule.description,
+      rule.classificationCode,
+      rule.active ? 1 : 0,
+    ];
+
+    rule.conditions.forEach((c) => {
+      row.push(c.property);
+      row.push(c.operator);
+      row.push(c.value);
+    });
+
+    // ensure row has same length as header
+    while (row.length < header.length) {
+      row.push("");
+    }
+
+    rows.push(row);
+  }
+
+  const worksheet = XLSX.utils.aoa_to_sheet(rows);
+  const workbook = XLSX.utils.book_new();
+  XLSX.utils.book_append_sheet(workbook, worksheet, "Rules");
+
+  return XLSX.write(workbook, { type: "binary", bookType: "xlsx" });
+}


### PR DESCRIPTION
## Summary
- allow downloading rules as Excel
- wire export option into context and UI
- document Excel export in README

## Testing
- `npm run lint` *(fails: next not found)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to export classification rules to Excel files for easier sharing and backup.
  - Updated the user interface to include an "Export to Excel" option in the export menu.

- **Documentation**
  - Updated the README to reflect the new rule export to Excel feature and recent updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->