### PR TITLE
Add OR condition support to rules

### DIFF
--- a/components/rule-panel.tsx
+++ b/components/rule-panel.tsx
@@ -237,6 +237,7 @@ export function RulePanel() {
           value: "",
         },
       ],
+      matchType: base?.matchType || "all",
       classificationCode:
         base?.classificationCode || Object.keys(classifications)[0] || "",
       active: base?.active ?? true,
@@ -246,7 +247,7 @@ export function RulePanel() {
 
   const openEditRuleDialog = (rule: Rule) => {
     setCurrentRule(rule);
-    setEditingRule({ ...rule });
+    setEditingRule({ matchType: "all", ...rule });
     setIsRuleDialogOpen(true);
   };
 
@@ -634,16 +635,18 @@ export function RulePanel() {
                       {t('rules.conditions')}
                     </div>
                     <div className="space-y-1.5 pl-1">
-                      {rule.conditions.map(
-                        (condition: RuleCondition, index: number) => (
-                          <div
-                            key={index}
-                            className="flex flex-nowrap items-baseline gap-x-2 p-1 bg-muted/30 rounded text-xs"
-                          >
+                      {rule.conditions.map((condition: RuleCondition, index: number) => (
+                        <div key={index} className="space-y-1">
+                          {index > 0 && (
+                            <div className="flex justify-center">
+                              <Badge variant="outline">
+                                {t(`logic.${rule.matchType === 'any' ? 'or' : 'and'}`)}
+                              </Badge>
+                            </div>
+                          )}
+                          <div className="flex flex-nowrap items-baseline gap-x-2 p-1 bg-muted/30 rounded text-xs">
                             <span className="font-medium text-foreground/90 whitespace-nowrap">
-                              {propertyOptions.find(
-                                (p) => p.value === condition.property
-                              )?.label || condition.property}
+                              {propertyOptions.find((p) => p.value === condition.property)?.label || condition.property}
                             </span>
                             <span className="text-muted-foreground whitespace-nowrap">
                               {t(`operators.${condition.operator}`)}
@@ -652,8 +655,8 @@ export function RulePanel() {
                               {String(condition.value)}
                             </span>
                           </div>
-                        )
-                      )}
+                        </div>
+                      ))}
                     </div>
                   </div>
                 )}
@@ -726,17 +729,41 @@ export function RulePanel() {
 
               {/* Conditions Section */}
               <div className="space-y-3">
-                <Label className="font-medium">
-                  {t('rules.conditions')}
-                </Label>
+                <div className="flex items-center justify-between">
+                  <Label className="font-medium">
+                    {t('rules.conditions')}
+                  </Label>
+                  <Select
+                    value={editingRule.matchType || 'all'}
+                    onValueChange={(val) =>
+                      setEditingRule({ ...editingRule!, matchType: val as 'all' | 'any' })
+                    }
+                  >
+                    <SelectTrigger className="w-32">
+                      <SelectValue placeholder={t('rules.matchType')} />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="all">{t('rules.matchAll')}</SelectItem>
+                      <SelectItem value="any">{t('rules.matchAny')}</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
                 <div className="rounded-md border p-3 space-y-3">
                   {editingRule.conditions?.map((condition, index) => (
-                    <div key={index} className="grid sm:grid-cols-12 gap-3 items-center">
-                      <div className="col-span-full sm:col-span-5 mb-2 sm:mb-0">
-                        <div className="relative w-full">
-                          <CreatableCombobox
-                            options={propertyOptions}
-                            value={condition.property}
+                    <div key={index} className="space-y-1">
+                      {index > 0 && (
+                        <div className="flex justify-center">
+                          <Badge variant="outline">
+                            {t(`logic.${editingRule.matchType === 'any' ? 'or' : 'and'}`)}
+                          </Badge>
+                        </div>
+                      )}
+                      <div className="grid sm:grid-cols-12 gap-3 items-center">
+                        <div className="col-span-full sm:col-span-5 mb-2 sm:mb-0">
+                          <div className="relative w-full">
+                            <CreatableCombobox
+                              options={propertyOptions}
+                              value={condition.property}
                             onChange={(value) =>
                               handleConditionChange(index, "property", value)
                             }
@@ -793,6 +820,7 @@ export function RulePanel() {
                         >
                           <Trash2 className="h-4 w-4 text-destructive" />
                         </Button>
+                      </div>
                       </div>
                     </div>
                   ))}

--- a/context/ifc-context.tsx
+++ b/context/ifc-context.tsx
@@ -30,6 +30,7 @@ export interface Rule {
   name: string;
   description: string;
   conditions: RuleCondition[];
+  matchType?: "all" | "any"; // how to combine conditions (AND/OR)
   classificationCode: string;
   active: boolean;
 }
@@ -424,6 +425,7 @@ export function IFCContextProvider({ children }: { children: ReactNode }) {
     async (
       elementNode: SpatialStructureNode,
       conditions: RuleCondition[],
+      matchType: "all" | "any",
       modelID: number,
       api: IfcAPI, // Passed explicitly, not from context state directly in this func
     ): Promise<boolean> => {
@@ -758,9 +760,13 @@ export function IFCContextProvider({ children }: { children: ReactNode }) {
             console.warn("Unsupported operator:", condition.operator);
             return false;
         }
-        if (!conditionMet) return false;
+        if (matchType === "all") {
+          if (!conditionMet) return false;
+        } else {
+          if (conditionMet) return true;
+        }
       }
-      return true;
+      return matchType === "all" ? true : false;
     },
     [],
   );
@@ -877,6 +883,7 @@ export function IFCContextProvider({ children }: { children: ReactNode }) {
             const matches = await matchesAllConditionsCallback(
               elementNode,
               rule.conditions,
+              rule.matchType ?? "all",
               model.modelID,
               ifcApiInternal,
             );
@@ -1020,6 +1027,7 @@ export function IFCContextProvider({ children }: { children: ReactNode }) {
             const matches = await matchesAllConditionsCallback(
               elementNode,
               rule.conditions,
+              rule.matchType ?? "all",
               model.modelID,
               ifcApiInternal,
             );

--- a/public/locales/de/common.json
+++ b/public/locales/de/common.json
@@ -232,6 +232,9 @@
     "operatorPlaceholder": "Operator auswählen",
     "valuePlaceholder": "Wert",
     "booleanValuePlaceholder": "z.B. true, false, ja, nein",
+    "matchType": "Bedingungslogik",
+    "matchAll": "Alle Bedingungen (UND)",
+    "matchAny": "Eine Bedingung genügt (ODER)",
     "selectClassification": "Klassifizierung zum Anwenden auswählen",
     "manageRules": "Regeln verwalten",
     "searchClassificationPlaceholder": "Klassifizierungen suchen oder erstellen...",
@@ -246,6 +249,10 @@
     "contains": "Enthält",
     "greaterThan": "Größer als",
     "lessThan": "Kleiner als"
+  },
+  "logic": {
+    "and": "UND",
+    "or": "ODER"
   },
   "docs": {
     "latestFeaturesTitle": "Neueste Funktionen",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -230,6 +230,9 @@
     "operatorPlaceholder": "Select operator",
     "valuePlaceholder": "Value",
     "booleanValuePlaceholder": "e.g., true, false, yes, no",
+    "matchType": "Condition Logic",
+    "matchAll": "All conditions (AND)",
+    "matchAny": "Any condition (OR)",
     "selectClassification": "Select classification to apply",
     "manageRules": "Manage Rules",
     "searchClassificationPlaceholder": "Search or create classification...",
@@ -244,6 +247,10 @@
     "contains": "Contains",
     "greaterThan": "Greater Than",
     "lessThan": "Less Than"
+  },
+  "logic": {
+    "and": "AND",
+    "or": "OR"
   },
   "docs": {
     "latestFeaturesTitle": "Latest Features",

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -230,6 +230,9 @@
         "operatorPlaceholder": "Sélectionner un opérateur",
         "valuePlaceholder": "Valeur",
         "booleanValuePlaceholder": "ex. true, false, oui, non",
+        "matchType": "Logique des conditions",
+        "matchAll": "Toutes les conditions (ET)",
+        "matchAny": "N'importe quelle condition (OU)",
         "selectClassification": "Sélectionner la classification à appliquer",
         "manageRules": "Gérer les règles",
         "searchClassificationPlaceholder": "Rechercher ou créer une classification...",
@@ -244,6 +247,10 @@
         "contains": "Contient",
         "greaterThan": "Supérieur à",
         "lessThan": "Inférieur à"
+    },
+    "logic": {
+        "and": "ET",
+        "or": "OU"
     },
     "docs": {
         "latestFeaturesTitle": "Dernières fonctionnalités",

--- a/public/locales/it/common.json
+++ b/public/locales/it/common.json
@@ -230,6 +230,9 @@
         "operatorPlaceholder": "Seleziona operatore",
         "valuePlaceholder": "Valore",
         "booleanValuePlaceholder": "es. true, false, sì, no",
+        "matchType": "Logica condizioni",
+        "matchAll": "Tutte le condizioni (E)",
+        "matchAny": "Almeno una condizione (O)",
         "selectClassification": "Seleziona classificazione da applicare",
         "manageRules": "Gestisci regole",
         "searchClassificationPlaceholder": "Cerca o crea classificazione...",
@@ -244,6 +247,10 @@
         "contains": "Contiene",
         "greaterThan": "Maggiore di",
         "lessThan": "Minore di"
+    },
+    "logic": {
+        "and": "E",
+        "or": "O"
     },
     "docs": {
         "latestFeaturesTitle": "Ultime funzionalità",

--- a/services/rule-export-service.ts
+++ b/services/rule-export-service.ts
@@ -13,13 +13,14 @@ export function exportRulesToExcel(rules: Rule[]): ArrayBuffer {
       0
     );
 
-    const header = [
-      "id",
-      "name",
-      "description",
-      "classificationCode",
-      "active",
-    ];
+  const header = [
+    "id",
+    "name",
+    "description",
+    "classificationCode",
+    "active",
+    "matchType",
+  ];
     for (let i = 1; i <= maxConditions; i++) {
       header.push(`property${i}`);
       header.push(`operator${i}`);
@@ -35,6 +36,7 @@ export function exportRulesToExcel(rules: Rule[]): ArrayBuffer {
         rule.description,
         rule.classificationCode,
         rule.active ? 1 : 0,
+        rule.matchType ?? "all",
       ];
 
       rule.conditions.forEach((c) => {

--- a/services/rule-import-service.ts
+++ b/services/rule-import-service.ts
@@ -33,7 +33,10 @@ export async function parseRulesFromExcel(file: File): Promise<Rule[]> {
     const activeRaw = row[idx("active")];
     const active = String(activeRaw).toLowerCase() !== "false" && activeRaw !== 0;
 
-    const start = idx("active") + 1;
+    const matchTypeIdx = idx("matchType");
+    const matchType = matchTypeIdx !== -1 ? String(row[matchTypeIdx] || "all").toLowerCase() as "all" | "any" : "all";
+
+    const start = (matchTypeIdx !== -1 ? matchTypeIdx : idx("active")) + 1;
     const conditions: RuleCondition[] = [];
     for (let col = start; col < header.length; col += 3) {
       const property = row[col];
@@ -54,6 +57,7 @@ export async function parseRulesFromExcel(file: File): Promise<Rule[]> {
       description,
       classificationCode,
       active,
+      matchType,
       conditions,
     });
   }


### PR DESCRIPTION
## Summary
- allow rules to combine conditions with logical OR or AND
- expose `matchType` property on rules
- update rule evaluator for OR logic
- add UI controls and badges for selecting match logic
- include `matchType` when importing/exporting rules
- localize new strings for all languages

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68451d718b7483208d59578f2d924eb4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for configuring how rule conditions are matched, allowing users to choose between "all" (AND) or "any" (OR) logic when defining or editing rules.
  - Introduced a dropdown in the rule editor to select the condition logic type.
  - Visual badges now display the logical operator between conditions in rule lists and editors.

- **Localization**
  - Added new translations for condition logic options and logical operators in English, German, French, and Italian.

- **Import/Export**
  - Excel import and export of rules now includes the condition logic type ("matchType") for each rule.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->