### PR TITLE
Add property-based classification match feature

### DIFF
--- a/public/locales/de/common.json
+++ b/public/locales/de/common.json
@@ -94,7 +94,8 @@
     "editRule": "Regel bearbeiten",
     "deleteRule": "Regel löschen",
     "previewRule": "Regelauswirkung anzeigen",
-    "clearPreview": "Vorschau zurücksetzen"
+    "clearPreview": "Vorschau zurücksetzen",
+    "match": "Zuordnen"
   },
   "messages": {
     "loading": "Wird geladen...",
@@ -161,6 +162,12 @@
     "classificationPlural": "Klassifikationen",
     "searchPlaceholder": "Klassifizierungen durchsuchen...",
     "noSearchResults": "Keine Klassifizierungen entsprechen Ihrer Suche.",
+    "matchFromProperty": "Nach Eigenschaft zuordnen",
+    "codePropertyKey": "Eigenschaftsschlüssel für Code",
+    "namePropertyKey": "Eigenschaftsschlüssel für Name",
+    "useWildcard": "Wildcards verwenden",
+    "useFuzzy": "Unscharfe Suche",
+    "matching": "Suche läuft...",
     "noClassificationFound": "Keine Klassifizierung gefunden. Tippen Sie, um zu erstellen.",
     "createNewClassification": "Neue Klassifizierung \"{{value}}\" erstellen"
   },

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -94,7 +94,8 @@
     "editRule": "Edit Rule",
     "deleteRule": "Delete Rule",
     "previewRule": "Preview Rule Impact",
-    "clearPreview": "Clear Preview"
+    "clearPreview": "Clear Preview",
+    "match": "Match"
   },
   "messages": {
     "loading": "Loading...",
@@ -160,7 +161,13 @@
     "classificationSingular": "classification",
     "classificationPlural": "classifications",
     "searchPlaceholder": "Search classifications...",
-    "noSearchResults": "No classifications match your search."
+    "noSearchResults": "No classifications match your search.",
+    "matchFromProperty": "Match From Property",
+    "codePropertyKey": "Code Property Key",
+    "namePropertyKey": "Name Property Key",
+    "useWildcard": "Use Wildcards",
+    "useFuzzy": "Use Fuzzy Matching",
+    "matching": "Matching..."
   },
   "rules": {
     "addNew": "Add New Rule",


### PR DESCRIPTION
## Summary
- add a dialog in the Classification panel to match elements from property values
- implement matching logic with optional wildcard and fuzzy matching
- expose new `matchClassificationsFromProperties` API in IFC context
- translate new UI strings in English and German locales

## Testing
- `npm run lint` *(fails: next not found)*