### PR TITLE
Remove export confirmation modal

### DIFF
--- a/components/classification-panel.tsx
+++ b/components/classification-panel.tsx
@@ -711,7 +711,6 @@ export function ClassificationPanel() {
           : originalFileName;
         const newFileName = `${baseName}_classified.ifc`;
         downloadFile(modifiedIfcData, newFileName, "application/octet-stream");
-        alert("IFC model exported successfully!");
       } else {
         alert("IFC export failed. Please check the console for more details.");
       }


### PR DESCRIPTION
## Summary
- streamline IFC export process by removing the success alert

## Testing
- `npm run lint`
- `npm run build` *(fails: connect EHOSTUNREACH)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Removed the success alert notification after exporting an IFC model with classifications. The export process continues without displaying a confirmation message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->