### PR TITLE
Fix natural IFC naming with language selection

### DIFF
--- a/components/model-info.tsx
+++ b/components/model-info.tsx
@@ -304,7 +304,7 @@ export function ModelInfo() {
     getNaturalIfcClassName,
     getClassificationsForElement,
   } = useIFCContext();
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
 
   const elementClassifications = useMemo(
     () => getClassificationsForElement(selectedElement),
@@ -456,6 +456,9 @@ export function ModelInfo() {
     materialSets,
   } = processedProps;
 
+  const lang = i18n.language === "de" ? "de" : "en";
+  const naturalIfcInfo = getNaturalIfcClassName(ifcType, lang);
+
   // Render the detailed property information
   return (
     <div className="space-y-2">
@@ -480,11 +483,11 @@ export function ModelInfo() {
             </TooltipTrigger>
             <TooltipContent side="right" align="start" className="flex flex-col gap-1 z-50">
               <p className="font-medium">
-                {getNaturalIfcClassName(ifcType).name || ifcType}
+                {naturalIfcInfo.name || ifcType}
               </p>
-              {getNaturalIfcClassName(ifcType).schemaUrl && (
+              {naturalIfcInfo.schemaUrl && (
                 <a
-                  href={getNaturalIfcClassName(ifcType).schemaUrl}
+                  href={naturalIfcInfo.schemaUrl}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="text-xs text-blue-500 hover:text-blue-400 hover:underline flex items-center gap-1 mt-1 pt-1 border-t border-border/30"

--- a/components/spatial-tree-panel.tsx
+++ b/components/spatial-tree-panel.tsx
@@ -119,6 +119,8 @@ const TreeNode: React.FC<TreeNodeProps> = ({
     showElements,
     userHiddenElements,
   } = useIFCContext();
+  const { i18n } = useTranslation();
+  const lang = i18n.language === "de" ? "de" : "en";
   const memoizedChildren = useMemo(() => node.children || [], [node.children]);
 
   const currentModelIDForNode = isRootModelNode
@@ -228,7 +230,7 @@ const TreeNode: React.FC<TreeNodeProps> = ({
   };
 
   const originalIfcType = node.type;
-  const naturalNameResult = getNaturalIfcClassName(originalIfcType);
+  const naturalNameResult = getNaturalIfcClassName(originalIfcType, lang);
   const naturalIfcName = naturalNameResult?.name ?? "";
   const schemaUrl = naturalNameResult?.schemaUrl ?? "";
 
@@ -400,7 +402,8 @@ export function SpatialTreePanel() {
     removeIFCModel,
     getNaturalIfcClassName,
   } = useIFCContext();
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
+  const lang = i18n.language === "de" ? "de" : "en";
   const [isConfirmRemoveOpen, setIsConfirmRemoveOpen] = useState(false);
   const [modelToRemove, setModelToRemove] = useState<{
     id: string;
@@ -479,7 +482,7 @@ export function SpatialTreePanel() {
       keys: Set<string>
     ): SpatialStructureNode | null => {
       const norm = query.toLowerCase();
-      const naturalResult = getNaturalIfcClassName(node.type);
+      const naturalResult = getNaturalIfcClassName(node.type, lang);
       const natural = naturalResult && naturalResult.name ? naturalResult.name.toLowerCase() : "";
       const name = (node.Name || "").toLowerCase();
       const expressIdString = String(node.expressID);
@@ -501,7 +504,7 @@ export function SpatialTreePanel() {
       }
       return null;
     },
-    [getNaturalIfcClassName]
+    [getNaturalIfcClassName, lang]
   );
 
   const filteredModels = useMemo(() => {


### PR DESCRIPTION
## Summary
- use i18next language when resolving natural IFC class names
- show localized names in model info and spatial tree tooltips

## Testing
- `npm run lint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved language support for IFC class names and schema links, ensuring they are displayed in the user's selected language (German or English) throughout the interface.
- **Bug Fixes**
  - Ensured consistent language-aware display of IFC class information in tooltips and search/filter results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->