### PR TITLE
Enhance empty states with quick-add buttons

### DIFF
--- a/components/classification-panel.tsx
+++ b/components/classification-panel.tsx
@@ -1403,9 +1403,43 @@ export function ClassificationPanel() {
               <p className="text-base font-medium text-foreground/80 mb-2">
                 {t("noClassificationsAdded")}
               </p>
-              <p className="text-sm text-foreground/60">
+              <p className="text-sm text-foreground/60 mb-4">
                 {t("addClassification")}
               </p>
+              <div className="flex flex-col sm:flex-row items-center justify-center gap-2">
+                {isLoadingUniclass ? (
+                  <Button disabled>{t("buttons.loadingUniclass")}</Button>
+                ) : errorLoadingUniclass ? (
+                  <Button variant="destructive" disabled>
+                    {t("buttons.uniclassError", { message: errorLoadingUniclass })}
+                  </Button>
+                ) : defaultUniclassPr.length > 0 ? (
+                  <Button
+                    onClick={handleAddAllUniclassPr}
+                    disabled={areAllUniclassAdded()}
+                  >
+                    {t("buttons.loadUniclass", { count: defaultUniclassPr.length })}
+                  </Button>
+                ) : (
+                  <Button disabled>{t("buttons.noUniclassFound")}</Button>
+                )}
+                {isLoadingEBKPH ? (
+                  <Button disabled>{t("buttons.loadingEbkph")}</Button>
+                ) : errorLoadingEBKPH ? (
+                  <Button variant="destructive" disabled>
+                    {t("buttons.ebkphError", { message: errorLoadingEBKPH })}
+                  </Button>
+                ) : defaultEBKPH.length > 0 ? (
+                  <Button
+                    onClick={handleAddAlleBKPH}
+                    disabled={areAlleBKPHAdded()}
+                  >
+                    {t("buttons.loadEbkph", { count: defaultEBKPH.length })}
+                  </Button>
+                ) : (
+                  <Button disabled>{t("buttons.noEbkphFound")}</Button>
+                )}
+              </div>
             </>
           )}
         </div>

--- a/components/rule-panel.tsx
+++ b/components/rule-panel.tsx
@@ -531,9 +531,27 @@ export function RulePanel() {
             <Settings2 className="h-12 w-12 text-foreground/30" />
           </div>
           <p className="text-base font-medium text-foreground/80 mb-2">{t('noRulesDefined')}</p>
-          <p className="text-sm text-foreground/60">
+          <p className="text-sm text-foreground/60 mb-4">
             {t('createRulesDescription')}
           </p>
+          <div className="flex flex-col sm:flex-row items-center justify-center gap-2">
+            {isLoadingEBKPHRules ? (
+              <Button disabled>{t('rules.loadingEbkph')}</Button>
+            ) : errorLoadingEBKPHRules ? (
+              <Button variant="destructive" disabled>
+                {t('rules.ebkphError', { message: errorLoadingEBKPHRules })}
+              </Button>
+            ) : defaultEBKPHRules.length > 0 ? (
+              <Button
+                onClick={handleAddDefaultEBKPHRules}
+                disabled={areAllDefaultEBKPHRulesAdded()}
+              >
+                {t('rules.loadEbkph', { count: defaultEBKPHRules.length })}
+              </Button>
+            ) : (
+              <Button disabled>{t('rules.noEbkphFound')}</Button>
+            )}
+          </div>
         </div>
       ) : filteredRules.length === 0 ? (
         <div className="text-center py-8 flex-grow flex items-center justify-center">


### PR DESCRIPTION
## Summary
- improve empty classification panel with actions to load Uniclass or eBKP-H sets
- show button to load default eBKP-H rules when no rules exist

## Testing
- `npm run lint`
- `npm run build` *(fails: failed to fetch fonts)*

------
https://chatgpt.com/codex/tasks/task_e_686e4252982483209e683980dc04f719