### PR TITLE
Add wildcard mapping and sort results

### DIFF
--- a/components/classification-panel.tsx
+++ b/components/classification-panel.tsx
@@ -270,6 +270,9 @@ export function ClassificationPanel() {
       // Now perform the actual mapping operation
       await mapClassificationsFromModel(mapPsetName, mapPropertyName);
       setIsMapFromModelDialogOpen(false);
+      // After mapping, show classification colors and sort by elements count
+      if (!showAllClassificationColors) toggleShowAllClassificationColors();
+      setSortConfig({ key: "elementsCount", direction: "descending" });
       // Reset form on success
       setMapPsetName("");
       setMapPropertyName("");

--- a/context/ifc-context.tsx
+++ b/context/ifc-context.tsx
@@ -1491,7 +1491,28 @@ export function IFCContextProvider({ children }: { children: ReactNode }) {
           if (!props) continue;
           let val: any = undefined;
           if (psetName) {
-            val = props.propertySets?.[psetName]?.[propertyName];
+            if (psetName.includes('*')) {
+              const regex = new RegExp(
+                '^' +
+                  psetName
+                    .split('*')
+                    .map((s) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+                    .join('.*') +
+                  '$',
+                'i',
+              );
+              for (const key of Object.keys(props.propertySets || {})) {
+                if (regex.test(key)) {
+                  const v = props.propertySets?.[key]?.[propertyName];
+                  if (v !== undefined && v !== null) {
+                    val = v;
+                    break;
+                  }
+                }
+              }
+            } else {
+              val = props.propertySets?.[psetName]?.[propertyName];
+            }
           } else {
             val = props.propertySets?.['Element Attributes']?.[propertyName];
             if (val === undefined) val = props.attributes?.[propertyName];

--- a/public/locales/de/common.json
+++ b/public/locales/de/common.json
@@ -133,7 +133,7 @@
     "originalColors": "Zeigt die ursprünglichen Modellfarben an (blendet alle Klassifizierungsfarben aus).",
     "classificationColors": "Wendet alle Klassifizierungsfarben auf das Modell an.",
     "canvasSearch": "Elemente nach Eigenschaften filtern. Unterstützt * Platzhalter und Regex.",
-    "psetNameHelp": "Der exakte Name des Eigenschaftssatzes, der die Klassifizierungswerte enthält.",
+    "psetNameHelp": "Name des Eigenschaftssatzes mit Klassifizierungswerten. Unterstützt * Platzhalter.",
     "propertyNameHelp": "Der exakte Name der Eigenschaft, die den Klassifizierungscode oder Kennung enthält."
   },
   "sections": {

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -133,7 +133,7 @@
     "originalColors": "Show original model colors (hides all classification colors).",
     "classificationColors": "Apply all classification colors to the model.",
     "canvasSearch": "Filter elements by properties. Supports * wildcard and regex.",
-    "psetNameHelp": "The exact name of the property set containing classification values",
+    "psetNameHelp": "Name of the property set containing classification values. Supports * wildcard",
     "propertyNameHelp": "The exact name of the property containing the classification code or identifier"
   },
   "sections": {


### PR DESCRIPTION
## Summary
- allow wildcard property set names in model mapping
- auto-sort by element count and show classification colors after mapping
- update tooltips for property set input

## Testing
- `npm run lint`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for wildcard (*) matching when specifying property set names for classification mapping.

- **Improvements**
  - After mapping classifications, the UI now automatically displays all classification colors and sorts the list by element count in descending order for easier review.

- **Documentation**
  - Updated tooltip text to clarify that wildcard matching is supported for property set names in both English and German.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->