### PR TITLE
Add model property classification import

### DIFF
--- a/public/locales/de/common.json
+++ b/public/locales/de/common.json
@@ -94,7 +94,8 @@
     "editRule": "Regel bearbeiten",
     "deleteRule": "Regel löschen",
     "previewRule": "Regelauswirkung anzeigen",
-    "clearPreview": "Vorschau zurücksetzen"
+    "clearPreview": "Vorschau zurücksetzen",
+    "loadFromModel": "Aus Modell laden"
   },
   "messages": {
     "loading": "Wird geladen...",
@@ -161,6 +162,8 @@
     "classificationPlural": "Klassifikationen",
     "searchPlaceholder": "Klassifizierungen durchsuchen...",
     "noSearchResults": "Keine Klassifizierungen entsprechen Ihrer Suche.",
+    "selectPset": "Property Set",
+    "selectProperty": "Property",
     "noClassificationFound": "Keine Klassifizierung gefunden. Tippen Sie, um zu erstellen.",
     "createNewClassification": "Neue Klassifizierung \"{{value}}\" erstellen"
   },

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -94,7 +94,8 @@
     "editRule": "Edit Rule",
     "deleteRule": "Delete Rule",
     "previewRule": "Preview Rule Impact",
-    "clearPreview": "Clear Preview"
+    "clearPreview": "Clear Preview",
+    "loadFromModel": "Load from Model"
   },
   "messages": {
     "loading": "Loading...",
@@ -160,7 +161,9 @@
     "classificationSingular": "classification",
     "classificationPlural": "classifications",
     "searchPlaceholder": "Search classifications...",
-    "noSearchResults": "No classifications match your search."
+    "noSearchResults": "No classifications match your search.",
+    "selectPset": "Property Set",
+    "selectProperty": "Property"
   },
   "rules": {
     "addNew": "Add New Rule",


### PR DESCRIPTION
## Summary
- allow importing classification mappings from IFC model property sets
- support selecting property set and property via new dialog
- expose applyClassificationsFromModelProperty in context
- update i18n strings

## Testing
- `npm run lint`