### PR TITLE
Add Excel export for rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ IFC Classifier helps you classify IFC elements without needing expert knowledge 
   - Example: "Put all external, non-load bearing walls (except basement) into category C02.01"
   - See rule results live on your model
   - Import rules from JSON or Excel for easy setup
+  - Export rules to JSON or Excel for sharing
 
 - **✍️ Export Your Work:**
 
@@ -74,6 +75,7 @@ IFC Classifier helps you classify IFC elements without needing expert knowledge 
 **May 21, 2025:**
 
 - Added ability to import rule definitions from Excel (.xlsx) files.
+- Added ability to export rules to Excel for easier sharing.
 
 **May 19, 2025:**
 

--- a/components/rule-panel.tsx
+++ b/components/rule-panel.tsx
@@ -48,6 +48,7 @@ import {
   Tag,
   MoreHorizontal,
   FileOutput,
+  FileSpreadsheet,
   ArchiveRestore,
   AlertTriangle,
   CopyPlus,
@@ -81,6 +82,7 @@ export function RulePanel() {
     previewingRuleId,
     availableProperties,
     exportRulesAsJson,
+    exportRulesAsExcel,
     importRulesFromJson,
     importRulesFromExcel,
     removeAllRules,
@@ -158,6 +160,15 @@ export function RulePanel() {
   const handleExportJson = () => {
     const json = exportRulesAsJson();
     downloadFile(json, "rules.json", "application/json");
+  };
+
+  const handleExportExcel = () => {
+    const wbData = exportRulesAsExcel();
+    downloadFile(
+      wbData,
+      "rules.xlsx",
+      "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+    );
   };
 
   const triggerImport = () => fileInputRef.current?.click();
@@ -319,6 +330,9 @@ export function RulePanel() {
               </DropdownMenuLabel>
               <DropdownMenuItem onClick={handleExportJson}>
                 <FileOutput className="mr-2 h-4 w-4" /> Export Rules
+              </DropdownMenuItem>
+              <DropdownMenuItem onClick={handleExportExcel}>
+                <FileSpreadsheet className="mr-2 h-4 w-4" /> Export to Excel
               </DropdownMenuItem>
               <DropdownMenuItem
                 onSelect={(e) => {

--- a/context/ifc-context.tsx
+++ b/context/ifc-context.tsx
@@ -12,6 +12,7 @@ import React, {
 import type { IfcAPI } from "web-ifc"; // Import IfcAPI type
 import { Properties } from "web-ifc"; // Ensure Properties is imported
 import { parseRulesFromExcel } from "@/services/rule-import-service";
+import { exportRulesToExcel } from "@/services/rule-export-service";
 
 // Define types for Rules
 export interface RuleCondition {
@@ -132,6 +133,7 @@ interface IFCContextType {
   exportClassificationsAsJson: () => string;
   importClassificationsFromJson: (json: string) => void;
   exportRulesAsJson: () => string;
+  exportRulesAsExcel: () => ArrayBuffer;
   importRulesFromJson: (json: string) => void;
   importRulesFromExcel: (file: File) => Promise<void>;
   removeAllRules: () => void;
@@ -1444,6 +1446,10 @@ export function IFCContextProvider({ children }: { children: ReactNode }) {
     return JSON.stringify(rules, null, 2);
   }, [rules]);
 
+  const exportRulesAsExcel = useCallback((): ArrayBuffer => {
+    return exportRulesToExcel(rules);
+  }, [rules]);
+
   const importRulesFromJson = useCallback(
     (json: string) => {
       try {
@@ -1631,6 +1637,7 @@ export function IFCContextProvider({ children }: { children: ReactNode }) {
         exportClassificationsAsJson,
         importClassificationsFromJson,
         exportRulesAsJson,
+        exportRulesAsExcel,
         importRulesFromJson,
         importRulesFromExcel,
         removeAllRules,

--- a/services/ifc-export-service.ts
+++ b/services/ifc-export-service.ts
@@ -287,7 +287,7 @@ export async function exportIfcWithClassificationsService(
 }
 
 // --- Helper function for downloading ---
-export function downloadFile(content: string, fileName: string, contentType: string) {
+export function downloadFile(content: BlobPart, fileName: string, contentType: string) {
     const a = document.createElement("a");
     const file = new Blob([content], { type: contentType });
     a.href = URL.createObjectURL(file);
@@ -296,4 +296,4 @@ export function downloadFile(content: string, fileName: string, contentType: str
     a.click();
     URL.revokeObjectURL(a.href);
     document.body.removeChild(a);
-} 
+}

--- a/services/rule-export-service.ts
+++ b/services/rule-export-service.ts
@@ -1,0 +1,58 @@
+import * as XLSX from "xlsx";
+import { Rule } from "@/context/ifc-context";
+
+/**
+ * Convert an array of rules to an Excel workbook and return
+ * the workbook binary string. The format matches what
+ * `parseRulesFromExcel` expects during import.
+ */
+export function exportRulesToExcel(rules: Rule[]): ArrayBuffer {
+  const maxConditions = rules.reduce(
+    (max, r) => Math.max(max, r.conditions.length),
+    0
+  );
+
+  const header = [
+    "id",
+    "name",
+    "description",
+    "classificationCode",
+    "active",
+  ];
+  for (let i = 1; i <= maxConditions; i++) {
+    header.push(`property${i}`);
+    header.push(`operator${i}`);
+    header.push(`value${i}`);
+  }
+
+  const rows: any[][] = [header];
+
+  for (const rule of rules) {
+    const row: any[] = [
+      rule.id,
+      rule.name,
+      rule.description,
+      rule.classificationCode,
+      rule.active ? 1 : 0,
+    ];
+
+    rule.conditions.forEach((c) => {
+      row.push(c.property);
+      row.push(c.operator);
+      row.push(c.value);
+    });
+
+    // ensure row has same length as header
+    while (row.length < header.length) {
+      row.push("");
+    }
+
+    rows.push(row);
+  }
+
+  const worksheet = XLSX.utils.aoa_to_sheet(rows);
+  const workbook = XLSX.utils.book_new();
+  XLSX.utils.book_append_sheet(workbook, worksheet, "Rules");
+
+  return XLSX.write(workbook, { type: "array", bookType: "xlsx" });
+}

--- a/services/rule-export-service.ts
+++ b/services/rule-export-service.ts
@@ -7,52 +7,57 @@ import { Rule } from "@/context/ifc-context";
  * `parseRulesFromExcel` expects during import.
  */
 export function exportRulesToExcel(rules: Rule[]): ArrayBuffer {
-  const maxConditions = rules.reduce(
-    (max, r) => Math.max(max, r.conditions.length),
-    0
-  );
+  try {
+    const maxConditions = rules.reduce(
+      (max, r) => Math.max(max, r.conditions.length),
+      0
+    );
 
-  const header = [
-    "id",
-    "name",
-    "description",
-    "classificationCode",
-    "active",
-  ];
-  for (let i = 1; i <= maxConditions; i++) {
-    header.push(`property${i}`);
-    header.push(`operator${i}`);
-    header.push(`value${i}`);
-  }
-
-  const rows: any[][] = [header];
-
-  for (const rule of rules) {
-    const row: any[] = [
-      rule.id,
-      rule.name,
-      rule.description,
-      rule.classificationCode,
-      rule.active ? 1 : 0,
+    const header = [
+      "id",
+      "name",
+      "description",
+      "classificationCode",
+      "active",
     ];
-
-    rule.conditions.forEach((c) => {
-      row.push(c.property);
-      row.push(c.operator);
-      row.push(c.value);
-    });
-
-    // ensure row has same length as header
-    while (row.length < header.length) {
-      row.push("");
+    for (let i = 1; i <= maxConditions; i++) {
+      header.push(`property${i}`);
+      header.push(`operator${i}`);
+      header.push(`value${i}`);
     }
 
-    rows.push(row);
+    const rows: any[][] = [header];
+
+    for (const rule of rules) {
+      const row: any[] = [
+        rule.id,
+        rule.name,
+        rule.description,
+        rule.classificationCode,
+        rule.active ? 1 : 0,
+      ];
+
+      rule.conditions.forEach((c) => {
+        row.push(c.property);
+        row.push(c.operator);
+        row.push(c.value);
+      });
+
+      // ensure row has same length as header
+      while (row.length < header.length) {
+        row.push("");
+      }
+
+      rows.push(row);
+    }
+
+    const worksheet = XLSX.utils.aoa_to_sheet(rows);
+    const workbook = XLSX.utils.book_new();
+    XLSX.utils.book_append_sheet(workbook, worksheet, "Rules");
+
+    return XLSX.write(workbook, { type: "array", bookType: "xlsx" });
+  } catch (error) {
+    console.error("Error exporting rules to Excel:", error);
+    throw new Error("Failed to export rules to Excel. See console for details.");
   }
-
-  const worksheet = XLSX.utils.aoa_to_sheet(rows);
-  const workbook = XLSX.utils.book_new();
-  XLSX.utils.book_append_sheet(workbook, worksheet, "Rules");
-
-  return XLSX.write(workbook, { type: "array", bookType: "xlsx" });
 }


### PR DESCRIPTION
## Summary
- allow downloading rules as Excel
- wire export option into context and UI
- document Excel export in README
- fix Excel export to generate a valid workbook

## Testing
- `npm run lint` *(fails: next not found)*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to export classification rules as an Excel (.xlsx) file, in addition to the existing JSON export option. This feature is accessible from the rule export menu.

- **Documentation**
  - Updated the README to mention the new Excel export capability and reflected this change in the recent updates section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->