### PR TITLE
Move manual assignment section above classification list

### DIFF
--- a/components/classification-panel.tsx
+++ b/components/classification-panel.tsx
@@ -1136,6 +1136,36 @@ export function ClassificationPanel() {
         </Dialog>
       )}
 
+
+      {selectedElement && (
+        <div className="mt-4 space-y-2 border-t pt-4">
+          {highlightedClassificationCode ? (
+            <>
+              <Button className="w-full" onClick={handleAssignSelected}>
+                {t('buttons.assignSelected')}
+              </Button>
+              <Button
+                className="w-full"
+                variant="outline"
+                onClick={handleUnassignSelected}
+              >
+                {t('buttons.removeSelected')}
+              </Button>
+            </>
+          ) : (
+            <p className="text-sm text-muted-foreground">
+              {t('messages.highlightToAssign')}
+            </p>
+          )}
+          <Button
+            className="w-full"
+            variant="outline"
+            onClick={handleClearSelected}
+          >
+            {t('buttons.clearFromAll')}
+          </Button>
+        </div>
+      )}
       {sortedClassificationEntries.length === 0 ? (
         <div className="text-center py-8 flex-grow flex flex-col items-center justify-center">
           {searchQuery ? (
@@ -1290,35 +1320,6 @@ export function ClassificationPanel() {
         </div>
       )}
 
-      {selectedElement && (
-        <div className="mt-4 space-y-2 border-t pt-4">
-          {highlightedClassificationCode ? (
-            <>
-              <Button className="w-full" onClick={handleAssignSelected}>
-                {t('buttons.assignSelected')}
-              </Button>
-              <Button
-                className="w-full"
-                variant="outline"
-                onClick={handleUnassignSelected}
-              >
-                {t('buttons.removeSelected')}
-              </Button>
-            </>
-          ) : (
-            <p className="text-sm text-muted-foreground">
-              {t('messages.highlightToAssign')}
-            </p>
-          )}
-          <Button
-            className="w-full"
-            variant="outline"
-            onClick={handleClearSelected}
-          >
-            {t('buttons.clearFromAll')}
-          </Button>
-        </div>
-      )}
 
       {showExportSection && (
         <div className="mt-auto pt-4 border-t space-y-3">


### PR DESCRIPTION
## Summary
- place manual 3D element assignment controls above the classification list

## Testing
- `npm run lint`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Removed duplicate UI controls for classification assignment and removal to streamline the panel without changing existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->