### PR TITLE
Add Excel support for classifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ IFC Classifier helps you classify IFC elements without needing expert knowledge 
     - 🇬🇧 Uniclass
   - Or create your own custom system
   - Assign colors to visualize different classifications
+  - Import classifications from JSON or Excel
+  - Export classifications to JSON or Excel
 
 - **⚙️ Rule-Based Sorting:**
 
@@ -68,7 +70,7 @@ IFC Classifier helps you classify IFC elements without needing expert knowledge 
 - Major refactor of classification and IFC model components for better performance and readability.
 - Fixed an issue to preserve model coordinates when loading new IFC files.
 - Improved layout and introduced a rule management menu for easier access.
-- Added functionality to import and export classifications as JSON files.
+- Added functionality to import and export classifications as JSON or Excel files.
 - Added favicons for better cross-browser compatibility.
 - Enhanced property extraction and rendering from IFC models.
 

--- a/components/classification-panel.tsx
+++ b/components/classification-panel.tsx
@@ -60,6 +60,7 @@ import {
   FileInput,
   ArchiveRestore,
   Star,
+  FileSpreadsheet,
 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import {
@@ -120,7 +121,9 @@ export function ClassificationPanel() {
     unassignElementFromAllClassifications,
     removeAllClassifications,
     exportClassificationsAsJson,
+    exportClassificationsAsExcel,
     importClassificationsFromJson,
+    importClassificationsFromExcel,
   } = useIFCContext();
   const [isAddDialogOpen, setIsAddDialogOpen] = useState(false);
   const [newClassification, setNewClassification] = useState({
@@ -187,13 +190,24 @@ export function ClassificationPanel() {
   }, [loadedModels]);
 
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const excelInputRef = useRef<HTMLInputElement>(null);
 
   const handleExportJson = () => {
     const json = exportClassificationsAsJson();
     downloadFile(json, "classifications.json", "application/json");
   };
 
+  const handleExportExcel = () => {
+    const wbData = exportClassificationsAsExcel();
+    downloadFile(
+      wbData,
+      "classifications.xlsx",
+      "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+    );
+  };
+
   const triggerImport = () => fileInputRef.current?.click();
+  const triggerExcelImport = () => excelInputRef.current?.click();
 
   const handleImportJson = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
@@ -206,6 +220,13 @@ export function ClassificationPanel() {
       }
     };
     reader.readAsText(file);
+    e.target.value = "";
+  };
+
+  const handleImportExcel = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    importClassificationsFromExcel(file);
     e.target.value = "";
   };
 
@@ -891,7 +912,11 @@ export function ClassificationPanel() {
                 </DropdownMenuLabel>
                 <DropdownMenuItem onClick={handleExportJson}>
                   <FileOutput className="mr-2 h-4 w-4" />
-                  Export Classifications
+                  Export Classifications (JSON)
+                </DropdownMenuItem>
+                <DropdownMenuItem onClick={handleExportExcel}>
+                  <FileSpreadsheet className="mr-2 h-4 w-4" />
+                  Export to Excel
                 </DropdownMenuItem>
                 <DropdownMenuItem
                   onSelect={(e) => {
@@ -900,7 +925,16 @@ export function ClassificationPanel() {
                   }}
                 >
                   <ArchiveRestore className="mr-2 h-4 w-4" />
-                  Load Classifications
+                  Load Classifications (JSON)
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  onSelect={(e) => {
+                    e.preventDefault();
+                    triggerExcelImport();
+                  }}
+                >
+                  <ArchiveRestore className="mr-2 h-4 w-4" />
+                  Load from Excel
                 </DropdownMenuItem>
                 <DropdownMenuSeparator />
                 <DropdownMenuItem
@@ -1387,6 +1421,13 @@ export function ClassificationPanel() {
         accept="application/json"
         ref={fileInputRef}
         onChange={handleImportJson}
+        className="hidden"
+      />
+      <input
+        type="file"
+        accept=".xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+        ref={excelInputRef}
+        onChange={handleImportExcel}
         className="hidden"
       />
     </div>

--- a/services/classification-export-service.ts
+++ b/services/classification-export-service.ts
@@ -1,0 +1,39 @@
+import * as XLSX from "xlsx";
+import { ClassificationItem, SelectedElementInfo } from "@/context/ifc-context";
+
+/**
+ * Convert an array of classifications to an Excel workbook.
+ * Elements are serialized as "modelID:expressID" pairs separated by semicolons.
+ */
+export function exportClassificationsToExcel(
+  classifications: ClassificationItem[]
+): ArrayBuffer {
+  try {
+    const header = ["code", "name", "color", "elements"];
+    const rows: any[][] = [header];
+
+    for (const classification of classifications) {
+      const elements: SelectedElementInfo[] = classification.elements || [];
+      const elementStr = elements
+        .map((el) => `${el.modelID}:${el.expressID}`)
+        .join(";");
+      rows.push([
+        classification.code,
+        classification.name,
+        classification.color,
+        elementStr,
+      ]);
+    }
+
+    const worksheet = XLSX.utils.aoa_to_sheet(rows);
+    const workbook = XLSX.utils.book_new();
+    XLSX.utils.book_append_sheet(workbook, worksheet, "Classifications");
+
+    return XLSX.write(workbook, { type: "array", bookType: "xlsx" });
+  } catch (error) {
+    console.error("Error exporting classifications to Excel:", error);
+    throw new Error(
+      "Failed to export classifications to Excel. See console for details."
+    );
+  }
+}

--- a/services/classification-import-service.ts
+++ b/services/classification-import-service.ts
@@ -1,0 +1,45 @@
+import * as XLSX from "xlsx";
+import { ClassificationItem, SelectedElementInfo } from "@/context/ifc-context";
+
+/**
+ * Parse an Excel file into ClassificationItem objects.
+ * Expected columns: code, name, color, elements
+ * Elements should be encoded as "modelID:expressID" pairs separated by semicolons.
+ */
+export async function parseClassificationsFromExcel(
+  file: File
+): Promise<ClassificationItem[]> {
+  const buffer = await file.arrayBuffer();
+  const workbook = XLSX.read(buffer, { type: "array" });
+  const sheet = workbook.Sheets[workbook.SheetNames[0]];
+  const rows: any[][] = XLSX.utils.sheet_to_json(sheet, { header: 1 });
+  if (rows.length < 2) return [];
+
+  const header: string[] = rows[0].map((h) => String(h).trim().toLowerCase());
+  const idx = (name: string) => header.indexOf(name.toLowerCase());
+
+  const classifications: ClassificationItem[] = [];
+  for (let i = 1; i < rows.length; i++) {
+    const row = rows[i];
+    if (!row || row.length === 0) continue;
+
+    const code = String(row[idx("code")] ?? "").trim();
+    if (!code) continue;
+    const name = String(row[idx("name")] ?? "");
+    const color = String(row[idx("color")] ?? "");
+    const elementStr = String(row[idx("elements")] ?? "");
+    const elements: SelectedElementInfo[] = elementStr
+      ? elementStr.split(";").map((pair) => {
+          const [model, id] = pair.split(":");
+          return {
+            modelID: parseInt(model, 10),
+            expressID: parseInt(id, 10),
+          } as SelectedElementInfo;
+        })
+      : [];
+
+    classifications.push({ code, name, color, elements });
+  }
+
+  return classifications;
+}


### PR DESCRIPTION
## Summary
- allow importing/exporting classifications through Excel files
- implement Excel parse/export utilities
- wire new functionality into context provider and menu
- document Excel options in README

## Testing
- `npx tsc -p tsconfig.json` *(fails: Cannot find module 'react' or its corresponding type declarations)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for importing and exporting classifications in Excel (.xlsx) format in addition to JSON.
  - Updated the user interface to allow selection between JSON and Excel formats for import/export actions.

- **Documentation**
  - Updated the README to reflect new capabilities for importing and exporting classifications as both JSON and Excel files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->