### PR TITLE
Fix missing translation key for IFC Class

### DIFF
--- a/components/model-info.tsx
+++ b/components/model-info.tsx
@@ -304,7 +304,13 @@ export function ModelInfo() {
     getNaturalIfcClassName,
     getClassificationsForElement,
   } = useIFCContext();
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
+  const lang = i18n.language.startsWith("de") ? "de" : "en";
+  const ifcTypeValue = elementProperties?.ifcType ?? "";
+  const naturalIfcInfo = useMemo(
+    () => getNaturalIfcClassName(ifcTypeValue, lang),
+    [getNaturalIfcClassName, ifcTypeValue, lang],
+  );
 
   const elementClassifications = useMemo(
     () => getClassificationsForElement(selectedElement),
@@ -480,11 +486,11 @@ export function ModelInfo() {
             </TooltipTrigger>
             <TooltipContent side="right" align="start" className="flex flex-col gap-1 z-50">
               <p className="font-medium">
-                {getNaturalIfcClassName(ifcType).name || ifcType}
+                {naturalIfcInfo.name || ifcType}
               </p>
-              {getNaturalIfcClassName(ifcType).schemaUrl && (
+              {naturalIfcInfo.schemaUrl && (
                 <a
-                  href={getNaturalIfcClassName(ifcType).schemaUrl}
+                  href={naturalIfcInfo.schemaUrl}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="text-xs text-blue-500 hover:text-blue-400 hover:underline flex items-center gap-1 mt-1 pt-1 border-t border-border/30"

--- a/components/spatial-tree-panel.tsx
+++ b/components/spatial-tree-panel.tsx
@@ -228,7 +228,7 @@ const TreeNode: React.FC<TreeNodeProps> = ({
   };
 
   const originalIfcType = node.type;
-  const naturalNameResult = getNaturalIfcClassName(originalIfcType);
+  const naturalNameResult = getNaturalIfcClassName(originalIfcType, lang);
   const naturalIfcName = naturalNameResult?.name ?? "";
   const schemaUrl = naturalNameResult?.schemaUrl ?? "";
 
@@ -400,7 +400,8 @@ export function SpatialTreePanel() {
     removeIFCModel,
     getNaturalIfcClassName,
   } = useIFCContext();
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
+  const lang = i18n.language.startsWith("de") ? "de" : "en";
   const [isConfirmRemoveOpen, setIsConfirmRemoveOpen] = useState(false);
   const [modelToRemove, setModelToRemove] = useState<{
     id: string;
@@ -479,7 +480,7 @@ export function SpatialTreePanel() {
       keys: Set<string>
     ): SpatialStructureNode | null => {
       const norm = query.toLowerCase();
-      const naturalResult = getNaturalIfcClassName(node.type);
+      const naturalResult = getNaturalIfcClassName(node.type, lang);
       const natural = naturalResult && naturalResult.name ? naturalResult.name.toLowerCase() : "";
       const name = (node.Name || "").toLowerCase();
       const expressIdString = String(node.expressID);
@@ -501,7 +502,7 @@ export function SpatialTreePanel() {
       }
       return null;
     },
-    [getNaturalIfcClassName]
+    [getNaturalIfcClassName, lang]
   );
 
   const filteredModels = useMemo(() => {

--- a/public/locales/de/common.json
+++ b/public/locales/de/common.json
@@ -19,6 +19,7 @@
   "settingsPanel": "Einstellungen",
   "original": "Original",
   "colors": "Farben",
+  "IFC Class": "IFC-Klasse",
   "ifcModelViewer": "IFC Modell-Viewer",
   "uploadIFCFile": "Laden Sie eine IFC-Datei hoch oder wählen Sie ein Demomodell",
   "loadIFCFile": "IFC-Datei laden",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -19,6 +19,7 @@
   "settingsPanel": "Settings",
   "original": "Original",
   "colors": "Colors",
+  "IFC Class": "IFC Class",
   "ifcModelViewer": "IFC Model Viewer",
   "uploadIFCFile": "Upload an IFC file to get started or choose a demo model",
   "loadIFCFile": "Load IFC File",


### PR DESCRIPTION
## Summary
- add missing `IFC Class` entry to English and German translations
- use language-specific natural IFC class names when displaying IFC types

## Testing
- `npm run lint`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved display of IFC class names to be language-aware, automatically showing names in German or English based on user settings.
- **Bug Fixes**
  - Reduced redundant calls when displaying IFC class names, improving performance.
- **Documentation**
  - Added new translation entries for "IFC Class" in both English and German interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->