### PR TITLE
Add unclassified view option

### DIFF
--- a/components/classification-panel.tsx
+++ b/components/classification-panel.tsx
@@ -124,7 +124,9 @@ export function ClassificationPanel() {
     toggleClassificationHighlight,
     highlightedClassificationCode,
     showAllClassificationColors,
+    showOnlyUnclassified,
     toggleShowAllClassificationColors,
+    toggleShowOnlyUnclassified,
     loadedModels,
     selectedElement,
     selectedElements,
@@ -947,6 +949,24 @@ export function ClassificationPanel() {
                   </TooltipTrigger>
                   <TooltipContent>
                     <p>{t("tooltips.classificationColors")}</p>
+                  </TooltipContent>
+                </Tooltip>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      size="sm"
+                      className={`px-2 py-1 h-auto rounded-full text-xs transition-all duration-150 ease-in-out flex items-center justify-center ${showOnlyUnclassified ? "bg-primary text-primary-foreground shadow-sm" : "bg-transparent text-muted-foreground hover:bg-accent hover:text-accent-foreground"}`}
+                      onClick={toggleShowOnlyUnclassified}
+                    >
+                      <Eye className={`w-4 h-4 flex-shrink-0 ${showOnlyUnclassified ? "md:mr-1.5" : ""}`} />
+                      <span className={showOnlyUnclassified ? "hidden md:inline" : "hidden"}>
+                        {t("unclassified")}
+                      </span>
+                      <span className="sr-only">{t("tooltips.showUnclassified")}</span>
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    <p>{t("tooltips.showUnclassified")}</p>
                   </TooltipContent>
                 </Tooltip>
               </div>

--- a/components/ifc-model.tsx
+++ b/components/ifc-model.tsx
@@ -441,6 +441,7 @@ export function IFCModel({ modelData, outlineLayer }: IFCModelProps) {
     setAvailableCategoriesForModel,
     classifications,
     showAllClassificationColors,
+    showOnlyUnclassified,
     userHiddenElements,
     hiddenModelIds,
     setRawBufferForModel,
@@ -477,6 +478,15 @@ export function IFCModel({ modelData, outlineLayer }: IFCModelProps) {
       opacity: 0.85, // Slightly more opaque than general highlight
       side: THREE.DoubleSide, // Ensure it's visible from all angles
       depthTest: true, // Standard depth testing
+    });
+  }, []);
+
+  const unclassifiedMaterial = useMemo(() => {
+    return new THREE.MeshStandardMaterial({
+      color: 0x888888,
+      transparent: true,
+      opacity: 0.1,
+      side: THREE.DoubleSide,
     });
   }, []);
 
@@ -517,8 +527,9 @@ export function IFCModel({ modelData, outlineLayer }: IFCModelProps) {
       }
       highlightMaterial.dispose();
       selectionMaterial.dispose();
+      unclassifiedMaterial.dispose();
     };
-  }, [scene, ifcApi, modelData.id, highlightMaterial, selectionMaterial]);
+  }, [scene, ifcApi, modelData.id, highlightMaterial, selectionMaterial, unclassifiedMaterial]);
 
   const createThreeJSGeometry = useCallback(
     (ifcGeomData: any) => {
@@ -858,25 +869,27 @@ export function IFCModel({ modelData, outlineLayer }: IFCModelProps) {
         let targetMaterial: THREE.Material | THREE.Material[] =
           trueOriginalMaterial;
         let isCurrentlyVisible = true;
+        let isUnclassified = true;
+        let elementClassificationColor: string | null = null;
+        for (const classification of Object.values(
+          classifications as Record<string, any>
+        )) {
+          const inCls = classification.elements?.some(
+            (el: SelectedElementInfo) =>
+              el &&
+              el.modelID === currentModelID &&
+              el.expressID === expressID
+          );
+          if (inCls) {
+            elementClassificationColor = classification.color || "#808080";
+            isUnclassified = false;
+            break;
+          }
+        }
 
         // Step 1: Apply "Show All Classification Colors" if active
         if (showAllClassificationColors) {
-          let elementClassificationColor: string | null = null;
-          for (const classification of Object.values(
-            classifications as Record<string, any>
-          )) {
-            const isInClassification = classification.elements?.some(
-              (el: SelectedElementInfo) =>
-                el &&
-                el.modelID === currentModelID &&
-                el.expressID === expressID
-            );
-            if (isInClassification) {
-              elementClassificationColor = classification.color || "#808080";
-              break;
-            }
-          }
-          if (elementClassificationColor) {
+          if (!isUnclassified && elementClassificationColor) {
             let isCorrectMaterial = false;
             if (mesh.material instanceof THREE.MeshStandardMaterial) {
               if (
@@ -898,8 +911,14 @@ export function IFCModel({ modelData, outlineLayer }: IFCModelProps) {
               });
             }
           } else {
-            targetMaterial = trueOriginalMaterial;
+            targetMaterial = unclassifiedMaterial;
           }
+          if (showOnlyUnclassified && !isUnclassified) {
+            isCurrentlyVisible = false;
+          }
+        }
+        if (!showAllClassificationColors && showOnlyUnclassified && !isUnclassified) {
+          isCurrentlyVisible = false;
         }
 
         // Step 2: Apply single highlighted classification effects
@@ -1021,10 +1040,12 @@ export function IFCModel({ modelData, outlineLayer }: IFCModelProps) {
     highlightedClassificationCode,
     classifications,
     showAllClassificationColors,
+    showOnlyUnclassified,
     internalApiIdForEffects,
     ifcApi,
     highlightMaterial,
     selectionMaterial,
+    unclassifiedMaterial,
     userHiddenElements,
     hiddenModelIds,
   ]);

--- a/context/ifc-context.tsx
+++ b/context/ifc-context.tsx
@@ -132,6 +132,7 @@ interface IFCContextType {
     expressID: number,
   ) => Promise<ParsedElementProperties | null>;
   toggleShowAllClassificationColors: () => void; // Added new toggle function
+  toggleShowOnlyUnclassified: () => void;
 
   // Classification and Rule methods (can remain global or be refactored later if needed per model)
   addClassification: (classification: any) => void;
@@ -198,6 +199,8 @@ export function IFCContextProvider({ children }: { children: ReactNode }) {
   const [highlightedClassificationCode, setHighlightedClassificationCode] =
     useState<string | null>(null);
   const [showAllClassificationColors, setShowAllClassificationColors] =
+    useState<boolean>(false);
+  const [showOnlyUnclassified, setShowOnlyUnclassified] =
     useState<boolean>(false);
   const [previewingRuleId, setPreviewingRuleId] = useState<string | null>(null); // Added state
   const [userHiddenElements, setUserHiddenElements] = useState<
@@ -1580,6 +1583,10 @@ export function IFCContextProvider({ children }: { children: ReactNode }) {
     setPreviewingRuleId,
   ]);
 
+  const toggleShowOnlyUnclassified = useCallback(() => {
+    setShowOnlyUnclassified((prev) => !prev);
+  }, []);
+
   const addClassification = useCallback(
     (classificationItem: any) => {
       setClassifications((prev) => ({
@@ -2070,6 +2077,7 @@ export function IFCContextProvider({ children }: { children: ReactNode }) {
         ifcApi: ifcApiInternal,
         highlightedClassificationCode,
         showAllClassificationColors,
+        showOnlyUnclassified,
         previewingRuleId,
         userHiddenElements,
         hiddenModelIds,
@@ -2091,6 +2099,7 @@ export function IFCContextProvider({ children }: { children: ReactNode }) {
         setIfcApi,
         getElementPropertiesCached,
         toggleShowAllClassificationColors,
+        toggleShowOnlyUnclassified,
         baseCoordinationMatrix,
         setBaseCoordinationMatrix: setBaseCoordinationMatrixFn,
         addClassification,

--- a/public/locales/de/common.json
+++ b/public/locales/de/common.json
@@ -50,6 +50,7 @@
   "settingsPanel": "Einstellungen",
   "original": "Original",
   "colors": "Farben",
+  "unclassified": "Unklassifiziert",
   "ifcModelViewer": "IFC Modell-Viewer",
   "uploadIFCFile": "Laden Sie eine IFC-Datei hoch oder wählen Sie ein Demomodell",
   "loadIFCFile": "IFC-Datei laden",
@@ -167,6 +168,7 @@
     "modelUrls": "Verwalten Sie eine Liste von IFC-Modell-URLs. Sie können benutzerdefinierte URLs hinzufügen oder Demo-Modelle verwenden.",
     "originalColors": "Zeigt die ursprünglichen Modellfarben an (blendet alle Klassifizierungsfarben aus).",
     "classificationColors": "Wendet alle Klassifizierungsfarben auf das Modell an.",
+    "showUnclassified": "Nur unklassifizierte Elemente anzeigen.",
     "canvasSearch": "Elemente nach Eigenschaften filtern. Unterstützt * Platzhalter und Regex.",
     "psetNameHelp": "Name des Eigenschaftssatzes mit Klassifizierungswerten. Unterstützt * Platzhalter.",
     "propertyNameHelp": "Der exakte Name der Eigenschaft, die den Klassifizierungscode oder Kennung enthält."

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -50,6 +50,7 @@
   "settingsPanel": "Settings",
   "original": "Original",
   "colors": "Colors",
+  "unclassified": "Unclassified",
   "ifcModelViewer": "IFC Model Viewer",
   "uploadIFCFile": "Upload an IFC file to get started or choose a demo model",
   "loadIFCFile": "Load IFC File",
@@ -167,6 +168,7 @@
     "modelUrls": "Manage a list of IFC model URLs. You can add custom URLs or use the demo models.",
     "originalColors": "Show original model colors (hides all classification colors).",
     "classificationColors": "Apply all classification colors to the model.",
+    "showUnclassified": "Show only unclassified elements.",
     "canvasSearch": "Filter elements by properties. Supports * wildcard and regex.",
     "psetNameHelp": "Name of the property set containing classification values. Supports * wildcard",
     "propertyNameHelp": "The exact name of the property containing the classification code or identifier"

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -50,6 +50,7 @@
     "settingsPanel": "Paramètres",
     "original": "Original",
     "colors": "Couleurs",
+    "unclassified": "Non classé",
     "ifcModelViewer": "Visualiseur de modèle IFC",
     "uploadIFCFile": "Téléchargez un fichier IFC pour commencer ou choisissez un modèle de démonstration",
     "loadIFCFile": "Charger le fichier IFC",
@@ -167,6 +168,7 @@
         "modelUrls": "Gérez une liste d'URLs de modèles IFC. Vous pouvez ajouter des URLs personnalisées ou utiliser les modèles de démonstration.",
         "originalColors": "Afficher les couleurs originales du modèle (masque toutes les couleurs de classification).",
         "classificationColors": "Appliquer toutes les couleurs de classification au modèle.",
+        "showUnclassified": "Afficher uniquement les éléments non classés.",
         "canvasSearch": "Filtrer les éléments par propriétés. Prend en charge le joker * et les regex.",
         "psetNameHelp": "Nom du jeu de propriétés contenant les valeurs de classification. Prend en charge le joker *",
         "propertyNameHelp": "Le nom exact de la propriété contenant le code de classification ou l'identifiant"

--- a/public/locales/it/common.json
+++ b/public/locales/it/common.json
@@ -50,6 +50,7 @@
     "settingsPanel": "Impostazioni",
     "original": "Originale",
     "colors": "Colori",
+    "unclassified": "Non classificato",
     "ifcModelViewer": "Visualizzatore modello IFC",
     "uploadIFCFile": "Carica un file IFC per iniziare o scegli un modello demo",
     "loadIFCFile": "Carica file IFC",
@@ -167,6 +168,7 @@
         "modelUrls": "Gestisci un elenco di URL di modelli IFC. Puoi aggiungere URL personalizzati o utilizzare i modelli demo.",
         "originalColors": "Mostra i colori originali del modello (nasconde tutti i colori di classificazione).",
         "classificationColors": "Applica tutti i colori di classificazione al modello.",
+        "showUnclassified": "Mostra solo gli elementi non classificati.",
         "canvasSearch": "Filtra elementi per proprietà. Supporta jolly * e regex.",
         "psetNameHelp": "Nome del set di proprietà contenente i valori di classificazione. Supporta jolly *",
         "propertyNameHelp": "Il nome esatto della proprietà contenente il codice di classificazione o l'identificatore"


### PR DESCRIPTION
## Summary
- allow toggling visibility of unclassified elements
- fade unclassified elements when showing classification colors
- support isolating unclassified items in viewer
- update translations

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68708ec5344483208415be8d5a5e4412