### PR TITLE
Add mapping from model properties

### DIFF
--- a/components/classification-panel.tsx
+++ b/components/classification-panel.tsx
@@ -129,6 +129,7 @@ export function ClassificationPanel() {
     exportClassificationsAsExcel,
     importClassificationsFromJson,
     importClassificationsFromExcel,
+    assignClassificationsFromModel,
   } = useIFCContext();
   const { t } = useTranslation();
   const [isAddDialogOpen, setIsAddDialogOpen] = useState(false);
@@ -166,6 +167,10 @@ export function ClassificationPanel() {
   >(null);
   const [isConfirmRemoveOpen, setIsConfirmRemoveOpen] = useState(false);
   const [isConfirmRemoveAllOpen, setIsConfirmRemoveAllOpen] = useState(false);
+  const [isFromModelOpen, setIsFromModelOpen] = useState(false);
+  const [fromModelPset, setFromModelPset] = useState("");
+  const [fromModelCodeProp, setFromModelCodeProp] = useState("");
+  const [fromModelDescProp, setFromModelDescProp] = useState("");
   const [currentDefaultClassification, setCurrentDefaultClassification] =
     useState<string>("");
   const [searchQuery, setSearchQuery] = useState("");
@@ -550,6 +555,16 @@ export function ClassificationPanel() {
     if (selectedElement) {
       unassignElementFromAllClassifications(selectedElement);
     }
+  };
+
+  const handleAssignFromModel = async () => {
+    if (!fromModelPset || !fromModelCodeProp) return;
+    await assignClassificationsFromModel(
+      fromModelPset,
+      fromModelCodeProp,
+      fromModelDescProp || undefined,
+    );
+    setIsFromModelOpen(false);
   };
 
   // Component to render each row in the virtualized list
@@ -959,6 +974,10 @@ export function ClassificationPanel() {
                     </DropdownMenuItem>
                   </DropdownMenuSubContent>
                 </DropdownMenuSub>
+                <DropdownMenuItem onSelect={() => setIsFromModelOpen(true)}>
+                  <Upload className="mr-2 h-4 w-4" />
+                  {t('buttons.useFromModel')}
+                </DropdownMenuItem>
                 <DropdownMenuSeparator />
                 <DropdownMenuItem
                   className="text-destructive focus:bg-destructive/10 focus:text-destructive"
@@ -1452,6 +1471,56 @@ export function ClassificationPanel() {
               >
                 Remove All
               </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+      )}
+      {isFromModelOpen && (
+        <Dialog open={isFromModelOpen} onOpenChange={setIsFromModelOpen}>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>{t('classifications.assignFromModelTitle')}</DialogTitle>
+            </DialogHeader>
+            <div className="grid gap-4 py-4">
+              <div className="grid grid-cols-4 items-center gap-4">
+                <Label htmlFor="pset" className="text-right">
+                  {t('classifications.pset')}
+                </Label>
+                <Input
+                  id="pset"
+                  value={fromModelPset}
+                  onChange={(e) => setFromModelPset(e.target.value)}
+                  className="col-span-3"
+                />
+              </div>
+              <div className="grid grid-cols-4 items-center gap-4">
+                <Label htmlFor="codeProp" className="text-right">
+                  {t('classifications.codeProperty')}
+                </Label>
+                <Input
+                  id="codeProp"
+                  value={fromModelCodeProp}
+                  onChange={(e) => setFromModelCodeProp(e.target.value)}
+                  className="col-span-3"
+                />
+              </div>
+              <div className="grid grid-cols-4 items-center gap-4">
+                <Label htmlFor="descProp" className="text-right">
+                  {t('classifications.descriptionProperty')}
+                </Label>
+                <Input
+                  id="descProp"
+                  value={fromModelDescProp}
+                  onChange={(e) => setFromModelDescProp(e.target.value)}
+                  className="col-span-3"
+                />
+              </div>
+            </div>
+            <DialogFooter>
+              <Button variant="outline" onClick={() => setIsFromModelOpen(false)}>
+                {t('buttons.cancel')}
+              </Button>
+              <Button onClick={handleAssignFromModel}>{t('buttons.apply')}</Button>
             </DialogFooter>
           </DialogContent>
         </Dialog>

--- a/components/ifc-model.tsx
+++ b/components/ifc-model.tsx
@@ -750,6 +750,8 @@ export function IFCModel({ modelData, outlineLayer }: IFCModelProps) {
     setInternalApiIdForEffects,
     setRawBufferForModel,
     createMeshes,
+    baseCoordinationMatrix,
+    setBaseCoordinationMatrix,
   ]);
 
   // New useEffect for initial camera positioning

--- a/docs/classifications.ts
+++ b/docs/classifications.ts
@@ -4,6 +4,7 @@ const content = {
 - Use the color switch to apply all classification colors or restore the original model appearance.
 - Highlight a classification to see its elements in 3D. Use the speed dial to edit or remove it.
 - Import or export classifications as **JSON** or **Excel** files.
+- Map classifications from model properties via the menu option.
 - When an element is selected you can assign or remove it using the buttons at the bottom of the panel.
 `,
   de: `- Lade die integrierten Sets **Uniclass Pr** oder **eBKP‑H** über das Menü.
@@ -11,6 +12,7 @@ const content = {
 - Mit dem Farbschalter kannst du alle Klassifizierungsfarben anwenden oder das ursprüngliche Modell wiederherstellen.
 - Markiere eine Klassifizierung, um ihre Elemente in 3D zu sehen. Über das Speed-Dial kannst du sie bearbeiten oder entfernen.
 - Klassifizierungen lassen sich als **JSON** oder **Excel** importieren bzw. exportieren.
+- Klassifikationen können über eine Menüoption aus Modelleigenschaften übernommen werden.
 - Bei ausgewähltem Element kannst du es unten im Panel zuweisen oder entfernen.
 `};
 export default content;

--- a/public/locales/de/common.json
+++ b/public/locales/de/common.json
@@ -80,6 +80,7 @@
     "export": "Exportieren",
     "load": "Laden",
     "removeAllClassifications": "Alle Klassifizierungen entfernen",
+    "useFromModel": "Klassifizierungen aus Modell verwenden",
     "loadUniclass": "Uniclass Pr laden ({{count}})",
     "loadEbkph": "eBKP-H laden ({{count}})",
     "noUniclassFound": "Keine Uniclass Pr Elemente gefunden.",
@@ -161,6 +162,10 @@
     "classificationPlural": "Klassifikationen",
     "searchPlaceholder": "Klassifizierungen durchsuchen...",
     "noSearchResults": "Keine Klassifizierungen entsprechen Ihrer Suche.",
+    "assignFromModelTitle": "Klassifizierungen aus Modell verwenden",
+    "pset": "Property Set",
+    "codeProperty": "Code-Eigenschaft",
+    "descriptionProperty": "Beschreibungs-Eigenschaft",
     "noClassificationFound": "Keine Klassifizierung gefunden. Tippen Sie, um zu erstellen.",
     "createNewClassification": "Neue Klassifizierung \"{{value}}\" erstellen"
   },

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -80,6 +80,7 @@
     "export": "Export",
     "load": "Load",
     "removeAllClassifications": "Remove All Classifications",
+    "useFromModel": "Use Classifications from Model",
     "loadUniclass": "Load Uniclass Pr ({{count}})",
     "loadEbkph": "Load eBKP-H ({{count}})",
     "noUniclassFound": "No Uniclass Pr items found.",
@@ -160,7 +161,11 @@
     "classificationSingular": "classification",
     "classificationPlural": "classifications",
     "searchPlaceholder": "Search classifications...",
-    "noSearchResults": "No classifications match your search."
+    "noSearchResults": "No classifications match your search.",
+    "assignFromModelTitle": "Use Classifications from Model",
+    "pset": "Property Set",
+    "codeProperty": "Code Property",
+    "descriptionProperty": "Description Property"
   },
   "rules": {
     "addNew": "Add New Rule",


### PR DESCRIPTION
## Summary
- map classifications based on model Pset properties via new context function
- add UI in classification panel to specify property set and property names
- update documentation and translations for the new feature

## Testing
- `npm run lint` *(fails: next not found)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the ability to assign classifications directly from model properties via a new dialog in the classification panel.
  - Users can specify property set, code property, and description property to map classifications from the model.
- **Documentation**
  - Updated documentation (English and German) to describe the new classification mapping feature.
- **Style**
  - Added new localization strings for the new feature in both English and German.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->