### PR TITLE
Add classification mapping from model

### DIFF
--- a/components/ifc-model.tsx
+++ b/components/ifc-model.tsx
@@ -732,6 +732,23 @@ export function IFCModel({ modelData, outlineLayer }: IFCModelProps) {
           allTypesArray.map(String)
         );
         console.log(`IFCModel (${modelData.id}): Available categories set.`);
+
+        // ***** START DIAGNOSTIC LOG FOR getPropertySets *****
+        if (ifcApi && newIfcModelID !== null) {
+          try {
+            const tempPropertiesManager = new Properties(ifcApi);
+            console.log(`IFCModel (${modelData.id}): DIAGNOSTIC - Temp PropertiesManager created for modelID ${newIfcModelID}`);
+            const psets = await tempPropertiesManager.getPropertySets(newIfcModelID, 0, true, true);
+            console.log(`IFCModel (${modelData.id}): DIAGNOSTIC - getPropertySets(modelID: ${newIfcModelID}, 0, true, true) raw result:`, JSON.parse(JSON.stringify(psets)));
+            if (psets.length === 0) {
+              console.warn(`IFCModel (${modelData.id}): DIAGNOSTIC - getPropertySets returned an empty array for modelID ${newIfcModelID}.`);
+            }
+          } catch (e) {
+            console.error(`IFCModel (${modelData.id}): DIAGNOSTIC - Error directly calling getPropertySets:`, e);
+          }
+        }
+        // ***** END DIAGNOSTIC LOG FOR getPropertySets *****
+
         setIsLoading(false);
       } catch (error) {
         console.error(`IFCModel (${modelData.id}): Error loading:`, error);


### PR DESCRIPTION
## Summary
- map classification codes from IFC model property sets
- expose mapping function via context
- allow choosing property set and property in classification panel
- hook mapping function up to UI and dropdown menu

## Testing
- `npm run lint` *(fails: `next: not found`)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a "Map From Model" option in the classification panel, allowing users to map classification codes to IFC elements based on selected property sets and properties from the model.
  - Added a dialog with intuitive selection and creation of property sets and properties for enhanced mapping flexibility.

- **Improvements**
  - Enhanced classification management by enabling bulk mapping using model data, streamlining the classification process.
  - Added detailed diagnostic logging for property sets retrieval to improve transparency and troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->