### PR TITLE
Improve onboarding with quick-load actions

### DIFF
--- a/components/classification-panel.tsx
+++ b/components/classification-panel.tsx
@@ -1403,9 +1403,44 @@ export function ClassificationPanel() {
               <p className="text-base font-medium text-foreground/80 mb-2">
                 {t("noClassificationsAdded")}
               </p>
-              <p className="text-sm text-foreground/60">
+              <p className="text-sm text-foreground/60 mb-4">
                 {t("addClassification")}
               </p>
+              <div className="flex flex-col items-center gap-2">
+                {!isLoadingUniclass &&
+                  !errorLoadingUniclass &&
+                  defaultUniclassPr.length > 0 && (
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={handleAddAllUniclassPr}
+                      disabled={areAllUniclassAdded()}
+                    >
+                      {t("buttons.loadUniclass", {
+                        count: defaultUniclassPr.length,
+                      })}
+                    </Button>
+                  )}
+                {!isLoadingEBKPH &&
+                  !errorLoadingEBKPH &&
+                  defaultEBKPH.length > 0 && (
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={handleAddAlleBKPH}
+                      disabled={areAlleBKPHAdded()}
+                    >
+                      {t("buttons.loadEbkph", { count: defaultEBKPH.length })}
+                    </Button>
+                  )}
+                <Button
+                  variant="secondary"
+                  size="sm"
+                  onClick={() => setIsAddDialogOpen(true)}
+                >
+                  {t("buttons.addNewClassification")}
+                </Button>
+              </div>
             </>
           )}
         </div>

--- a/components/rule-panel.tsx
+++ b/components/rule-panel.tsx
@@ -531,9 +531,26 @@ export function RulePanel() {
             <Settings2 className="h-12 w-12 text-foreground/30" />
           </div>
           <p className="text-base font-medium text-foreground/80 mb-2">{t('noRulesDefined')}</p>
-          <p className="text-sm text-foreground/60">
+          <p className="text-sm text-foreground/60 mb-4">
             {t('createRulesDescription')}
           </p>
+          <div className="flex flex-col items-center gap-2">
+            {!isLoadingEBKPHRules &&
+              !errorLoadingEBKPHRules &&
+              defaultEBKPHRules.length > 0 && (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={handleAddDefaultEBKPHRules}
+                  disabled={areAllDefaultEBKPHRulesAdded()}
+                >
+                  {t('rules.loadEbkph', { count: defaultEBKPHRules.length })}
+                </Button>
+              )}
+            <Button variant="secondary" size="sm" onClick={() => openNewRuleDialog()}>
+              {t('rules.addNew')}
+            </Button>
+          </div>
         </div>
       ) : filteredRules.length === 0 ? (
         <div className="text-center py-8 flex-grow flex items-center justify-center">


### PR DESCRIPTION
## Summary
- display helpful actions when no classifications exist
- provide default rule loader when no rules exist

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686e4252982483209e683980dc04f719

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced empty state UI for classification and rule lists, providing clear messages and new action buttons.
  * Added buttons to quickly load default classifications (Uniclass PR, eBKP-H) or rules (eBKP-H) when available, and to add new entries directly from the empty state.
  * Improved layout and spacing for a more user-friendly experience when lists are empty.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->