### PR TITLE
Add multi-select capability

### DIFF
--- a/components/classification-panel.tsx
+++ b/components/classification-panel.tsx
@@ -120,7 +120,6 @@ export function ClassificationPanel() {
     showAllClassificationColors,
     toggleShowAllClassificationColors,
     loadedModels,
-    selectedElement,
     selectedElements,
     assignClassificationToElement,
     unassignClassificationFromElement,

--- a/components/ifc-model.tsx
+++ b/components/ifc-model.tsx
@@ -433,7 +433,6 @@ export function IFCModel({ modelData, outlineLayer }: IFCModelProps) {
     ifcApi,
     setSpatialTreeForModel,
     setElementProperties,
-    selectedElement,
     selectedElements,
     highlightedElements,
     highlightedClassificationCode,
@@ -796,7 +795,6 @@ export function IFCModel({ modelData, outlineLayer }: IFCModelProps) {
     console.log(
       `IFCModel (${modelData.id}) - Highlighting Effect Triggered. Dependencies:`,
       {
-        selectedElement,
         highlightedElementsCount: highlightedElements.length,
         classificationsKeys: Object.keys(classifications),
         internalApiIdForEffects,
@@ -828,9 +826,11 @@ export function IFCModel({ modelData, outlineLayer }: IFCModelProps) {
       `IFCModel (${modelData.id}) - Highlighting Effect: currentModelID = ${currentModelID}`
     );
 
-    const selectedExpressIDsInThisModel = selectedElements
-      .filter((el) => el.modelID === currentModelID)
-      .map((el) => el.expressID);
+    const selectedExpressIDsInThisModel = new Set(
+      selectedElements
+        .filter((el) => el.modelID === currentModelID)
+        .map((el) => el.expressID),
+    );
 
     console.log(
       `IFCModel (${modelData.id}) - Highlighting Effect: Selected IDs in this model = ${selectedExpressIDsInThisModel.join(',')}`,
@@ -838,9 +838,11 @@ export function IFCModel({ modelData, outlineLayer }: IFCModelProps) {
       selectedElements
     );
 
-    const highlightedExpressIDsInThisModel = highlightedElements
-      .filter((h) => h.modelID === currentModelID)
-      .map((h) => h.expressID);
+    const highlightedExpressIDsInThisModel = new Set(
+      highlightedElements
+        .filter((h) => h.modelID === currentModelID)
+        .map((h) => h.expressID),
+    );
 
     meshesRef.current.traverse((child) => {
       if (
@@ -965,7 +967,7 @@ export function IFCModel({ modelData, outlineLayer }: IFCModelProps) {
         }
 
         // Step 4: Selected Element (highest priority for visibility and material)
-        if (selectedExpressIDsInThisModel.includes(expressID)) {
+        if (selectedExpressIDsInThisModel.has(expressID)) {
           targetMaterial = selectionMaterial;
           isCurrentlyVisible = true;
           console.log(`SELECT OVERRIDE: Element ${currentModelID}-${expressID} visible despite filtering because it's selected`);
@@ -1046,39 +1048,6 @@ export function IFCModel({ modelData, outlineLayer }: IFCModelProps) {
     return foundMesh;
   };
 
-  // Memoized function for fetching properties
-  const fetchPropertiesForSelectedElement = useCallback(async () => {
-    if (!ifcApi || !selectedElement || internalApiIdForEffects === null || selectedElement.modelID !== internalApiIdForEffects) {
-      if (!selectedElement) setElementProperties(null);
-      return;
-    }
-    const props = await getElementPropertiesCached(internalApiIdForEffects, selectedElement.expressID);
-    if (props) {
-      setElementProperties(props);
-    } else {
-      setElementProperties({ error: "Failed to fetch properties" });
-    }
-  }, [ifcApi, selectedElement, internalApiIdForEffects, setElementProperties, getElementPropertiesCached]);
-
-
-  // Fetch properties effect - This is the useEffect that calls the memoized callback
-  useEffect(() => {
-    if (
-      selectedElement &&
-      internalApiIdForEffects !== null &&
-      selectedElement.modelID === internalApiIdForEffects
-    ) {
-      fetchPropertiesForSelectedElement();
-    } else {
-      setElementProperties(null);
-    }
-  }, [
-    selectedElement,
-    internalApiIdForEffects,
-    fetchPropertiesForSelectedElement,
-    modelData.id, // Added modelData.id here
-    setElementProperties, // Added setElementProperties here
-  ]);
 
   useEffect(() => {
     if (!ifcApi || internalApiIdForEffects === null) return; // baseCoordinationMatrix and setBaseCoordinationMatrix are checked by linter for this effect

--- a/components/ifc-viewer.tsx
+++ b/components/ifc-viewer.tsx
@@ -393,7 +393,7 @@ function SelectionListOverlay() {
 // Define the interface for the actions exposed by CameraActionsController
 export interface CameraActions {
   zoomToExtents: () => void;
-  zoomToSelected: (selection: SelectedElementInfo | null) => void;
+  zoomToSelected: (selections: SelectedElementInfo[]) => void;
 }
 
 // Simple component to capture the scene for external reference
@@ -548,28 +548,31 @@ const CameraActionsController = forwardRef<CameraActions, {}>((props, ref) => {
         );
       }
     },
-    zoomToSelected: (selection: SelectedElementInfo | null) => {
+    zoomToSelected: (selections: SelectedElementInfo[]) => {
       console.log(
         "CameraActionsController: zoomToSelected called with",
-        selection
+        selections,
       );
-      if (!selection || !(camera instanceof THREE.PerspectiveCamera)) return;
+      if (selections.length === 0 || !(camera instanceof THREE.PerspectiveCamera)) return;
 
-      let selectedMesh: THREE.Mesh | null = null;
+      const bbox = new THREE.Box3();
+      let found = false;
       scene.traverse((object) => {
-        if (selectedMesh) return;
         if (
           object instanceof THREE.Mesh &&
-          object.userData.modelID === selection.modelID &&
-          object.userData.expressID === selection.expressID
+          selections.some(
+            (s) =>
+              object.userData.modelID === s.modelID &&
+              object.userData.expressID === s.expressID,
+          )
         ) {
-          selectedMesh = object;
+          bbox.expandByObject(object);
+          found = true;
         }
       });
 
-      if (!selectedMesh) return;
+      if (!found) return;
 
-      const bbox = new THREE.Box3().setFromObject(selectedMesh);
       const center = bbox.getCenter(new THREE.Vector3());
       const sphere = bbox.getBoundingSphere(new THREE.Sphere());
       const radius = sphere.radius;
@@ -583,7 +586,7 @@ const CameraActionsController = forwardRef<CameraActions, {}>((props, ref) => {
         radius / Math.sin(Math.atan(Math.tan(fov / 2) * aspect));
       distance = Math.max(distance, effectiveRadiusForHorizontalFit);
 
-      distance *= 1.5; // Add a bit more padding for single selected objects
+      distance *= 1.5; // Add padding
       if (distance === 0 || !isFinite(distance) || distance < 0.1) distance = 5; // Fallback
       if (distance < pCamera.near * 2) distance = pCamera.near * 2 + radius; // Ensure it's not too close to near plane
 
@@ -807,7 +810,6 @@ function ViewerContent() {
     loadedModels,
     setIfcApi,
     ifcApi,
-    selectedElement,
     selectedElements,
     selectElement,
     toggleUserHideElement,
@@ -867,8 +869,8 @@ function ViewerContent() {
 
   const handleZoomSelected = useCallback(() => {
     console.log("ViewerContent: handleZoomSelected called");
-    cameraActionsRef.current?.zoomToSelected(selectedElement);
-  }, [selectedElement]);
+    cameraActionsRef.current?.zoomToSelected(selectedElements);
+  }, [selectedElements]);
 
   const toggleLeftPanel = () => {
     if (leftPanelRef.current) {
@@ -1364,14 +1366,10 @@ function ViewerContent() {
     }
   }, [ifcEngineReady, hasAutoLoadedModels, loadedModels, addIFCModel]);
 
-  // Re-enable selectedElement logging if desired, or keep it minimal
+  // Log selection changes for debugging
   useEffect(() => {
-    if (selectedElement) {
-      console.log("ViewerContent: Selected element changed: ", selectedElement);
-    } else {
-      console.log("ViewerContent: No element selected / selection cleared.");
-    }
-  }, [selectedElement]);
+    console.log("ViewerContent: Selection changed", selectedElements);
+  }, [selectedElements]);
 
   const customUnhideAllElements = useCallback(() => {
     unhideAllElements();

--- a/components/model-info.tsx
+++ b/components/model-info.tsx
@@ -355,7 +355,6 @@ const getPropertyIcon = (name: string): React.ReactNode => {
 
 export function ModelInfo() {
   const {
-    selectedElement,
     selectedElements,
     loadedModels,
     getNaturalIfcClassName,
@@ -417,15 +416,24 @@ export function ModelInfo() {
   const openSchemaReader = () => {
     if (naturalIfcInfo.schemaUrl) {
       setSelectedSchemaUrl(naturalIfcInfo.schemaUrl);
-      setSelectedIfcClassName(naturalIfcInfo.name || ifcType);
+      setSelectedIfcClassName(naturalIfcInfo.name || ifcType || "");
       setSchemaReaderOpen(true);
     }
   };
 
-  const elementClassifications = useMemo(
-    () => getClassificationsForElement(selectedElement),
-    [getClassificationsForElement, selectedElement],
-  );
+  const elementClassifications = useMemo(() => {
+    if (selectedElements.length === 0) return [] as any[];
+    if (selectedElements.length === 1)
+      return getClassificationsForElement(selectedElements[0]);
+    const sets = selectedElements.map((el) =>
+      getClassificationsForElement(el).map((c) => c.code),
+    );
+    const intersection = sets.reduce((acc, arr) =>
+      acc.filter((code) => arr.includes(code)),
+    sets[0]);
+    const all = getClassificationsForElement(selectedElements[0]);
+    return all.filter((c) => intersection.includes(c.code));
+  }, [getClassificationsForElement, selectedElements]);
 
   // Always compute processedProps, but handle null case
   const processedProps = useMemo(() => {
@@ -521,7 +529,7 @@ export function ModelInfo() {
   // Only show messages for "no selection" and "loading"
 
   // Empty state for no selection
-  if (!selectedElement) {
+  if (selectedElements.length === 0) {
     return (
       <div className="flex items-center justify-center h-full">
         <div className="text-center p-6">
@@ -572,7 +580,9 @@ export function ModelInfo() {
     materialSets,
   } = processedProps;
 
-  const naturalIfcInfo = getNaturalIfcClassName(ifcType, lang);
+  const naturalIfcInfo = ifcType
+    ? getNaturalIfcClassName(ifcType, lang)
+    : { name: t("multipleTypes"), schemaUrl: undefined };
 
   // Render the detailed property information
   return (

--- a/components/spatial-tree-panel.tsx
+++ b/components/spatial-tree-panel.tsx
@@ -86,7 +86,7 @@ interface TreeNodeProps {
   node: SpatialStructureNode;
   level: number;
   onSelectNode: (selection: SelectedElementInfo) => void;
-  selectedElementInfo: SelectedElementInfo | null;
+  selectedElements: SelectedElementInfo[];
   isRootModelNode?: boolean;
   modelFileInfo?: { id: string; name: string; modelID: number | null };
   onAttemptRemoveModel?: (modelId: string, modelName: string) => void;
@@ -103,7 +103,7 @@ const TreeNode: React.FC<TreeNodeProps> = ({
   node,
   level,
   onSelectNode,
-  selectedElementInfo,
+  selectedElements,
   isRootModelNode = false,
   modelFileInfo = { id: "unknown", name: "Model", modelID: null },
   onAttemptRemoveModel,
@@ -201,7 +201,8 @@ const TreeNode: React.FC<TreeNodeProps> = ({
     toggleNodeExpansion(nodeKey);
   };
 
-  const handleSelect = () => {
+  const handleSelect = (e: React.MouseEvent) => {
+    const additive = e.ctrlKey || e.metaKey;
     if (isRootModelNode || modelFileInfo.modelID === null) return;
 
     if (
@@ -214,10 +215,13 @@ const TreeNode: React.FC<TreeNodeProps> = ({
       node.type.includes("SITE") ||
       node.type.includes("PROJECT")
     ) {
-      onSelectNode({
-        modelID: modelFileInfo.modelID,
-        expressID: node.expressID,
-      });
+      onSelectNode(
+        {
+          modelID: modelFileInfo.modelID,
+          expressID: node.expressID,
+        },
+        additive,
+      );
     }
   };
 
@@ -281,8 +285,9 @@ const TreeNode: React.FC<TreeNodeProps> = ({
   const isSelected =
     !isRootModelNode &&
     modelFileInfo.modelID !== null &&
-    selectedElementInfo?.modelID === modelFileInfo.modelID &&
-    selectedElementInfo?.expressID === node.expressID;
+    selectedElements.some(
+      (sel) => sel.modelID === modelFileInfo.modelID && sel.expressID === node.expressID,
+    );
 
   return (
     <>
@@ -431,7 +436,7 @@ const TreeNode: React.FC<TreeNodeProps> = ({
           node={child}
           level={level + 1}
           onSelectNode={onSelectNode}
-          selectedElementInfo={selectedElementInfo}
+          selectedElements={selectedElements}
           isRootModelNode={false}
           modelFileInfo={modelFileInfo}
           onAttemptRemoveModel={onAttemptRemoveModel}
@@ -460,7 +465,8 @@ export function SpatialTreePanel() {
   const {
     loadedModels,
     selectElement,
-    selectedElement,
+    selectedElements,
+    toggleElementSelection,
     ifcApi,
     removeIFCModel,
     getNaturalIfcClassName,
@@ -617,24 +623,22 @@ export function SpatialTreePanel() {
         }
       });
       newScrollKey = null; // Don't scroll during search
-    } else if (
-      selectedElement &&
-      selectedElement.modelID !== null &&
-      loadedModels.length > 0
-    ) {
-      const targetModelID = selectedElement.modelID;
-      const targetExpressID = selectedElement.expressID;
-      const model = loadedModels.find((m) => m.modelID === targetModelID);
+    } else {
+      const activeSel = selectedElements[selectedElements.length - 1];
+      if (activeSel && activeSel.modelID !== null && loadedModels.length > 0) {
+        const targetModelID = activeSel.modelID;
+        const targetExpressID = activeSel.expressID;
+        const model = loadedModels.find((m) => m.modelID === targetModelID);
 
-      if (model && model.spatialTree) {
-        console.log(`Finding path to element: modelID=${targetModelID}, expressID=${targetExpressID}`);
-        const pathResult = findPathToNodeRecursive(
-          model.spatialTree,
-          targetExpressID,
-          targetModelID,
-          [],
-          null,
-        );
+        if (model && model.spatialTree) {
+          console.log(`Finding path to element: modelID=${targetModelID}, expressID=${targetExpressID}`);
+          const pathResult = findPathToNodeRecursive(
+            model.spatialTree,
+            targetExpressID,
+            targetModelID,
+            [],
+            null,
+          );
 
         if (pathResult) {
           console.log(`Path found, expanding keys:`, pathResult.pathKeys);
@@ -657,6 +661,7 @@ export function SpatialTreePanel() {
         } else {
           console.log(`No path found for element: modelID=${targetModelID}, expressID=${targetExpressID}`);
         }
+        }
       }
     }
 
@@ -674,7 +679,7 @@ export function SpatialTreePanel() {
 
     setSelectedNodeKeyForScroll(newScrollKey);
   }, [
-    selectedElement,
+    selectedElements,
     loadedModels,
     findPathToNodeRecursive,
     filteredModels,
@@ -700,11 +705,11 @@ export function SpatialTreePanel() {
     }
   }, [selectedNodeKeyForScroll]);
 
-  const handleNodeSelection = (selection: SelectedElementInfo) => {
+  const handleNodeSelection = (selection: SelectedElementInfo, additive: boolean) => {
     console.log(
       `SpatialTree: Node selected - ModelID: ${selection.modelID}, ExpressID: ${selection.expressID}`,
     );
-    selectElement(selection);
+    toggleElementSelection(selection, additive);
   };
 
   const handleAttemptRemoveModel = (modelId: string, modelName: string) => {
@@ -805,7 +810,7 @@ export function SpatialTreePanel() {
                 node={modelRootNodeForTree}
                 level={0}
                 onSelectNode={handleNodeSelection}
-                selectedElementInfo={selectedElement}
+                selectedElements={selectedElements}
                 isRootModelNode={true}
                 modelFileInfo={{
                   id: modelEntry.id,

--- a/context/ifc-context.tsx
+++ b/context/ifc-context.tsx
@@ -73,10 +73,9 @@ export interface ClassificationItem {
 
 interface IFCContextType {
   loadedModels: LoadedModelData[]; // Array of loaded models
-  selectedElement: SelectedElementInfo | null;
   selectedElements: SelectedElementInfo[];
   highlightedElements: SelectedElementInfo[]; // Assuming highlights can also be model-specific
-  elementProperties: any | null; // Properties of the selectedElement
+  elementProperties: any | null; // Properties of the selection
   availableCategories: Record<number, string[]>; // Categories per modelID
   classifications: Record<string, any>; // Global classifications for now
   rules: Rule[]; // Global rules for now
@@ -183,8 +182,6 @@ const IFCContext = createContext<IFCContextType | undefined>(undefined);
 
 export function IFCContextProvider({ children }: { children: ReactNode }) {
   const [loadedModels, setLoadedModels] = useState<LoadedModelData[]>([]);
-  const [selectedElement, setSelectedElement] =
-    useState<SelectedElementInfo | null>(null);
   const [selectedElements, setSelectedElements] = useState<SelectedElementInfo[]>([]);
   const [highlightedElements, setHighlightedElements] = useState<
     SelectedElementInfo[]
@@ -1086,7 +1083,7 @@ export function IFCContextProvider({ children }: { children: ReactNode }) {
   const commonLoadLogic = useCallback(
     (url: string, name: string, fileIdToUse?: string): LoadedModelData => {
       const id = fileIdToUse || generateFileId();
-      setSelectedElement(null);
+      setSelectedElements([]);
       setElementPropertiesInternal(null);
       setHighlightedElements([]);
       return {
@@ -1100,7 +1097,7 @@ export function IFCContextProvider({ children }: { children: ReactNode }) {
     },
     [
       generateFileId,
-      setSelectedElement,
+      setSelectedElements,
       setElementPropertiesInternal,
       setHighlightedElements,
     ],
@@ -1154,21 +1151,21 @@ export function IFCContextProvider({ children }: { children: ReactNode }) {
         return filtered;
       });
       if (
-        selectedElement &&
-        loadedModels.find((m) => m.id === id)?.modelID ===
-        selectedElement.modelID
+        selectedElements.some(
+          (el) => loadedModels.find((m) => m.id === id)?.modelID === el.modelID,
+        )
       ) {
-        setSelectedElement(null);
+        setSelectedElements([]);
         setElementPropertiesInternal(null);
       }
     },
     [
       ifcApiInternal,
-      selectedElement,
+      selectedElements,
       loadedModels,
       setLoadedModels,
       setAvailableCategoriesInternal,
-      setSelectedElement,
+      setSelectedElements,
       setElementPropertiesInternal,
     ],
   );
@@ -1211,7 +1208,6 @@ export function IFCContextProvider({ children }: { children: ReactNode }) {
       } else {
         setSelectedElements([]);
       }
-      setSelectedElement(selection);
       setHighlightedElements([]);
       setHighlightedClassificationCode(null);
       setShowAllClassificationColors(false);
@@ -1223,7 +1219,6 @@ export function IFCContextProvider({ children }: { children: ReactNode }) {
       }
     },
     [
-      setSelectedElement,
       setHighlightedElements,
       setHighlightedClassificationCode,
       setShowAllClassificationColors,
@@ -1236,7 +1231,6 @@ export function IFCContextProvider({ children }: { children: ReactNode }) {
   const selectElements = useCallback(
     (selection: SelectedElementInfo[]) => {
       setSelectedElements(selection);
-      setSelectedElement(selection.length ? selection[selection.length - 1] : null);
       setHighlightedElements([]);
       setHighlightedClassificationCode(null);
       setShowAllClassificationColors(false);
@@ -1245,7 +1239,6 @@ export function IFCContextProvider({ children }: { children: ReactNode }) {
     },
     [
       setSelectedElements,
-      setSelectedElement,
       setHighlightedElements,
       setHighlightedClassificationCode,
       setShowAllClassificationColors,
@@ -1256,7 +1249,6 @@ export function IFCContextProvider({ children }: { children: ReactNode }) {
 
   const clearSelection = useCallback(() => {
     setSelectedElements([]);
-    setSelectedElement(null);
     setHighlightedElements([]);
     setHighlightedClassificationCode(null);
     setShowAllClassificationColors(false);
@@ -1264,7 +1256,6 @@ export function IFCContextProvider({ children }: { children: ReactNode }) {
     setElementPropertiesInternal(null);
   }, [
     setSelectedElements,
-    setSelectedElement,
     setHighlightedElements,
     setHighlightedClassificationCode,
     setShowAllClassificationColors,
@@ -1294,7 +1285,6 @@ export function IFCContextProvider({ children }: { children: ReactNode }) {
             newSelection = [element];
           }
         }
-        setSelectedElement(newSelection.length ? newSelection[newSelection.length - 1] : null);
         setHighlightedElements([]);
         setHighlightedClassificationCode(null);
         setShowAllClassificationColors(false);
@@ -1305,7 +1295,6 @@ export function IFCContextProvider({ children }: { children: ReactNode }) {
     },
     [
       setSelectedElements,
-      setSelectedElement,
       setHighlightedElements,
       setHighlightedClassificationCode,
       setShowAllClassificationColors,
@@ -1804,23 +1793,25 @@ export function IFCContextProvider({ children }: { children: ReactNode }) {
             "IFCContext: Element was visible, now hiding:",
             elementToToggle,
           );
-          // Check if the element being hidden is the currently selected element
+          // Deselect if the element being hidden was selected
           if (
-            selectedElement &&
-            selectedElement.modelID === elementToToggle.modelID &&
-            selectedElement.expressID === elementToToggle.expressID
+            selectedElements.some(
+              (sel) =>
+                sel.modelID === elementToToggle.modelID &&
+                sel.expressID === elementToToggle.expressID,
+            )
           ) {
             console.log(
               "IFCContext: Deselecting element because it is now hidden.",
             );
-            setSelectedElement(null); // Deselect
-            setElementPropertiesInternal(null); // Clear its properties
+            setSelectedElements([]);
+            setElementPropertiesInternal(null);
           }
           return [...prevHidden, elementToToggle];
         }
       });
     },
-    [selectedElement, setSelectedElement, setElementPropertiesInternal],
+    [selectedElements, setSelectedElements, setElementPropertiesInternal],
   );
 
   const unhideLastElement = useCallback(() => {
@@ -1874,12 +1865,15 @@ export function IFCContextProvider({ children }: { children: ReactNode }) {
             )
           ) {
             if (
-              selectedElement &&
-              selectedElement.modelID === el.modelID &&
-              selectedElement.expressID === el.expressID
+              selectedElements.some(
+                (sel) => sel.modelID === el.modelID && sel.expressID === el.expressID,
+              )
             ) {
-              console.log("IFCContext: Deselecting element that's being hidden:", el);
-              setSelectedElement(null);
+              console.log(
+                "IFCContext: Deselecting element that's being hidden:",
+                el,
+              );
+              setSelectedElements([]);
               setElementPropertiesInternal(null);
             }
             newHidden.push(el);
@@ -1891,7 +1885,7 @@ export function IFCContextProvider({ children }: { children: ReactNode }) {
         return newHidden;
       });
     },
-    [selectedElement, setSelectedElement, setElementPropertiesInternal],
+    [selectedElements, setSelectedElements, setElementPropertiesInternal],
   );
 
   const showElements = useCallback((elements: SelectedElementInfo[]) => {
@@ -1909,7 +1903,6 @@ export function IFCContextProvider({ children }: { children: ReactNode }) {
     <IFCContext.Provider
       value={{
         loadedModels,
-        selectedElement,
         selectedElements,
         highlightedElements,
         elementProperties,


### PR DESCRIPTION
## Summary
- allow selecting multiple elements and manage selection globally
- modify property panel to show only shared properties
- update classification panel to handle all selected elements
- highlight multiple selections in viewer and show overlay list

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font `Inter`)*

------
https://chatgpt.com/codex/tasks/task_e_68492e94e5988320a29dcb8340ac84b0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced support for selecting multiple elements at once throughout the application.
  - Added a selection overlay that displays a list of all currently selected elements.
  - UI controls for classification, visibility, and information panels now operate on multiple selected elements.

- **Refactor**
  - Updated selection logic and related UI components to handle multi-selection instead of single selection.
  - Improved property display by merging and intersecting properties of multiple selected elements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->