### PR TITLE
fix: update error handling in i18n client provider

### DIFF
--- a/app/i18n-client-provider.tsx
+++ b/app/i18n-client-provider.tsx
@@ -73,7 +73,7 @@ export default function I18nClientProvider({
               callback(null, { data, status: response.status });
             } catch (e) {
               console.error("i18next-http-backend request error:", e);
-              callback(e, { data: null as any, status: 0 });
+              callback(e, { data: {}, status: 0 });
             }
           },
         },


### PR DESCRIPTION
- Changed the error callback to return an empty object instead of null when an error occurs during the i18next-http-backend request. This improves the consistency of the response structure.