### PR TITLE
Add docs modal content

### DIFF
--- a/components/docs/DocumentationModal.tsx
+++ b/components/docs/DocumentationModal.tsx
@@ -1,20 +1,12 @@
 "use client";
 
 import React, { useState, useEffect } from "react";
-import { X, ChevronLeft, ChevronRight, Home, Zap, FileText, Cog, ChevronsRight, Info } from "lucide-react";
+import { X, ChevronLeft, ChevronRight } from "lucide-react";
+import { DOC_SECTIONS } from "./docsContent";
 
 interface DocumentationModalProps {
     onClose: () => void;
 }
-
-const DOC_SECTIONS = [
-    { id: "general", title: "Welcome!", icon: <Home className="h-5 w-5" />, content: "General Info Content" },
-    { id: "getting-started", title: "Getting Started", icon: <Zap className="h-5 w-5" />, content: "Getting Started Content" },
-    { id: "classifications", title: "Classifications", icon: <FileText className="h-5 w-5" />, content: "Classifications Content: Loading default, creating custom, export options." },
-    { id: "rules", title: "Rules", icon: <ChevronsRight className="h-5 w-5" />, content: "Rules Content: Import/export, creating custom, managing rules." },
-    { id: "settings", title: "Settings", icon: <Cog className="h-5 w-5" />, content: "Settings Content" },
-    { id: "workflow", title: "Typical Workflow", icon: <Info className="h-5 w-5" />, content: "Typical Workflow Content: Detailed start-to-end example including rules." },
-];
 
 const DocumentationModal: React.FC<DocumentationModalProps> = ({ onClose }) => {
     const [currentStep, setCurrentStep] = useState(0);

--- a/components/docs/docsContent.ts
+++ b/components/docs/docsContent.ts
@@ -1,0 +1,22 @@
+import React from "react";
+import { Home, Zap, LayoutDashboard, FileText, ChevronsRight, Cog, Info } from "lucide-react";
+
+import welcome from "@/docs/welcome";
+import gettingStarted from "@/docs/getting-started";
+import ui from "@/docs/ui";
+import classifications from "@/docs/classifications";
+import rules from "@/docs/rules";
+import settings from "@/docs/settings";
+import workflow from "@/docs/workflow";
+
+export const DOC_SECTIONS = [
+  { id: "general", title: "Welcome!", icon: <Home className="h-5 w-5" />, content: welcome },
+  { id: "getting-started", title: "Getting Started", icon: <Zap className="h-5 w-5" />, content: gettingStarted },
+  { id: "ui", title: "Interface & 3D", icon: <LayoutDashboard className="h-5 w-5" />, content: ui },
+  { id: "classifications", title: "Classifications", icon: <FileText className="h-5 w-5" />, content: classifications },
+  { id: "rules", title: "Rules", icon: <ChevronsRight className="h-5 w-5" />, content: rules },
+  { id: "settings", title: "Settings", icon: <Cog className="h-5 w-5" />, content: settings },
+  { id: "workflow", title: "Typical Workflow", icon: <Info className="h-5 w-5" />, content: workflow },
+] as const;
+
+export type DocSection = (typeof DOC_SECTIONS)[number];

--- a/docs/classifications.ts
+++ b/docs/classifications.ts
@@ -1,0 +1,11 @@
+const content = `
+## Managing Classifications
+
+- Load the built‑in **Uniclass Pr** or **eBKP‑H** sets from the menu.
+- Create custom entries with a code, name and color.
+- Use the color switch to apply all classification colors or restore the original model appearance.
+- Highlight a classification to see its elements in 3D. Use the speed dial to edit or remove it.
+- Import or export classifications as **JSON** or **Excel** files.
+- When an element is selected you can assign or remove it using the buttons at the bottom of the panel.
+`;
+export default content;

--- a/docs/getting-started.ts
+++ b/docs/getting-started.ts
@@ -1,0 +1,19 @@
+const content = `
+## Loading a Model
+
+1. Click **Load IFC File** in the viewer or drop a file onto the canvas.
+2. Demo model URLs can also be managed in **Settings**.
+
+## Exploring the Model
+
+- Use the **Model Explorer** on the left to browse the spatial tree.
+- Selecting an element shows its properties in the **Properties** panel below.
+
+## Classifying Elements
+
+1. Open the **Classifications** tab on the right.
+2. Load a default set or create your own entries.
+3. Select an element in 3D and choose **Assign Selected Element**.
+
+`; 
+export default content;

--- a/docs/rules.ts
+++ b/docs/rules.ts
@@ -1,0 +1,12 @@
+const content = `
+## Rule Engine
+
+Rules automatically assign classifications based on element properties.
+
+- Define conditions using any available property and operator.
+- Each rule targets a classification and can be toggled active or inactive.
+- Use **Preview Rule Impact** to highlight elements that match before applying.
+- Import or export rule sets as **JSON** or **Excel**.
+- Load the provided eBKP‑H rule set from the menu when needed.
+`;
+export default content;

--- a/docs/settings.ts
+++ b/docs/settings.ts
@@ -1,0 +1,9 @@
+const content = `
+## Application Settings
+
+- Choose a **Default Classification** to load automatically.
+- Enable **Always apply on load** to classify models as soon as they are opened.
+- Manage a list of model URLs. Demo models can be added with one click.
+- Add your own URL and name to reuse frequently loaded files.
+`;
+export default content;

--- a/docs/ui.ts
+++ b/docs/ui.ts
@@ -1,0 +1,25 @@
+const content = `
+## Interface Overview
+
+The app is divided into three areas: a **Model Explorer** on the left, a central **3D view**, and tabs for **Classifications**, **Rules** and **Settings** on the right. The top menubar lets you toggle the theme and open this guide.
+
+### 3D Controls
+
+- **Orbit:** left mouse drag
+- **Pan:** middle mouse drag or Shift + left drag
+- **Zoom:** scroll wheel or right drag
+- **Select:** left click an element
+
+### View Toolbar
+
+The toolbar below the canvas offers quick actions:
+
+- **Zoom to Extents** (E) – fit the whole model
+- **Zoom to Selected** (F) – focus the active element
+- **Hide Selected** (Spacebar) – toggle visibility of the current selection
+- **Unhide Last** (Ctrl/Cmd+Z) – restore the last hidden element
+- **Unhide All** (Shift+A) – show everything again
+
+Keyboard shortcuts are shown in parentheses.
+`;
+export default content;

--- a/docs/welcome.ts
+++ b/docs/welcome.ts
@@ -1,0 +1,7 @@
+const content = `
+# IFC Classifier
+
+IfcClassifier helps you apply standardized classifications to IFC models right in your browser. The project is open source under the AGPL v3 license and is still a work in progress.
+
+`;
+export default content;

--- a/docs/workflow.ts
+++ b/docs/workflow.ts
@@ -1,0 +1,10 @@
+const content = `
+## Typical Workflow
+
+1. Load your IFC model and choose a classification set.
+2. Optionally load default rules or create your own.
+3. Run rule previews and adjust classifications as required.
+4. Manually assign or remove classifications where needed.
+5. Export the IFC file once everything is classified.
+`;
+export default content;


### PR DESCRIPTION
## Summary
- add doc text files covering features and UI controls
- organize documentation sections in a single module
- hook modal to new content

## Testing
- `npm run lint` *(fails: next not found)*