### PR TITLE
Fix single material display

### DIFF
--- a/services/ifc-properties.ts
+++ b/services/ifc-properties.ts
@@ -298,7 +298,6 @@ export async function getAllElementProperties(
         groupName = `Material: ${materialName}`;
         if (!psetsData[groupName]) psetsData[groupName] = {};
         extractDirectAttributes(matDef, psetsData[groupName], ["Name", "Description"]);
-        if (Object.keys(psetsData[groupName]).length === 0) delete psetsData[groupName];
       } else if (matDefType === "IFCMATERIALLAYERSET") {
         const layerSetName = matDefNameFromIFC || `MatLayerSet_${matDef.expressID}`;
         groupName = `LayerSet: ${layerSetName}`;


### PR DESCRIPTION
## Summary
- keep material info set even when no extra props found so single materials are shown

## Testing
- `npm run lint`
