### PR TITLE
Enable multi-selection in viewer

### DIFF
--- a/components/classification-panel.tsx
+++ b/components/classification-panel.tsx
@@ -121,6 +121,7 @@ export function ClassificationPanel() {
     toggleShowAllClassificationColors,
     loadedModels,
     selectedElement,
+    selectedElements,
     assignClassificationToElement,
     unassignClassificationFromElement,
     unassignElementFromAllClassifications,
@@ -586,27 +587,25 @@ export function ClassificationPanel() {
   };
 
   const handleAssignSelected = () => {
-    if (selectedElement && highlightedClassificationCode) {
-      assignClassificationToElement(
-        highlightedClassificationCode,
-        selectedElement
+    if (highlightedClassificationCode) {
+      selectedElements.forEach((el) =>
+        assignClassificationToElement(highlightedClassificationCode, el)
       );
     }
   };
 
   const handleUnassignSelected = () => {
-    if (selectedElement && highlightedClassificationCode) {
-      unassignClassificationFromElement(
-        highlightedClassificationCode,
-        selectedElement
+    if (highlightedClassificationCode) {
+      selectedElements.forEach((el) =>
+        unassignClassificationFromElement(highlightedClassificationCode, el)
       );
     }
   };
 
   const handleClearSelected = () => {
-    if (selectedElement) {
-      unassignElementFromAllClassifications(selectedElement);
-    }
+    selectedElements.forEach((el) =>
+      unassignElementFromAllClassifications(el)
+    );
   };
 
   // Component to render each row in the virtualized list
@@ -1356,19 +1355,19 @@ export function ClassificationPanel() {
         </Dialog>
       )}
 
-      {selectedElement && (
+      {selectedElements.length > 0 && (
         <div className="mt-4 space-y-2 border-t pt-4">
           {highlightedClassificationCode ? (
             <>
               <Button className="w-full" onClick={handleAssignSelected}>
-                {t("buttons.assignSelected")}
+                {t("buttons.assignSelected")} {selectedElements.length > 1 && `(${selectedElements.length})`}
               </Button>
               <Button
                 className="w-full"
                 variant="outline"
                 onClick={handleUnassignSelected}
               >
-                {t("buttons.removeSelected")}
+                {t("buttons.removeSelected")} {selectedElements.length > 1 && `(${selectedElements.length})`}
               </Button>
             </>
           ) : (
@@ -1381,7 +1380,7 @@ export function ClassificationPanel() {
             variant="outline"
             onClick={handleClearSelected}
           >
-            {t("buttons.clearFromAll")}
+            {t("buttons.clearFromAll")} {selectedElements.length > 1 && `(${selectedElements.length})`}
           </Button>
         </div>
       )}

--- a/components/ifc-model.tsx
+++ b/components/ifc-model.tsx
@@ -434,6 +434,7 @@ export function IFCModel({ modelData, outlineLayer }: IFCModelProps) {
     setSpatialTreeForModel,
     setElementProperties,
     selectedElement,
+    selectedElements,
     highlightedElements,
     highlightedClassificationCode,
     setModelIDForLoadedModel,
@@ -827,15 +828,13 @@ export function IFCModel({ modelData, outlineLayer }: IFCModelProps) {
       `IFCModel (${modelData.id}) - Highlighting Effect: currentModelID = ${currentModelID}`
     );
 
-    const selectedExpressIDInThisModel =
-      selectedElement?.modelID === currentModelID
-        ? selectedElement.expressID
-        : null;
+    const selectedExpressIDsInThisModel = selectedElements
+      .filter((sel) => sel.modelID === currentModelID)
+      .map((sel) => sel.expressID);
 
     console.log(
-      `IFCModel (${modelData.id}) - Highlighting Effect: Calculated selectedExpressIDInThisModel = ${selectedExpressIDInThisModel}`,
-      `Selected Element from context:`,
-      selectedElement
+      `IFCModel (${modelData.id}) - Highlighting Effect: Selected IDs count = ${selectedExpressIDsInThisModel.length}`,
+      selectedElements
     );
 
     const highlightedExpressIDsInThisModel = highlightedElements
@@ -965,11 +964,7 @@ export function IFCModel({ modelData, outlineLayer }: IFCModelProps) {
         }
 
         // Step 4: Selected Element (highest priority for visibility and material)
-        if (
-          selectedElement &&
-          selectedElement.modelID === currentModelID &&
-          selectedElement.expressID === expressID
-        ) {
+        if (selectedExpressIDsInThisModel.includes(expressID)) {
           targetMaterial = selectionMaterial;
           isCurrentlyVisible = true;
           console.log(`SELECT OVERRIDE: Element ${currentModelID}-${expressID} visible despite filtering because it's selected`);
@@ -1021,6 +1016,7 @@ export function IFCModel({ modelData, outlineLayer }: IFCModelProps) {
     });
   }, [
     selectedElement,
+    selectedElements,
     highlightedElements,
     highlightedClassificationCode,
     classifications,

--- a/components/ifc-viewer.tsx
+++ b/components/ifc-viewer.tsx
@@ -205,7 +205,8 @@ function GlobalInteractionHandler() {
             if (
               selectedElement &&
               selectedElement.modelID === clickedModelID &&
-              selectedElement.expressID === clickedExpressID
+              selectedElement.expressID === clickedExpressID &&
+              !event.ctrlKey
             ) {
               console.log(
                 "GlobalInteractionHandler: Clicked on already selected element. Deselecting."
@@ -216,7 +217,7 @@ function GlobalInteractionHandler() {
                 "GlobalInteractionHandler: Selecting new element:",
                 selectionInfo
               );
-              selectElement(selectionInfo);
+              selectElement(selectionInfo, event.ctrlKey);
             }
           } else {
             console.log(

--- a/components/model-info.tsx
+++ b/components/model-info.tsx
@@ -331,6 +331,7 @@ const getPropertyIcon = (name: string): React.ReactNode => {
 export function ModelInfo() {
   const {
     selectedElement,
+    selectedElements,
     elementProperties,
     loadedModels,
     getNaturalIfcClassName,
@@ -456,7 +457,7 @@ export function ModelInfo() {
   // Only show messages for "no selection" and "loading"
 
   // Empty state for no selection
-  if (!selectedElement) {
+  if (selectedElements.length === 0) {
     return (
       <div className="flex items-center justify-center h-full">
         <div className="text-center p-6">
@@ -468,6 +469,24 @@ export function ModelInfo() {
           </p>
           <p className="text-sm text-foreground/60">
             {t("clickElementToView")}
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  if (selectedElements.length > 1) {
+    return (
+      <div className="flex items-center justify-center h-full">
+        <div className="text-center p-6">
+          <div className="flex justify-center mb-4">
+            <Box className="h-8 w-8 text-foreground/30" />
+          </div>
+          <p className="text-base font-medium text-foreground/80 mb-2">
+            {t("properties")}
+          </p>
+          <p className="text-sm text-foreground/60">
+            {t("messages.multipleSelected", { count: selectedElements.length })}
           </p>
         </div>
       </div>

--- a/components/spatial-tree-panel.tsx
+++ b/components/spatial-tree-panel.tsx
@@ -85,7 +85,7 @@ interface PathFindingResult {
 interface TreeNodeProps {
   node: SpatialStructureNode;
   level: number;
-  onSelectNode: (selection: SelectedElementInfo) => void;
+  onSelectNode: (selection: SelectedElementInfo, additive: boolean) => void;
   selectedElementInfo: SelectedElementInfo | null;
   isRootModelNode?: boolean;
   modelFileInfo?: { id: string; name: string; modelID: number | null };
@@ -201,7 +201,8 @@ const TreeNode: React.FC<TreeNodeProps> = ({
     toggleNodeExpansion(nodeKey);
   };
 
-  const handleSelect = () => {
+  const handleSelect = (e: React.MouseEvent) => {
+    const additive = e.ctrlKey || e.metaKey;
     if (isRootModelNode || modelFileInfo.modelID === null) return;
 
     if (
@@ -214,10 +215,13 @@ const TreeNode: React.FC<TreeNodeProps> = ({
       node.type.includes("SITE") ||
       node.type.includes("PROJECT")
     ) {
-      onSelectNode({
-        modelID: modelFileInfo.modelID,
-        expressID: node.expressID,
-      });
+      onSelectNode(
+        {
+          modelID: modelFileInfo.modelID,
+          expressID: node.expressID,
+        },
+        additive
+      );
     }
   };
 
@@ -700,11 +704,11 @@ export function SpatialTreePanel() {
     }
   }, [selectedNodeKeyForScroll]);
 
-  const handleNodeSelection = (selection: SelectedElementInfo) => {
+  const handleNodeSelection = (selection: SelectedElementInfo, additive: boolean) => {
     console.log(
       `SpatialTree: Node selected - ModelID: ${selection.modelID}, ExpressID: ${selection.expressID}`,
     );
-    selectElement(selection);
+    selectElement(selection, additive);
   };
 
   const handleAttemptRemoveModel = (modelId: string, modelName: string) => {

--- a/context/ifc-context.tsx
+++ b/context/ifc-context.tsx
@@ -74,6 +74,7 @@ export interface ClassificationItem {
 interface IFCContextType {
   loadedModels: LoadedModelData[]; // Array of loaded models
   selectedElement: SelectedElementInfo | null;
+  selectedElements: SelectedElementInfo[];
   highlightedElements: SelectedElementInfo[]; // Assuming highlights can also be model-specific
   elementProperties: any | null; // Properties of the selectedElement
   availableCategories: Record<number, string[]>; // Categories per modelID
@@ -115,7 +116,7 @@ interface IFCContextType {
   ) => void;
   setRawBufferForModel: (id: string, buffer: ArrayBuffer) => void; // Keep this one
 
-  selectElement: (selection: SelectedElementInfo | null) => void;
+  selectElement: (selection: SelectedElementInfo | null, additive?: boolean) => void;
   toggleClassificationHighlight: (classificationCode: string) => void;
   setElementProperties: (properties: any | null) => void;
   setAvailableCategoriesForModel: (
@@ -181,6 +182,7 @@ export function IFCContextProvider({ children }: { children: ReactNode }) {
   const [loadedModels, setLoadedModels] = useState<LoadedModelData[]>([]);
   const [selectedElement, setSelectedElement] =
     useState<SelectedElementInfo | null>(null);
+  const [selectedElements, setSelectedElements] = useState<SelectedElementInfo[]>([]);
   const [highlightedElements, setHighlightedElements] = useState<
     SelectedElementInfo[]
   >([]);
@@ -1150,12 +1152,14 @@ export function IFCContextProvider({ children }: { children: ReactNode }) {
       });
       if (
         selectedElement &&
-        loadedModels.find((m) => m.id === id)?.modelID ===
-        selectedElement.modelID
+        loadedModels.find((m) => m.id === id)?.modelID === selectedElement.modelID
       ) {
         setSelectedElement(null);
         setElementPropertiesInternal(null);
       }
+      setSelectedElements((prev) =>
+        prev.filter((el) => loadedModels.find((m) => m.id === id)?.modelID !== el.modelID),
+      );
     },
     [
       ifcApiInternal,
@@ -1164,6 +1168,7 @@ export function IFCContextProvider({ children }: { children: ReactNode }) {
       setLoadedModels,
       setAvailableCategoriesInternal,
       setSelectedElement,
+      setSelectedElements,
       setElementPropertiesInternal,
     ],
   );
@@ -1200,24 +1205,44 @@ export function IFCContextProvider({ children }: { children: ReactNode }) {
   );
 
   const selectElement = useCallback(
-    (selection: SelectedElementInfo | null) => {
-      setSelectedElement(selection);
+    (selection: SelectedElementInfo | null, additive: boolean = false) => {
       setHighlightedElements([]);
       setHighlightedClassificationCode(null);
       setShowAllClassificationColors(false);
       setPreviewingRuleId(null); // Clear active rule preview
-      if (!selection) {
-        setElementPropertiesInternal(null);
-      } else {
-        // Properties will be fetched by IFCModel's useEffect based on selectedElement change
-        // So, we don't necessarily need to set them to null here if a new selection is made.
-        // However, if the old selectedElement was different, its props should be cleared.
-        // For simplicity, if we are selecting something new (or null), clear old props.
-        setElementPropertiesInternal(null); // Clear old props before new ones are fetched
-      }
+
+      setSelectedElements((prev) => {
+        if (!selection) {
+          setSelectedElement(null);
+          setElementPropertiesInternal(null);
+          return [];
+        }
+
+        if (additive) {
+          const exists = prev.some(
+            (el) => el.modelID === selection.modelID && el.expressID === selection.expressID,
+          );
+          let newArr: SelectedElementInfo[];
+          if (exists) {
+            newArr = prev.filter(
+              (el) => !(el.modelID === selection.modelID && el.expressID === selection.expressID),
+            );
+          } else {
+            newArr = [...prev, selection];
+          }
+          setSelectedElement(newArr.length ? newArr[newArr.length - 1] : null);
+          setElementPropertiesInternal(null);
+          return newArr;
+        } else {
+          setSelectedElement(selection);
+          setElementPropertiesInternal(null);
+          return [selection];
+        }
+      });
     },
     [
       setSelectedElement,
+      setSelectedElements,
       setHighlightedElements,
       setHighlightedClassificationCode,
       setShowAllClassificationColors,
@@ -1728,11 +1753,25 @@ export function IFCContextProvider({ children }: { children: ReactNode }) {
             setSelectedElement(null); // Deselect
             setElementPropertiesInternal(null); // Clear its properties
           }
+          setSelectedElements((prev) =>
+            prev.filter(
+              (el) =>
+                !(
+                  el.modelID === elementToToggle.modelID &&
+                  el.expressID === elementToToggle.expressID
+                ),
+            ),
+          );
           return [...prevHidden, elementToToggle];
         }
       });
     },
-    [selectedElement, setSelectedElement, setElementPropertiesInternal],
+    [
+      selectedElement,
+      setSelectedElement,
+      setSelectedElements,
+      setElementPropertiesInternal,
+    ],
   );
 
   const unhideLastElement = useCallback(() => {
@@ -1790,10 +1829,18 @@ export function IFCContextProvider({ children }: { children: ReactNode }) {
               selectedElement.modelID === el.modelID &&
               selectedElement.expressID === el.expressID
             ) {
-              console.log("IFCContext: Deselecting element that's being hidden:", el);
+              console.log(
+                "IFCContext: Deselecting element that's being hidden:",
+                el,
+              );
               setSelectedElement(null);
               setElementPropertiesInternal(null);
             }
+            setSelectedElements((prev) =>
+              prev.filter(
+                (sel) => !(sel.modelID === el.modelID && sel.expressID === el.expressID),
+              ),
+            );
             newHidden.push(el);
             addedCount++;
           }
@@ -1803,7 +1850,7 @@ export function IFCContextProvider({ children }: { children: ReactNode }) {
         return newHidden;
       });
     },
-    [selectedElement, setSelectedElement, setElementPropertiesInternal],
+    [selectedElement, setSelectedElement, setSelectedElements, setElementPropertiesInternal],
   );
 
   const showElements = useCallback((elements: SelectedElementInfo[]) => {
@@ -1822,6 +1869,7 @@ export function IFCContextProvider({ children }: { children: ReactNode }) {
       value={{
         loadedModels,
         selectedElement,
+        selectedElements,
         highlightedElements,
         elementProperties,
         availableCategories,

--- a/public/locales/de/common.json
+++ b/public/locales/de/common.json
@@ -135,7 +135,8 @@
     "error": "Ein Fehler ist aufgetreten",
     "success": "Erfolg!",
     "noDataAvailable": "Keine Daten verfügbar",
-    "highlightToAssign": "Markieren Sie eine Klassifizierung zum Zuweisen."
+    "highlightToAssign": "Markieren Sie eine Klassifizierung zum Zuweisen.",
+    "multipleSelected": "Mehrere Elemente ausgewählt ({{count}}). Wähle eins, um die Eigenschaften zu sehen."
   },
   "modelViewer": {
     "fitToView": "Ansicht anpassen (E)",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -135,7 +135,8 @@
     "error": "An error occurred",
     "success": "Success!",
     "noDataAvailable": "No data available",
-    "highlightToAssign": "Highlight a classification to assign."
+    "highlightToAssign": "Highlight a classification to assign.",
+    "multipleSelected": "Multiple elements selected ({{count}}). Choose one to view its properties."
   },
   "modelViewer": {
     "fitToView": "Fit to View (E)",

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -135,7 +135,8 @@
         "error": "Une erreur s'est produite",
         "success": "Succès !",
         "noDataAvailable": "Aucune donnée disponible",
-        "highlightToAssign": "Surlignez une classification pour l'assigner."
+        "highlightToAssign": "Surlignez une classification pour l'assigner.",
+        "multipleSelected": "Plusieurs éléments sélectionnés ({{count}}). Choisissez-en un pour voir ses propriétés."
     },
     "modelViewer": {
         "fitToView": "Ajuster à la vue (E)",

--- a/public/locales/it/common.json
+++ b/public/locales/it/common.json
@@ -135,7 +135,8 @@
         "error": "Si è verificato un errore",
         "success": "Successo!",
         "noDataAvailable": "Nessun dato disponibile",
-        "highlightToAssign": "Evidenzia una classificazione per assegnare."
+        "highlightToAssign": "Evidenzia una classificazione per assegnare.",
+        "multipleSelected": "Selezionati più elementi ({{count}}). Scegline uno per vedere le proprietà."
     },
     "modelViewer": {
         "fitToView": "Adatta alla vista (E)",


### PR DESCRIPTION
## Summary
- support multiple element selection in context and viewer
- update IFC model highlights for multi-selection
- adapt tree panel and property panel for multiple selections
- apply manual classification actions to all selected elements
- add translation for multi-selection message

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684930ed460c8320a3127ae6c7f58a86

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enabled selection and management of multiple elements at once, including multi-element classification and batch actions.
  - Added support for Ctrl/Meta key to allow additive (multi-)selection in viewers and tree panels.
  - Updated UI panels to display information and actions for multiple selected elements, including count indicators.

- **Localization**
  - Added new translations for messages related to multiple selection in English, German, French, and Italian.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->