### PR TITLE
Add Excel import/export for classifications

### DIFF
--- a/components/classification-panel.tsx
+++ b/components/classification-panel.tsx
@@ -40,6 +40,9 @@ import {
   DropdownMenuLabel,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
 } from "@/components/ui/dropdown-menu";
 import {
   Plus,
@@ -58,6 +61,7 @@ import {
   Upload,
   FileOutput,
   FileInput,
+  FileSpreadsheet,
   ArchiveRestore,
   Star,
 } from "lucide-react";
@@ -120,7 +124,9 @@ export function ClassificationPanel() {
     unassignElementFromAllClassifications,
     removeAllClassifications,
     exportClassificationsAsJson,
+    exportClassificationsAsExcel,
     importClassificationsFromJson,
+    importClassificationsFromExcel,
   } = useIFCContext();
   const [isAddDialogOpen, setIsAddDialogOpen] = useState(false);
   const [newClassification, setNewClassification] = useState({
@@ -187,13 +193,24 @@ export function ClassificationPanel() {
   }, [loadedModels]);
 
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const excelInputRef = useRef<HTMLInputElement>(null);
 
   const handleExportJson = () => {
     const json = exportClassificationsAsJson();
     downloadFile(json, "classifications.json", "application/json");
   };
 
+  const handleExportExcel = () => {
+    const wbData = exportClassificationsAsExcel();
+    downloadFile(
+      wbData,
+      "classifications.xlsx",
+      "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+    );
+  };
+
   const triggerImport = () => fileInputRef.current?.click();
+  const triggerExcelImport = () => excelInputRef.current?.click();
 
   const handleImportJson = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
@@ -206,6 +223,13 @@ export function ClassificationPanel() {
       }
     };
     reader.readAsText(file);
+    e.target.value = "";
+  };
+
+  const handleImportExcel = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    importClassificationsFromExcel(file);
     e.target.value = "";
   };
 
@@ -889,19 +913,42 @@ export function ClassificationPanel() {
                 <DropdownMenuLabel className="text-xs font-semibold text-muted-foreground px-2 py-1.5">
                   Manage Data
                 </DropdownMenuLabel>
-                <DropdownMenuItem onClick={handleExportJson}>
-                  <FileOutput className="mr-2 h-4 w-4" />
-                  Export Classifications
-                </DropdownMenuItem>
-                <DropdownMenuItem
-                  onSelect={(e) => {
-                    e.preventDefault();
-                    triggerImport();
-                  }}
-                >
-                  <ArchiveRestore className="mr-2 h-4 w-4" />
-                  Load Classifications
-                </DropdownMenuItem>
+                <DropdownMenuSub>
+                  <DropdownMenuSubTrigger>
+                    <FileOutput className="mr-2 h-4 w-4" /> Export
+                  </DropdownMenuSubTrigger>
+                  <DropdownMenuSubContent>
+                    <DropdownMenuItem onClick={handleExportJson}>
+                      JSON
+                    </DropdownMenuItem>
+                    <DropdownMenuItem onClick={handleExportExcel}>
+                      Excel
+                    </DropdownMenuItem>
+                  </DropdownMenuSubContent>
+                </DropdownMenuSub>
+                <DropdownMenuSub>
+                  <DropdownMenuSubTrigger>
+                    <ArchiveRestore className="mr-2 h-4 w-4" /> Load
+                  </DropdownMenuSubTrigger>
+                  <DropdownMenuSubContent>
+                    <DropdownMenuItem
+                      onSelect={(e) => {
+                        e.preventDefault();
+                        triggerImport();
+                      }}
+                    >
+                      JSON
+                    </DropdownMenuItem>
+                    <DropdownMenuItem
+                      onSelect={(e) => {
+                        e.preventDefault();
+                        triggerExcelImport();
+                      }}
+                    >
+                      Excel
+                    </DropdownMenuItem>
+                  </DropdownMenuSubContent>
+                </DropdownMenuSub>
                 <DropdownMenuSeparator />
                 <DropdownMenuItem
                   className="text-destructive focus:bg-destructive/10 focus:text-destructive"
@@ -1387,6 +1434,13 @@ export function ClassificationPanel() {
         accept="application/json"
         ref={fileInputRef}
         onChange={handleImportJson}
+        className="hidden"
+      />
+      <input
+        type="file"
+        accept=".xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+        ref={excelInputRef}
+        onChange={handleImportExcel}
         className="hidden"
       />
     </div>

--- a/context/ifc-context.tsx
+++ b/context/ifc-context.tsx
@@ -13,6 +13,8 @@ import type { IfcAPI } from "web-ifc"; // Import IfcAPI type
 import { Properties } from "web-ifc"; // Ensure Properties is imported
 import { parseRulesFromExcel } from "@/services/rule-import-service";
 import { exportRulesToExcel } from "@/services/rule-export-service";
+import { exportClassificationsToExcel } from "@/services/classification-export-service";
+import { parseClassificationsFromExcel } from "@/services/classification-import-service";
 
 // Define types for Rules
 export interface RuleCondition {
@@ -132,6 +134,8 @@ interface IFCContextType {
 
   exportClassificationsAsJson: () => string;
   importClassificationsFromJson: (json: string) => void;
+  exportClassificationsAsExcel: () => ArrayBuffer;
+  importClassificationsFromExcel: (file: File) => Promise<void>;
   exportRulesAsJson: () => string;
   exportRulesAsExcel: () => ArrayBuffer;
   importRulesFromJson: (json: string) => void;
@@ -1442,6 +1446,30 @@ export function IFCContextProvider({ children }: { children: ReactNode }) {
     [setClassifications]
   );
 
+  const exportClassificationsAsExcel = useCallback((): ArrayBuffer => {
+    return exportClassificationsToExcel(classifications);
+  }, [classifications]);
+
+  const importClassificationsFromExcel = useCallback(
+    async (file: File) => {
+      try {
+        const parsed = await parseClassificationsFromExcel(file);
+        setClassifications((prev) => {
+          const updated = { ...prev };
+          parsed.forEach((item) => {
+            if (item.code) {
+              updated[item.code] = { ...item, elements: item.elements || [] };
+            }
+          });
+          return updated;
+        });
+      } catch (e) {
+        console.error("Failed to import classifications from Excel", e);
+      }
+    },
+    [setClassifications]
+  );
+
   const exportRulesAsJson = useCallback((): string => {
     return JSON.stringify(rules, null, 2);
   }, [rules]);
@@ -1635,7 +1663,9 @@ export function IFCContextProvider({ children }: { children: ReactNode }) {
         updateRule,
         previewRuleHighlight,
         exportClassificationsAsJson,
+        exportClassificationsAsExcel,
         importClassificationsFromJson,
+        importClassificationsFromExcel,
         exportRulesAsJson,
         exportRulesAsExcel,
         importRulesFromJson,

--- a/services/classification-export-service.ts
+++ b/services/classification-export-service.ts
@@ -1,0 +1,21 @@
+import * as XLSX from "xlsx";
+import { ClassificationItem, SelectedElementInfo } from "@/context/ifc-context";
+
+/**
+ * Export classifications to an Excel workbook.
+ * Elements are serialized as "modelID:expressID" pairs separated by semicolons.
+ */
+export function exportClassificationsToExcel(classifications: Record<string, ClassificationItem>): ArrayBuffer {
+  const header = ["code", "name", "color", "elements"];
+  const rows: any[][] = [header];
+  for (const cls of Object.values(classifications)) {
+    const elementsStr = (cls.elements || [])
+      .map((el: SelectedElementInfo) => `${el.modelID}:${el.expressID}`)
+      .join(";");
+    rows.push([cls.code, cls.name, cls.color, elementsStr]);
+  }
+  const worksheet = XLSX.utils.aoa_to_sheet(rows);
+  const workbook = XLSX.utils.book_new();
+  XLSX.utils.book_append_sheet(workbook, worksheet, "Classifications");
+  return XLSX.write(workbook, { type: "array", bookType: "xlsx" });
+}

--- a/services/classification-import-service.ts
+++ b/services/classification-import-service.ts
@@ -1,0 +1,42 @@
+import * as XLSX from "xlsx";
+import { ClassificationItem, SelectedElementInfo } from "@/context/ifc-context";
+
+/**
+ * Parse an Excel file and return an array of ClassificationItem objects.
+ * Expects columns: code | name | color | elements
+ * Elements should be in "modelID:expressID" format separated by semicolons.
+ */
+export async function parseClassificationsFromExcel(file: File): Promise<ClassificationItem[]> {
+  const buffer = await file.arrayBuffer();
+  const workbook = XLSX.read(buffer, { type: "array" });
+  const sheet = workbook.Sheets[workbook.SheetNames[0]];
+  const rows: any[][] = XLSX.utils.sheet_to_json(sheet, { header: 1 });
+  if (rows.length < 2) return [];
+
+  const header: string[] = rows[0].map((h) => String(h).trim().toLowerCase());
+  const idx = (name: string) => header.indexOf(name);
+
+  const items: ClassificationItem[] = [];
+  for (let i = 1; i < rows.length; i++) {
+    const row = rows[i];
+    if (!row || row.length === 0) continue;
+    const code = String(row[idx("code")] ?? "").trim();
+    if (!code) continue;
+    const name = String(row[idx("name")] ?? "");
+    const color = String(row[idx("color")] ?? "#3b82f6");
+    const elementsStr = String(row[idx("elements")] ?? "");
+    let elements: SelectedElementInfo[] = [];
+    if (elementsStr) {
+      elements = elementsStr.split(";").map((pair) => {
+        const [modelIdStr, expressIdStr] = pair.split(":");
+        return {
+          modelID: parseInt(modelIdStr, 10),
+          expressID: parseInt(expressIdStr, 10),
+        } as SelectedElementInfo;
+      });
+    }
+    items.push({ code, name, color, elements });
+  }
+
+  return items;
+}


### PR DESCRIPTION
## Summary
- support Excel import/export of classifications
- create new services for Excel parsing
- expose Excel helpers in IFC context
- enhance classification panel UI with submenu for JSON/Excel

## Testing
- `npm run lint` *(fails: `next` not found)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for importing and exporting classification data in Excel (.xlsx) format, in addition to the existing JSON format.
  - Updated the data management menu to offer separate options for Excel and JSON import/export.
- **User Interface**
  - Enhanced dropdown menus with nested submenus for clearer import and export choices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->