### PR TITLE
Clarify auto load setting

### DIFF
--- a/components/settings-panel.tsx
+++ b/components/settings-panel.tsx
@@ -18,7 +18,7 @@ import {
 } from "@/components/ui/tooltip";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Trash2, Check, Plus, Library } from "lucide-react";
+import { Trash2, Check, Plus, Library, Sparkles } from "lucide-react";
 import { useTranslation } from "react-i18next";
 
 interface ModelSource {
@@ -143,7 +143,8 @@ export function SettingsPanel({ onSettingsChanged }: SettingsPanelProps) {
             <div className="grid grid-cols-3 items-center gap-4">
               <Tooltip>
                 <TooltipTrigger asChild>
-                  <Label htmlFor="autoload" className="col-span-1 cursor-help">
+                  <Label htmlFor="autoload" className="col-span-1 cursor-help flex items-center gap-1">
+                    <Sparkles className="h-4 w-4 text-yellow-500" />
                     {t('settings.alwaysApplyOnLoad')}
                   </Label>
                 </TooltipTrigger>

--- a/docs/settings.ts
+++ b/docs/settings.ts
@@ -1,12 +1,12 @@
 const content = {
   en: `- Choose a **Default Classification** to load automatically.
-- Enable **Always apply on load** to classify models as soon as they are opened.
-- Manage a list of model URLs. Demo models can be added with one click.
-- Add your own URL and name to reuse frequently loaded files.
-`,
+  - Enable **Auto load models & classification** to automatically load saved models and apply your chosen classification.
+  - Manage a list of model URLs. Demo models can be added with one click.
+  - Add your own URL and name to reuse frequently loaded files.
+  `,
   de: `- Wähle eine **Default Classification**, die automatisch geladen wird.
-- Aktiviere **Always apply on load**, damit Modelle beim Öffnen sofort klassifiziert werden.
-- Verwalte eine Liste von Modell-URLs. Demo-Modelle können mit einem Klick hinzugefügt werden.
-- Füge eigene URLs und Namen hinzu, um häufig genutzte Dateien schnell zu laden.
+  - Aktiviere **Modelle automatisch laden & klassifizieren**, damit gespeicherte Modelle automatisch geladen und die gewählte Klassifizierung angewendet werden.
+  - Verwalte eine Liste von Modell-URLs. Demo-Modelle können mit einem Klick hinzugefügt werden.
+  - Füge eigene URLs und Namen hinzu, um häufig genutzte Dateien schnell zu laden.
 `};
 export default content;

--- a/public/locales/de/common.json
+++ b/public/locales/de/common.json
@@ -54,7 +54,7 @@
   },
   "settings": {
     "defaultClassification": "Standard-Klassifizierung",
-    "alwaysApplyOnLoad": "Beim Laden automatisch anwenden",
+    "alwaysApplyOnLoad": "Modelle automatisch laden & klassifizieren",
     "modelUrls": "Modell-URLs",
     "demoModels": "Demo-Modelle",
     "name": "Name",
@@ -127,7 +127,7 @@
   },
   "tooltips": {
     "defaultClassification": "Legt das Standard-Klassifizierungssystem fest.",
-    "autoLoad": "Wenn aktiviert, wird die ausgewählte 'Standard-Klassifizierung' beim Laden automatisch angewendet.",
+    "autoLoad": "Wenn aktiviert, werden gespeicherte Modell-URLs automatisch geladen und die ausgewählte 'Standard-Klassifizierung' angewendet.",
     "modelUrls": "Verwalten Sie eine Liste von IFC-Modell-URLs. Sie können benutzerdefinierte URLs hinzufügen oder Demo-Modelle verwenden.",
     "originalColors": "Zeigt die ursprünglichen Modellfarben an (blendet alle Klassifizierungsfarben aus).",
     "classificationColors": "Wendet alle Klassifizierungsfarben auf das Modell an.",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -54,7 +54,7 @@
   },
   "settings": {
     "defaultClassification": "Default Classification",
-    "alwaysApplyOnLoad": "Always apply on load",
+    "alwaysApplyOnLoad": "Auto load models & classification",
     "modelUrls": "Model URLs",
     "demoModels": "Demo Models",
     "name": "Name",
@@ -127,7 +127,7 @@
   },
   "tooltips": {
     "defaultClassification": "Sets the default classification system.",
-    "autoLoad": "If enabled, the selected 'Default Classification' will be automatically applied on load.",
+    "autoLoad": "If enabled, saved model URLs load automatically and the selected 'Default Classification' is applied.",
     "modelUrls": "Manage a list of IFC model URLs. You can add custom URLs or use the demo models.",
     "originalColors": "Show original model colors (hides all classification colors).",
     "classificationColors": "Apply all classification colors to the model.",


### PR DESCRIPTION
## Summary
- clarify that autoload switch loads model URLs and classification
- update docs snippet accordingly
- add Sparkles icon for autoload label

## Testing
- `npm run lint`