### PR TITLE
Add classification mapping from model properties

### DIFF
--- a/components/classification-panel.tsx
+++ b/components/classification-panel.tsx
@@ -129,6 +129,7 @@ export function ClassificationPanel() {
     exportClassificationsAsExcel,
     importClassificationsFromJson,
     importClassificationsFromExcel,
+    mapClassificationsFromModel,
   } = useIFCContext();
   const { t } = useTranslation();
   const [isAddDialogOpen, setIsAddDialogOpen] = useState(false);
@@ -140,6 +141,9 @@ export function ClassificationPanel() {
   const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
   const [currentClassificationForEdit, setCurrentClassificationForEdit] =
     useState<ClassificationItem | null>(null);
+  const [isMapFromModelDialogOpen, setIsMapFromModelDialogOpen] = useState(false);
+  const [mapPsetName, setMapPsetName] = useState("");
+  const [mapPropertyName, setMapPropertyName] = useState("");
   const [defaultUniclassPr, setDefaultUniclassPr] = useState<
     ClassificationItem[]
   >([]);
@@ -228,6 +232,11 @@ export function ClassificationPanel() {
 
   const triggerImport = () => fileInputRef.current?.click();
   const triggerExcelImport = () => excelInputRef.current?.click();
+
+  const handleMapFromModel = async () => {
+    await mapClassificationsFromModel(mapPsetName, mapPropertyName);
+    setIsMapFromModelDialogOpen(false);
+  };
 
   const handleImportJson = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
@@ -958,6 +967,9 @@ export function ClassificationPanel() {
                     </DropdownMenuItem>
                   </DropdownMenuSubContent>
                 </DropdownMenuSub>
+                <DropdownMenuItem onSelect={() => setIsMapFromModelDialogOpen(true)}>
+                  <FileInput className="mr-2 h-4 w-4" /> {t('buttons.mapFromModel')}
+                </DropdownMenuItem>
                 <DropdownMenuSeparator />
                 <DropdownMenuItem
                   className="text-destructive focus:bg-destructive/10 focus:text-destructive"
@@ -1054,6 +1066,43 @@ export function ClassificationPanel() {
         </Dialog>
         {/* The old "Row 2 Management Dropdown section" is now fully replaced by the 3-dot menu in the header and this restored dialog. */}
         {/* The hidden file input for import is kept at the end of the component. */}
+        <Dialog open={isMapFromModelDialogOpen} onOpenChange={setIsMapFromModelDialogOpen}>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>{t('classifications.mapFromModelTitle')}</DialogTitle>
+            </DialogHeader>
+            <div className="grid gap-4 py-4">
+              <div className="grid grid-cols-4 items-center gap-4">
+                <Label htmlFor="map-pset" className="text-right">
+                  {t('classifications.psetName')}
+                </Label>
+                <Input
+                  id="map-pset"
+                  value={mapPsetName}
+                  onChange={(e) => setMapPsetName(e.target.value)}
+                  className="col-span-3"
+                />
+              </div>
+              <div className="grid grid-cols-4 items-center gap-4">
+                <Label htmlFor="map-prop" className="text-right">
+                  {t('classifications.propertyName')}
+                </Label>
+                <Input
+                  id="map-prop"
+                  value={mapPropertyName}
+                  onChange={(e) => setMapPropertyName(e.target.value)}
+                  className="col-span-3"
+                />
+              </div>
+            </div>
+            <DialogFooter>
+              <Button variant="outline" onClick={() => setIsMapFromModelDialogOpen(false)}>
+                {t('buttons.cancel')}
+              </Button>
+              <Button onClick={handleMapFromModel}>{t('buttons.apply')}</Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
       </div>
 
       {/* Edit Classification Dialog */}

--- a/context/ifc-context.tsx
+++ b/context/ifc-context.tsx
@@ -168,6 +168,10 @@ interface IFCContextType {
   getClassificationsForElement: (
     element: SelectedElementInfo | null,
   ) => ClassificationItem[];
+  mapClassificationsFromModel: (
+    psetName: string,
+    propertyName: string,
+  ) => Promise<void>;
 }
 
 const IFCContext = createContext<IFCContextType | undefined>(undefined);
@@ -1457,6 +1461,86 @@ export function IFCContextProvider({ children }: { children: ReactNode }) {
     [classifications],
   );
 
+  const mapClassificationsFromModel = useCallback(
+    async (psetName: string, propertyName: string) => {
+      if (!ifcApiInternal) return;
+      if (!ifcApiInternal.properties) {
+        try {
+          ifcApiInternal.properties = new Properties(ifcApiInternal);
+        } catch (e) {
+          console.error('Failed to init properties', e);
+          return;
+        }
+      }
+
+      const classCodes = Object.keys(classifications);
+      const newElements: Record<string, SelectedElementInfo[]> = {};
+      classCodes.forEach((c) => (newElements[c] = []));
+
+      for (const model of loadedModels) {
+        if (model.modelID == null || !model.spatialTree) continue;
+        const elements = getAllElementsFromSpatialTreeNodesRecursive(
+          model.spatialTree ? [model.spatialTree] : []
+        );
+        for (const el of elements) {
+          if (el.expressID === undefined) continue;
+          const props = await getElementPropertiesCached(
+            model.modelID,
+            el.expressID
+          );
+          if (!props) continue;
+          let val: any = undefined;
+          if (psetName) {
+            val = props.propertySets?.[psetName]?.[propertyName];
+          } else {
+            val = props.propertySets?.['Element Attributes']?.[propertyName];
+            if (val === undefined) val = props.attributes?.[propertyName];
+          }
+          if (val && typeof val === 'object' && 'value' in val) val = val.value;
+          if (val === undefined && (el as any)[propertyName] !== undefined) {
+            const direct = (el as any)[propertyName];
+            val = direct?.value !== undefined ? direct.value : direct;
+          }
+          if (val === undefined || val === null) continue;
+          const code = String(val).trim();
+          if (classifications[code]) {
+            const info = { modelID: model.modelID, expressID: el.expressID };
+            if (
+              !newElements[code].some(
+                (e) => e.modelID === info.modelID && e.expressID === info.expressID
+              )
+            ) {
+              newElements[code].push(info);
+            }
+          }
+        }
+      }
+
+      setClassifications((prev) => {
+        const updated = { ...prev };
+        let changed = false;
+        for (const c of classCodes) {
+          const elems = newElements[c] || [];
+          if (JSON.stringify(prev[c].elements || []) !== JSON.stringify(elems)) {
+            updated[c] = { ...prev[c], elements: elems };
+            changed = true;
+          }
+        }
+        if (changed) {
+          console.log('IFCContext: classifications mapped from model');
+        }
+        return updated;
+      });
+    },
+    [
+      ifcApiInternal,
+      classifications,
+      loadedModels,
+      getElementPropertiesCached,
+      getAllElementsFromSpatialTreeNodesRecursive,
+    ]
+  );
+
   const addRule = useCallback(
     (ruleItem: Rule) => {
       setRules((prev) => [...prev, ruleItem]);
@@ -1763,6 +1847,7 @@ export function IFCContextProvider({ children }: { children: ReactNode }) {
         unhideLastElement,
         unhideAllElements,
         toggleModelVisibility,
+        mapClassificationsFromModel,
         naturalIfcClassNames,
         getNaturalIfcClassName,
       }}

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -94,7 +94,8 @@
     "editRule": "Edit Rule",
     "deleteRule": "Delete Rule",
     "previewRule": "Preview Rule Impact",
-    "clearPreview": "Clear Preview"
+    "clearPreview": "Clear Preview",
+    "mapFromModel": "Map From Model"
   },
   "messages": {
     "loading": "Loading...",
@@ -160,7 +161,10 @@
     "classificationSingular": "classification",
     "classificationPlural": "classifications",
     "searchPlaceholder": "Search classifications...",
-    "noSearchResults": "No classifications match your search."
+    "noSearchResults": "No classifications match your search.",
+    "mapFromModelTitle": "Map Classifications from Model",
+    "psetName": "PSet Name",
+    "propertyName": "Property Name"
   },
   "rules": {
     "addNew": "Add New Rule",


### PR DESCRIPTION
## Summary
- support mapping classifications from model properties via new `mapClassificationsFromModel` context method
- expose mapping option in the classifications panel menu with modal dialog
- extend i18n with new strings

## Testing
- `npm run lint`