### PR TITLE
Fix schema fetch via local proxy

### DIFF
--- a/app/api/proxy/route.ts
+++ b/app/api/proxy/route.ts
@@ -1,0 +1,31 @@
+import { NextRequest } from 'next/server';
+
+export async function GET(request: NextRequest) {
+  const url = request.nextUrl.searchParams.get('url');
+  if (!url) {
+    return new Response('Missing url', { status: 400 });
+  }
+
+  try {
+    const res = await fetch(url, {
+      headers: { 'Accept': 'text/html' }
+    });
+
+    if (!res.ok) {
+      const text = await res.text();
+      return new Response(text, { status: res.status, statusText: res.statusText });
+    }
+
+    const text = await res.text();
+    return new Response(text, {
+      status: 200,
+      headers: {
+        'Content-Type': res.headers.get('content-type') || 'text/html; charset=utf-8',
+        'Access-Control-Allow-Origin': '*'
+      }
+    });
+  } catch (error) {
+    console.error('Proxy fetch failed:', error);
+    return new Response('Proxy error', { status: 500 });
+  }
+}

--- a/components/schema-reader.tsx
+++ b/components/schema-reader.tsx
@@ -886,6 +886,11 @@ export function SchemaReader({
         // Strategy 1: Try enhanced CORS proxies
         const corsProxies = [
             {
+                name: "local",
+                url: (url: string) => `/api/proxy?url=${encodeURIComponent(url)}`,
+                headers: { 'Accept': 'text/html' }
+            },
+            {
                 name: "thingproxy.freeboard.io",
                 url: (url: string) => `https://thingproxy.freeboard.io/fetch/${url}`,
                 headers: { 'Accept': 'text/html' }

--- a/components/ui/cors-status-banner.tsx
+++ b/components/ui/cors-status-banner.tsx
@@ -35,6 +35,7 @@ interface ProxyService {
 
 export function CorsStatusBanner({ className, onDismiss }: CorsStatusBannerProps) {
     const [proxyServices, setProxyServices] = useState<ProxyService[]>([
+        { name: "local", status: 'checking' },
         { name: "thingproxy.freeboard.io", status: 'checking' },
         { name: "crossorigin.me", status: 'checking' },
         { name: "cors.sh", status: 'checking' },
@@ -51,6 +52,9 @@ export function CorsStatusBanner({ className, onDismiss }: CorsStatusBannerProps
         let proxyUrl: string;
 
         switch (service.name) {
+            case 'local':
+                proxyUrl = `/api/proxy?url=${encodeURIComponent(testUrl)}`;
+                break;
             case 'thingproxy.freeboard.io':
                 proxyUrl = `https://thingproxy.freeboard.io/fetch/${testUrl}`;
                 break;

--- a/lib/useSchemaPreview.ts
+++ b/lib/useSchemaPreview.ts
@@ -160,7 +160,7 @@ export function useSchemaPreview(schemaUrl?: string) {
     try {
       const controller = new AbortController();
       const timeoutId = setTimeout(() => controller.abort(), 3000); // 3 second timeout
-      const proxyUrl = `https://thingproxy.freeboard.io/fetch/${url}`;
+      const proxyUrl = `/api/proxy?url=${encodeURIComponent(url)}`;
 
       const res = await fetch(proxyUrl, {
         signal: controller.signal,


### PR DESCRIPTION
## Summary
- add Next.js API route `/api/proxy` to proxy remote docs
- use the local proxy when fetching schema previews
- use the local proxy before external proxies when loading full schema
- include the local proxy in the CORS status banner

## Testing
- `npm run lint`
