### PR TITLE
Add property-based classification match feature

### DIFF
--- a/context/ifc-context.tsx
+++ b/context/ifc-context.tsx
@@ -142,6 +142,13 @@ interface IFCContextType {
   importRulesFromExcel: (file: File) => Promise<void>;
   removeAllRules: () => void;
 
+  matchClassificationsFromProperties: (
+    codeKey: string,
+    nameKey: string,
+    useWildcard: boolean,
+    useFuzzy: boolean,
+  ) => Promise<void>;
+
   assignClassificationToElement: (
     classificationCode: string,
     element: SelectedElementInfo,
@@ -1543,6 +1550,173 @@ export function IFCContextProvider({ children }: { children: ReactNode }) {
     setRules([]);
   }, [setRules]);
 
+  const wildcardToRegex = (pattern: string): RegExp => {
+    const escaped = pattern.replace(/[.+^${}()|[\]\\]/g, "\\$&");
+    const regexStr = "^" + escaped.replace(/\*/g, ".*").replace(/\?/g, ".") + "$";
+    return new RegExp(regexStr, "i");
+  };
+
+  const levenshtein = (a: string, b: string): number => {
+    const an = a ? a.length : 0;
+    const bn = b ? b.length : 0;
+    if (an === 0) return bn;
+    if (bn === 0) return an;
+    const matrix = Array.from({ length: an + 1 }, () => new Array(bn + 1).fill(0));
+    for (let i = 0; i <= an; i++) matrix[i][0] = i;
+    for (let j = 0; j <= bn; j++) matrix[0][j] = j;
+    for (let i = 1; i <= an; i++) {
+      for (let j = 1; j <= bn; j++) {
+        const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+        matrix[i][j] = Math.min(
+          matrix[i - 1][j] + 1,
+          matrix[i][j - 1] + 1,
+          matrix[i - 1][j - 1] + cost,
+        );
+      }
+    }
+    return matrix[an][bn];
+  };
+
+  const matchClassificationsFromProperties = useCallback(
+    async (
+      codeKey: string,
+      nameKey: string,
+      useWildcard: boolean,
+      useFuzzy: boolean,
+    ) => {
+      if (!ifcApiInternal) return;
+
+      if (!ifcApiInternal.properties) {
+        try {
+          ifcApiInternal.properties = new Properties(ifcApiInternal);
+        } catch (e) {
+          console.error("Failed to init properties in match", e);
+          return;
+        }
+      }
+
+      const classificationByName = Object.values(classifications).reduce<Record<string, string>>(
+        (acc, c: any) => {
+          acc[c.name.toLowerCase()] = c.code;
+          return acc;
+        },
+        {},
+      );
+
+      const matchValueToCode = (val: string): string | null => {
+        const v = val.toLowerCase();
+        if (classifications[v]) return v;
+        for (const code in classifications) {
+          if (code.toLowerCase() === v) return code;
+          if (useWildcard && wildcardToRegex(v).test(code.toLowerCase())) return code;
+          if (useFuzzy && levenshtein(v, code.toLowerCase()) <= 2) return code;
+        }
+        if (classificationByName[v]) return classificationByName[v];
+        for (const name in classificationByName) {
+          if (useWildcard && wildcardToRegex(v).test(name)) return classificationByName[name];
+          if (useFuzzy && levenshtein(v, name) <= 3) return classificationByName[name];
+        }
+        return null;
+      };
+
+      const getValueForKey = async (
+        props: any,
+        node: SpatialStructureNode,
+        key: string,
+        modelID: number,
+      ) => {
+        if (!key) return undefined;
+        if (key === "Ifc Class") return node.type;
+        if (key.includes(".")) {
+          const [pset, prop] = key.split(".");
+          let psetObj = props[pset];
+          if (!psetObj && Array.isArray(props.PropertySets)) {
+            psetObj = props.PropertySets.find((ps: any) => ps.Name?.value === pset);
+          }
+          if (psetObj && psetObj.HasProperties) {
+            const target = psetObj.HasProperties.find((p: any) => p.Name?.value === prop);
+            if (target) return target.NominalValue?.value ?? target.NominalValue;
+          }
+        } else {
+          const direct = props[key];
+          if (direct !== undefined) return direct?.value ?? direct;
+          const nodeVal = (node as any)[key];
+          if (nodeVal !== undefined) return nodeVal?.value ?? nodeVal;
+        }
+        return undefined;
+      };
+
+      const codeKeys = codeKey ? [codeKey] : [];
+      const nameKeys = nameKey ? [nameKey] : [];
+
+      const updates: Record<string, SelectedElementInfo[]> = {};
+
+      for (const model of loadedModels) {
+        if (model.modelID == null || !model.spatialTree) continue;
+        const elements = getAllElementsFromSpatialTreeNodesRecursive([
+          model.spatialTree,
+        ]);
+        for (const node of elements) {
+          if (node.expressID === undefined) continue;
+          let props: any = null;
+          try {
+            props = await ifcApiInternal.properties.getItemProperties(
+              model.modelID,
+              node.expressID,
+              true,
+            );
+          } catch {
+            continue;
+          }
+          let foundCode: string | null = null;
+          for (const key of codeKeys) {
+            const val = await getValueForKey(props, node, key, model.modelID);
+            if (val !== undefined && val !== null) {
+              foundCode = matchValueToCode(String(val));
+              if (foundCode) break;
+            }
+          }
+          if (!foundCode) {
+            for (const key of nameKeys) {
+              const val = await getValueForKey(props, node, key, model.modelID);
+              if (val !== undefined && val !== null) {
+                foundCode = matchValueToCode(String(val));
+                if (foundCode) break;
+              }
+            }
+          }
+          if (foundCode) {
+            if (!updates[foundCode]) updates[foundCode] = [];
+            updates[foundCode].push({ modelID: model.modelID, expressID: node.expressID });
+          }
+        }
+      }
+
+      setClassifications((prev) => {
+        const updated = { ...prev };
+        for (const code in updates) {
+          if (!updated[code]) {
+            updated[code] = { code, name: code, color: "#888888", elements: [] };
+          }
+          const existing: SelectedElementInfo[] = updated[code].elements || [];
+          updates[code].forEach((el) => {
+            if (!existing.some((e: SelectedElementInfo) => e.modelID === el.modelID && e.expressID === el.expressID)) {
+              existing.push(el);
+            }
+          });
+          updated[code].elements = existing;
+        }
+        return updated;
+      });
+    },
+    [
+      ifcApiInternal,
+      classifications,
+      loadedModels,
+      getAllElementsFromSpatialTreeNodesRecursive,
+    ],
+  );
+
   const toggleUserHideElement = useCallback(
     (elementToToggle: SelectedElementInfo) => {
       console.log(
@@ -1726,6 +1900,7 @@ export function IFCContextProvider({ children }: { children: ReactNode }) {
         importRulesFromJson,
         importRulesFromExcel,
         removeAllRules,
+        matchClassificationsFromProperties,
         toggleUserHideElement,
         hideElements,
         showElements,

--- a/public/locales/de/common.json
+++ b/public/locales/de/common.json
@@ -94,7 +94,8 @@
     "editRule": "Regel bearbeiten",
     "deleteRule": "Regel löschen",
     "previewRule": "Regelauswirkung anzeigen",
-    "clearPreview": "Vorschau zurücksetzen"
+    "clearPreview": "Vorschau zurücksetzen",
+    "match": "Zuordnen"
   },
   "messages": {
     "loading": "Wird geladen...",
@@ -161,6 +162,12 @@
     "classificationPlural": "Klassifikationen",
     "searchPlaceholder": "Klassifizierungen durchsuchen...",
     "noSearchResults": "Keine Klassifizierungen entsprechen Ihrer Suche.",
+    "matchFromProperty": "Nach Eigenschaft zuordnen",
+    "codePropertyKey": "Eigenschaftsschlüssel für Code",
+    "namePropertyKey": "Eigenschaftsschlüssel für Name",
+    "useWildcard": "Wildcards verwenden",
+    "useFuzzy": "Unscharfe Suche",
+    "matching": "Suche läuft...",
     "noClassificationFound": "Keine Klassifizierung gefunden. Tippen Sie, um zu erstellen.",
     "createNewClassification": "Neue Klassifizierung \"{{value}}\" erstellen"
   },

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -94,7 +94,8 @@
     "editRule": "Edit Rule",
     "deleteRule": "Delete Rule",
     "previewRule": "Preview Rule Impact",
-    "clearPreview": "Clear Preview"
+    "clearPreview": "Clear Preview",
+    "match": "Match"
   },
   "messages": {
     "loading": "Loading...",
@@ -160,7 +161,13 @@
     "classificationSingular": "classification",
     "classificationPlural": "classifications",
     "searchPlaceholder": "Search classifications...",
-    "noSearchResults": "No classifications match your search."
+    "noSearchResults": "No classifications match your search.",
+    "matchFromProperty": "Match From Property",
+    "codePropertyKey": "Code Property Key",
+    "namePropertyKey": "Name Property Key",
+    "useWildcard": "Use Wildcards",
+    "useFuzzy": "Use Fuzzy Matching",
+    "matching": "Matching..."
   },
   "rules": {
     "addNew": "Add New Rule",


### PR DESCRIPTION
## Summary
- add a dialog in the Classification panel to match elements from property values
- implement matching logic with optional wildcard and fuzzy matching
- expose new `matchClassificationsFromProperties` API in IFC context
- translate new UI strings in English and German locales
- fix a TypeScript type error in classification matching

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a "Match From Property" option in the classification panel, allowing users to assign classifications to elements based on property values.
  - Added support for wildcard and fuzzy matching when matching properties.
  - New dialog interface for entering property keys and matching options.

- **Localization**
  - Added English and German translations for the new classification matching features and related UI elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->