### PR TITLE
Implement classification mapping from model

### DIFF
--- a/components/classification-panel.tsx
+++ b/components/classification-panel.tsx
@@ -64,6 +64,7 @@ import {
   FileSpreadsheet,
   ArchiveRestore,
   Star,
+  Tag,
   Cuboid,
 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
@@ -129,6 +130,7 @@ export function ClassificationPanel() {
     exportClassificationsAsExcel,
     importClassificationsFromJson,
     importClassificationsFromExcel,
+    mapClassificationsFromModel,
   } = useIFCContext();
   const { t } = useTranslation();
   const [isAddDialogOpen, setIsAddDialogOpen] = useState(false);
@@ -137,6 +139,9 @@ export function ClassificationPanel() {
     name: "",
     color: "#3b82f6",
   });
+  const [isMapDialogOpen, setIsMapDialogOpen] = useState(false);
+  const [mapPset, setMapPset] = useState("");
+  const [mapProperty, setMapProperty] = useState("");
   const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
   const [currentClassificationForEdit, setCurrentClassificationForEdit] =
     useState<ClassificationItem | null>(null);
@@ -525,6 +530,13 @@ export function ClassificationPanel() {
       );
       setIsEditDialogOpen(false);
       setCurrentClassificationForEdit(null);
+    }
+  };
+
+  const handleApplyMapping = async () => {
+    if (mapPset && mapProperty) {
+      await mapClassificationsFromModel(mapPset, mapProperty);
+      setIsMapDialogOpen(false);
     }
   };
 
@@ -923,6 +935,10 @@ export function ClassificationPanel() {
                 <DropdownMenuLabel className="text-xs font-semibold text-muted-foreground px-2 py-1.5">
                   {t('sections.manageData')}
                 </DropdownMenuLabel>
+                <DropdownMenuItem onSelect={() => setIsMapDialogOpen(true)}>
+                  <Tag className="mr-2 h-4 w-4" />
+                  {t('classifications.mapFromModel')}
+                </DropdownMenuItem>
                 <DropdownMenuSub>
                   <DropdownMenuSubTrigger>
                     <FileOutput className="mr-2 h-4 w-4" /> {t('buttons.export')}
@@ -1050,6 +1066,43 @@ export function ClassificationPanel() {
               <Button onClick={handleAddClassification}>
                 {t('buttons.add')}
               </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+        <Dialog open={isMapDialogOpen} onOpenChange={setIsMapDialogOpen}>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>{t('classifications.mapFromModel')}</DialogTitle>
+            </DialogHeader>
+            <div className="grid gap-4 py-4">
+              <div className="grid grid-cols-4 items-center gap-4">
+                <Label htmlFor="pset" className="text-right">
+                  {t('classifications.psetInputLabel')}
+                </Label>
+                <Input
+                  id="pset"
+                  value={mapPset}
+                  onChange={(e) => setMapPset(e.target.value)}
+                  className="col-span-3"
+                />
+              </div>
+              <div className="grid grid-cols-4 items-center gap-4">
+                <Label htmlFor="property" className="text-right">
+                  {t('classifications.propertyInputLabel')}
+                </Label>
+                <Input
+                  id="property"
+                  value={mapProperty}
+                  onChange={(e) => setMapProperty(e.target.value)}
+                  className="col-span-3"
+                />
+              </div>
+            </div>
+            <DialogFooter>
+              <Button variant="outline" onClick={() => setIsMapDialogOpen(false)}>
+                {t('buttons.cancel')}
+              </Button>
+              <Button onClick={handleApplyMapping}>{t('buttons.apply')}</Button>
             </DialogFooter>
           </DialogContent>
         </Dialog>

--- a/public/locales/de/common.json
+++ b/public/locales/de/common.json
@@ -161,6 +161,10 @@
     "classificationPlural": "Klassifikationen",
     "searchPlaceholder": "Klassifizierungen durchsuchen...",
     "noSearchResults": "Keine Klassifizierungen entsprechen Ihrer Suche.",
+    "mapFromModel": "Aus Modell zuordnen",
+    "psetInputLabel": "PSet Name",
+    "propertyInputLabel": "Eigenschaft",
+    "applyFromModel": "Anwenden",
     "noClassificationFound": "Keine Klassifizierung gefunden. Tippen Sie, um zu erstellen.",
     "createNewClassification": "Neue Klassifizierung \"{{value}}\" erstellen"
   },

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -160,7 +160,11 @@
     "classificationSingular": "classification",
     "classificationPlural": "classifications",
     "searchPlaceholder": "Search classifications...",
-    "noSearchResults": "No classifications match your search."
+    "noSearchResults": "No classifications match your search.",
+    "mapFromModel": "Map from Model",
+    "psetInputLabel": "Property Set",
+    "propertyInputLabel": "Property",
+    "applyFromModel": "Apply"
   },
   "rules": {
     "addNew": "Add New Rule",


### PR DESCRIPTION
## Summary
- allow mapping classifications from model property sets
- expose new `mapClassificationsFromModel` in context
- add UI in classification panel to trigger mapping via modal
- update i18n strings for new feature

## Testing
- `npm run lint` *(fails: `next` not found)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to map classifications from model property sets and properties via a new dialog in the classification panel.
- **Localization**
  - Added new English and German translations for the new mapping feature in the classification panel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->