### PR TITLE
Add unclassified element isolation

### DIFF
--- a/components/classification-panel.tsx
+++ b/components/classification-panel.tsx
@@ -125,6 +125,8 @@ export function ClassificationPanel() {
     highlightedClassificationCode,
     showAllClassificationColors,
     toggleShowAllClassificationColors,
+    showOnlyUnclassified,
+    toggleShowOnlyUnclassified,
     loadedModels,
     selectedElement,
     selectedElements,
@@ -947,6 +949,30 @@ export function ClassificationPanel() {
                   </TooltipTrigger>
                   <TooltipContent>
                     <p>{t("tooltips.classificationColors")}</p>
+                  </TooltipContent>
+                </Tooltip>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      size="sm"
+                      className={`px-2 py-1 h-auto rounded-full text-xs transition-all duration-150 ease-in-out flex items-center justify-center ${showOnlyUnclassified ? "bg-primary text-primary-foreground shadow-sm" : "bg-transparent text-muted-foreground hover:bg-accent hover:text-accent-foreground"}`}
+                      onClick={() => {
+                        toggleShowOnlyUnclassified();
+                      }}
+                    >
+                      <Eye
+                        className={`w-4 h-4 flex-shrink-0 ${showOnlyUnclassified ? "md:mr-1.5" : ""}`}
+                      />
+                      <span className={showOnlyUnclassified ? "hidden md:inline" : "hidden"}>
+                        {t("unclassified")}
+                      </span>
+                      <span className="sr-only">
+                        {t("tooltips.showUnclassifiedOnly")}
+                      </span>
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    <p>{t("tooltips.showUnclassifiedOnly")}</p>
                   </TooltipContent>
                 </Tooltip>
               </div>

--- a/components/ifc-model.tsx
+++ b/components/ifc-model.tsx
@@ -441,6 +441,7 @@ export function IFCModel({ modelData, outlineLayer }: IFCModelProps) {
     setAvailableCategoriesForModel,
     classifications,
     showAllClassificationColors,
+    showOnlyUnclassified,
     userHiddenElements,
     hiddenModelIds,
     setRawBufferForModel,
@@ -859,47 +860,79 @@ export function IFCModel({ modelData, outlineLayer }: IFCModelProps) {
           trueOriginalMaterial;
         let isCurrentlyVisible = true;
 
-        // Step 1: Apply "Show All Classification Colors" if active
-        if (showAllClassificationColors) {
-          let elementClassificationColor: string | null = null;
-          for (const classification of Object.values(
-            classifications as Record<string, any>
-          )) {
-            const isInClassification = classification.elements?.some(
+        // Determine if element is classified
+        let isClassified = false;
+        for (const classification of Object.values(
+          classifications as Record<string, any>
+        )) {
+          if (
+            classification.elements?.some(
               (el: SelectedElementInfo) =>
                 el &&
                 el.modelID === currentModelID &&
-                el.expressID === expressID
-            );
-            if (isInClassification) {
-              elementClassificationColor = classification.color || "#808080";
-              break;
-            }
+                el.expressID === expressID,
+            )
+          ) {
+            isClassified = true;
+            break;
           }
-          if (elementClassificationColor) {
-            let isCorrectMaterial = false;
-            if (mesh.material instanceof THREE.MeshStandardMaterial) {
-              if (
-                mesh.material.color.getHexString().toLowerCase() ===
-                elementClassificationColor.substring(1).toLowerCase() &&
-                mesh.material.opacity === 0.9 &&
-                mesh.material.transparent
-              ) {
-                isCorrectMaterial = true;
-                targetMaterial = mesh.material; // Use existing material instance
+        }
+
+        // Step 1: Apply "Show All Classification Colors" if active
+        if (showAllClassificationColors) {
+          if (isClassified) {
+            let elementClassificationColor: string | null = null;
+            for (const classification of Object.values(
+              classifications as Record<string, any>
+            )) {
+              const isInClassification = classification.elements?.some(
+                (el: SelectedElementInfo) =>
+                  el &&
+                  el.modelID === currentModelID &&
+                  el.expressID === expressID,
+              );
+              if (isInClassification) {
+                elementClassificationColor = classification.color || "#808080";
+                break;
               }
             }
-            if (!isCorrectMaterial) {
-              targetMaterial = new THREE.MeshStandardMaterial({
-                color: new THREE.Color(elementClassificationColor),
-                transparent: true,
-                opacity: 0.9,
-                side: THREE.DoubleSide,
-              });
+            if (elementClassificationColor) {
+              let isCorrectMaterial = false;
+              if (mesh.material instanceof THREE.MeshStandardMaterial) {
+                if (
+                  mesh.material.color.getHexString().toLowerCase() ===
+                    elementClassificationColor.substring(1).toLowerCase() &&
+                  mesh.material.opacity === 0.9 &&
+                  mesh.material.transparent
+                ) {
+                  isCorrectMaterial = true;
+                  targetMaterial = mesh.material;
+                }
+              }
+              if (!isCorrectMaterial) {
+                targetMaterial = new THREE.MeshStandardMaterial({
+                  color: new THREE.Color(elementClassificationColor),
+                  transparent: true,
+                  opacity: 0.9,
+                  side: THREE.DoubleSide,
+                });
+              }
             }
           } else {
-            targetMaterial = trueOriginalMaterial;
+            // Unclassified elements appear faint grey
+            targetMaterial = new THREE.MeshStandardMaterial({
+              color: new THREE.Color("#cccccc"),
+              transparent: true,
+              opacity: 0.1,
+              side: THREE.DoubleSide,
+              wireframe: true,
+            });
           }
+        }
+
+        // Step 1.5: Isolate unclassified if requested
+        if (showOnlyUnclassified && isClassified) {
+          isCurrentlyVisible = false;
         }
 
         // Step 2: Apply single highlighted classification effects
@@ -1027,6 +1060,7 @@ export function IFCModel({ modelData, outlineLayer }: IFCModelProps) {
     selectionMaterial,
     userHiddenElements,
     hiddenModelIds,
+    showOnlyUnclassified,
   ]);
 
   // Renamed to avoid conflict if a global findMeshByExpressID is ever introduced

--- a/context/ifc-context.tsx
+++ b/context/ifc-context.tsx
@@ -83,6 +83,7 @@ interface IFCContextType {
   ifcApi: IfcAPI | null;
   highlightedClassificationCode: string | null;
   showAllClassificationColors: boolean; // Added for global classification colors visibility
+  showOnlyUnclassified: boolean;
   previewingRuleId: string | null; // Added to track active rule preview
   userHiddenElements: SelectedElementInfo[]; // New state for user-hidden elements
   availableProperties: string[]; // Collected property names for rule building
@@ -132,6 +133,7 @@ interface IFCContextType {
     expressID: number,
   ) => Promise<ParsedElementProperties | null>;
   toggleShowAllClassificationColors: () => void; // Added new toggle function
+  toggleShowOnlyUnclassified: () => void;
 
   // Classification and Rule methods (can remain global or be refactored later if needed per model)
   addClassification: (classification: any) => void;
@@ -198,6 +200,8 @@ export function IFCContextProvider({ children }: { children: ReactNode }) {
   const [highlightedClassificationCode, setHighlightedClassificationCode] =
     useState<string | null>(null);
   const [showAllClassificationColors, setShowAllClassificationColors] =
+    useState<boolean>(false);
+  const [showOnlyUnclassified, setShowOnlyUnclassified] =
     useState<boolean>(false);
   const [previewingRuleId, setPreviewingRuleId] = useState<string | null>(null); // Added state
   const [userHiddenElements, setUserHiddenElements] = useState<
@@ -1580,6 +1584,20 @@ export function IFCContextProvider({ children }: { children: ReactNode }) {
     setPreviewingRuleId,
   ]);
 
+  const toggleShowOnlyUnclassified = useCallback(() => {
+    setShowOnlyUnclassified((prev) => !prev);
+    setHighlightedClassificationCode(null);
+    setHighlightedElements([]);
+    setShowAllClassificationColors(false);
+    setPreviewingRuleId(null);
+  }, [
+    setShowOnlyUnclassified,
+    setHighlightedClassificationCode,
+    setHighlightedElements,
+    setShowAllClassificationColors,
+    setPreviewingRuleId,
+  ]);
+
   const addClassification = useCallback(
     (classificationItem: any) => {
       setClassifications((prev) => ({
@@ -2070,6 +2088,7 @@ export function IFCContextProvider({ children }: { children: ReactNode }) {
         ifcApi: ifcApiInternal,
         highlightedClassificationCode,
         showAllClassificationColors,
+        showOnlyUnclassified,
         previewingRuleId,
         userHiddenElements,
         hiddenModelIds,
@@ -2091,6 +2110,7 @@ export function IFCContextProvider({ children }: { children: ReactNode }) {
         setIfcApi,
         getElementPropertiesCached,
         toggleShowAllClassificationColors,
+        toggleShowOnlyUnclassified,
         baseCoordinationMatrix,
         setBaseCoordinationMatrix: setBaseCoordinationMatrixFn,
         addClassification,

--- a/public/locales/de/common.json
+++ b/public/locales/de/common.json
@@ -50,6 +50,7 @@
   "settingsPanel": "Einstellungen",
   "original": "Original",
   "colors": "Farben",
+  "unclassified": "Unklassifiziert",
   "ifcModelViewer": "IFC Modell-Viewer",
   "uploadIFCFile": "Laden Sie eine IFC-Datei hoch oder wählen Sie ein Demomodell",
   "loadIFCFile": "IFC-Datei laden",
@@ -169,7 +170,8 @@
     "classificationColors": "Wendet alle Klassifizierungsfarben auf das Modell an.",
     "canvasSearch": "Elemente nach Eigenschaften filtern. Unterstützt * Platzhalter und Regex.",
     "psetNameHelp": "Name des Eigenschaftssatzes mit Klassifizierungswerten. Unterstützt * Platzhalter.",
-    "propertyNameHelp": "Der exakte Name der Eigenschaft, die den Klassifizierungscode oder Kennung enthält."
+    "propertyNameHelp": "Der exakte Name der Eigenschaft, die den Klassifizierungscode oder Kennung enthält.",
+    "showUnclassifiedOnly": "Nur unklassifizierte Elemente anzeigen"
   },
   "sections": {
     "defaultSets": "Standard-Sets",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -50,6 +50,7 @@
   "settingsPanel": "Settings",
   "original": "Original",
   "colors": "Colors",
+  "unclassified": "Unclassified",
   "ifcModelViewer": "IFC Model Viewer",
   "uploadIFCFile": "Upload an IFC file to get started or choose a demo model",
   "loadIFCFile": "Load IFC File",
@@ -169,7 +170,8 @@
     "classificationColors": "Apply all classification colors to the model.",
     "canvasSearch": "Filter elements by properties. Supports * wildcard and regex.",
     "psetNameHelp": "Name of the property set containing classification values. Supports * wildcard",
-    "propertyNameHelp": "The exact name of the property containing the classification code or identifier"
+    "propertyNameHelp": "The exact name of the property containing the classification code or identifier",
+    "showUnclassifiedOnly": "Show only unclassified elements"
   },
   "sections": {
     "defaultSets": "Default Sets",

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -50,6 +50,7 @@
     "settingsPanel": "Paramètres",
     "original": "Original",
     "colors": "Couleurs",
+    "unclassified": "Non classé",
     "ifcModelViewer": "Visualiseur de modèle IFC",
     "uploadIFCFile": "Téléchargez un fichier IFC pour commencer ou choisissez un modèle de démonstration",
     "loadIFCFile": "Charger le fichier IFC",
@@ -169,7 +170,8 @@
         "classificationColors": "Appliquer toutes les couleurs de classification au modèle.",
         "canvasSearch": "Filtrer les éléments par propriétés. Prend en charge le joker * et les regex.",
         "psetNameHelp": "Nom du jeu de propriétés contenant les valeurs de classification. Prend en charge le joker *",
-        "propertyNameHelp": "Le nom exact de la propriété contenant le code de classification ou l'identifiant"
+        "propertyNameHelp": "Le nom exact de la propriété contenant le code de classification ou l'identifiant",
+        "showUnclassifiedOnly": "Afficher uniquement les éléments non classés"
     },
     "sections": {
         "defaultSets": "Jeux par défaut",

--- a/public/locales/it/common.json
+++ b/public/locales/it/common.json
@@ -50,6 +50,7 @@
     "settingsPanel": "Impostazioni",
     "original": "Originale",
     "colors": "Colori",
+    "unclassified": "Non classificato",
     "ifcModelViewer": "Visualizzatore modello IFC",
     "uploadIFCFile": "Carica un file IFC per iniziare o scegli un modello demo",
     "loadIFCFile": "Carica file IFC",
@@ -169,7 +170,8 @@
         "classificationColors": "Applica tutti i colori di classificazione al modello.",
         "canvasSearch": "Filtra elementi per proprietà. Supporta jolly * e regex.",
         "psetNameHelp": "Nome del set di proprietà contenente i valori di classificazione. Supporta jolly *",
-        "propertyNameHelp": "Il nome esatto della proprietà contenente il codice di classificazione o l'identificatore"
+        "propertyNameHelp": "Il nome esatto della proprietà contenente il codice di classificazione o l'identificatore",
+        "showUnclassifiedOnly": "Mostra solo gli elementi non classificati"
     },
     "sections": {
         "defaultSets": "Set predefiniti",


### PR DESCRIPTION
## Summary
- support toggling an "unclassified" isolation mode in context
- hide classified elements when isolation is active in `IFCModel`
- fade unclassified items in color mode
- add UI button in classification panel for isolating unclassified elements
- localize strings for this feature in EN/DE/FR/IT translations

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font Inter)*

------
https://chatgpt.com/codex/tasks/task_e_68708ec5344483208415be8d5a5e4412

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a toggle button to the classification panel that allows users to display only unclassified elements.
  * Unclassified elements are now visually distinguished and can be isolated in the model view.

* **Localization**
  * Added translations for "Unclassified" and the "Show only unclassified elements" tooltip in English, German, French, and Italian.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->