### PR TITLE
Add spatial tree search

### DIFF
--- a/public/locales/de/common.json
+++ b/public/locales/de/common.json
@@ -193,5 +193,9 @@
         "contains": "Enthält",
         "greaterThan": "Größer als",
         "lessThan": "Kleiner als"
+    },
+    "modelTree": {
+        "searchPlaceholder": "Modellstruktur durchsuchen...",
+        "noSearchResults": "Keine Elemente entsprechen der Suche."
     }
 }

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -193,5 +193,9 @@
         "contains": "Contains",
         "greaterThan": "Greater Than",
         "lessThan": "Less Than"
+    },
+    "modelTree": {
+        "searchPlaceholder": "Search model tree...",
+        "noSearchResults": "No elements match your search."
     }
 }


### PR DESCRIPTION
## Summary
- implement search bar for model tree panel
- show empty state when no search results are found
- add translations for search placeholders

## Testing
- `npm run lint` *(fails: next not found)*