### PR TITLE
Add unclassified view option

### DIFF
--- a/components/classification-panel.tsx
+++ b/components/classification-panel.tsx
@@ -54,6 +54,7 @@ import {
   Trash2,
   Edit,
   Eye,
+  EyeOff,
   Palette,
   Eraser,
   CircleOff,
@@ -125,6 +126,8 @@ export function ClassificationPanel() {
     highlightedClassificationCode,
     showAllClassificationColors,
     toggleShowAllClassificationColors,
+    showOnlyUnclassified,
+    toggleShowOnlyUnclassified,
     loadedModels,
     selectedElement,
     selectedElements,
@@ -950,6 +953,34 @@ export function ClassificationPanel() {
                   </TooltipContent>
                 </Tooltip>
               </div>
+            </TooltipProvider>
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    size="sm"
+                    className={`p-2 h-auto rounded-full ${showOnlyUnclassified ? "bg-primary text-primary-foreground" : "bg-transparent text-muted-foreground hover:bg-accent hover:text-accent-foreground"}`}
+                    onClick={toggleShowOnlyUnclassified}
+                  >
+                    {showOnlyUnclassified ? (
+                      <EyeOff className="w-4 h-4 md:mr-1.5" />
+                    ) : (
+                      <Eye className="w-4 h-4" />
+                    )}
+                    <span
+                      className={
+                        showOnlyUnclassified ? "hidden md:inline" : "hidden"
+                      }
+                    >
+                      {t("unclassified")}
+                    </span>
+                    <span className="sr-only">{t("tooltips.unclassifiedOnly")}</span>
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>
+                  <p>{t("tooltips.unclassifiedOnly")}</p>
+                </TooltipContent>
+              </Tooltip>
             </TooltipProvider>
             {/* 3-dot Manage Menu */}
             <DropdownMenu>

--- a/components/ifc-model.tsx
+++ b/components/ifc-model.tsx
@@ -441,6 +441,7 @@ export function IFCModel({ modelData, outlineLayer }: IFCModelProps) {
     setAvailableCategoriesForModel,
     classifications,
     showAllClassificationColors,
+    showOnlyUnclassified,
     userHiddenElements,
     hiddenModelIds,
     setRawBufferForModel,
@@ -859,46 +860,63 @@ export function IFCModel({ modelData, outlineLayer }: IFCModelProps) {
           trueOriginalMaterial;
         let isCurrentlyVisible = true;
 
+        // Determine if element is classified
+        const isClassified = Object.values(
+          classifications as Record<string, any>
+        ).some((classification) =>
+          classification.elements?.some(
+            (el: SelectedElementInfo) =>
+              el && el.modelID === currentModelID && el.expressID === expressID
+          )
+        );
+
         // Step 1: Apply "Show All Classification Colors" if active
         if (showAllClassificationColors) {
-          let elementClassificationColor: string | null = null;
-          for (const classification of Object.values(
-            classifications as Record<string, any>
-          )) {
-            const isInClassification = classification.elements?.some(
-              (el: SelectedElementInfo) =>
-                el &&
-                el.modelID === currentModelID &&
-                el.expressID === expressID
-            );
-            if (isInClassification) {
-              elementClassificationColor = classification.color || "#808080";
-              break;
-            }
-          }
-          if (elementClassificationColor) {
-            let isCorrectMaterial = false;
-            if (mesh.material instanceof THREE.MeshStandardMaterial) {
-              if (
-                mesh.material.color.getHexString().toLowerCase() ===
-                elementClassificationColor.substring(1).toLowerCase() &&
-                mesh.material.opacity === 0.9 &&
-                mesh.material.transparent
-              ) {
-                isCorrectMaterial = true;
-                targetMaterial = mesh.material; // Use existing material instance
+          if (isClassified) {
+            let elementClassificationColor: string | null = null;
+            for (const classification of Object.values(
+              classifications as Record<string, any>
+            )) {
+              const isInClassification = classification.elements?.some(
+                (el: SelectedElementInfo) =>
+                  el &&
+                  el.modelID === currentModelID &&
+                  el.expressID === expressID
+              );
+              if (isInClassification) {
+                elementClassificationColor = classification.color || "#808080";
+                break;
               }
             }
-            if (!isCorrectMaterial) {
-              targetMaterial = new THREE.MeshStandardMaterial({
-                color: new THREE.Color(elementClassificationColor),
-                transparent: true,
-                opacity: 0.9,
-                side: THREE.DoubleSide,
-              });
+            if (elementClassificationColor) {
+              let isCorrectMaterial = false;
+              if (mesh.material instanceof THREE.MeshStandardMaterial) {
+                if (
+                  mesh.material.color.getHexString().toLowerCase() ===
+                    elementClassificationColor.substring(1).toLowerCase() &&
+                  mesh.material.opacity === 0.9 &&
+                  mesh.material.transparent
+                ) {
+                  isCorrectMaterial = true;
+                  targetMaterial = mesh.material;
+                }
+              }
+              if (!isCorrectMaterial) {
+                targetMaterial = new THREE.MeshStandardMaterial({
+                  color: new THREE.Color(elementClassificationColor),
+                  transparent: true,
+                  opacity: 0.9,
+                  side: THREE.DoubleSide,
+                });
+              }
             }
           } else {
-            targetMaterial = trueOriginalMaterial;
+            targetMaterial = new THREE.MeshStandardMaterial({
+              color: new THREE.Color("#bbbbbb"),
+              transparent: true,
+              opacity: 0.1,
+              side: THREE.DoubleSide,
+            });
           }
         }
 
@@ -964,7 +982,12 @@ export function IFCModel({ modelData, outlineLayer }: IFCModelProps) {
           console.log(`HIDE: Element ${currentModelID}-${expressID} hidden by user filters`);
         }
 
-        // Step 4: Selected Element (highest priority for visibility and material)
+        // Step 4: If isolating unclassified elements, hide classified ones
+        if (showOnlyUnclassified && isClassified) {
+          isCurrentlyVisible = false;
+        }
+
+        // Step 5: Selected Element (highest priority for visibility and material)
         if (selectedExpressIDsInThisModel.includes(expressID)) {
           targetMaterial = selectionMaterial;
           isCurrentlyVisible = true;
@@ -1027,6 +1050,7 @@ export function IFCModel({ modelData, outlineLayer }: IFCModelProps) {
     selectionMaterial,
     userHiddenElements,
     hiddenModelIds,
+    showOnlyUnclassified,
   ]);
 
   // Renamed to avoid conflict if a global findMeshByExpressID is ever introduced

--- a/context/ifc-context.tsx
+++ b/context/ifc-context.tsx
@@ -83,6 +83,7 @@ interface IFCContextType {
   ifcApi: IfcAPI | null;
   highlightedClassificationCode: string | null;
   showAllClassificationColors: boolean; // Added for global classification colors visibility
+  showOnlyUnclassified: boolean; // New flag to isolate unclassified elements
   previewingRuleId: string | null; // Added to track active rule preview
   userHiddenElements: SelectedElementInfo[]; // New state for user-hidden elements
   availableProperties: string[]; // Collected property names for rule building
@@ -132,6 +133,7 @@ interface IFCContextType {
     expressID: number,
   ) => Promise<ParsedElementProperties | null>;
   toggleShowAllClassificationColors: () => void; // Added new toggle function
+  toggleShowOnlyUnclassified: () => void; // Toggle showing only unclassified elements
 
   // Classification and Rule methods (can remain global or be refactored later if needed per model)
   addClassification: (classification: any) => void;
@@ -198,6 +200,8 @@ export function IFCContextProvider({ children }: { children: ReactNode }) {
   const [highlightedClassificationCode, setHighlightedClassificationCode] =
     useState<string | null>(null);
   const [showAllClassificationColors, setShowAllClassificationColors] =
+    useState<boolean>(false);
+  const [showOnlyUnclassified, setShowOnlyUnclassified] =
     useState<boolean>(false);
   const [previewingRuleId, setPreviewingRuleId] = useState<string | null>(null); // Added state
   const [userHiddenElements, setUserHiddenElements] = useState<
@@ -1580,6 +1584,10 @@ export function IFCContextProvider({ children }: { children: ReactNode }) {
     setPreviewingRuleId,
   ]);
 
+  const toggleShowOnlyUnclassified = useCallback(() => {
+    setShowOnlyUnclassified((prev) => !prev);
+  }, []);
+
   const addClassification = useCallback(
     (classificationItem: any) => {
       setClassifications((prev) => ({
@@ -2091,6 +2099,8 @@ export function IFCContextProvider({ children }: { children: ReactNode }) {
         setIfcApi,
         getElementPropertiesCached,
         toggleShowAllClassificationColors,
+        showOnlyUnclassified,
+        toggleShowOnlyUnclassified,
         baseCoordinationMatrix,
         setBaseCoordinationMatrix: setBaseCoordinationMatrixFn,
         addClassification,

--- a/public/locales/de/common.json
+++ b/public/locales/de/common.json
@@ -50,6 +50,7 @@
   "settingsPanel": "Einstellungen",
   "original": "Original",
   "colors": "Farben",
+  "unclassified": "Unklassiert",
   "ifcModelViewer": "IFC Modell-Viewer",
   "uploadIFCFile": "Laden Sie eine IFC-Datei hoch oder wählen Sie ein Demomodell",
   "loadIFCFile": "IFC-Datei laden",
@@ -167,6 +168,7 @@
     "modelUrls": "Verwalten Sie eine Liste von IFC-Modell-URLs. Sie können benutzerdefinierte URLs hinzufügen oder Demo-Modelle verwenden.",
     "originalColors": "Zeigt die ursprünglichen Modellfarben an (blendet alle Klassifizierungsfarben aus).",
     "classificationColors": "Wendet alle Klassifizierungsfarben auf das Modell an.",
+    "unclassifiedOnly": "Nur unklassierte Elemente anzeigen.",
     "canvasSearch": "Elemente nach Eigenschaften filtern. Unterstützt * Platzhalter und Regex.",
     "psetNameHelp": "Name des Eigenschaftssatzes mit Klassifizierungswerten. Unterstützt * Platzhalter.",
     "propertyNameHelp": "Der exakte Name der Eigenschaft, die den Klassifizierungscode oder Kennung enthält."

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -50,6 +50,7 @@
   "settingsPanel": "Settings",
   "original": "Original",
   "colors": "Colors",
+  "unclassified": "Unclassified",
   "ifcModelViewer": "IFC Model Viewer",
   "uploadIFCFile": "Upload an IFC file to get started or choose a demo model",
   "loadIFCFile": "Load IFC File",
@@ -167,6 +168,7 @@
     "modelUrls": "Manage a list of IFC model URLs. You can add custom URLs or use the demo models.",
     "originalColors": "Show original model colors (hides all classification colors).",
     "classificationColors": "Apply all classification colors to the model.",
+    "unclassifiedOnly": "Show only unclassified elements.",
     "canvasSearch": "Filter elements by properties. Supports * wildcard and regex.",
     "psetNameHelp": "Name of the property set containing classification values. Supports * wildcard",
     "propertyNameHelp": "The exact name of the property containing the classification code or identifier"

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -49,7 +49,8 @@
     "rulesPanel": "Règles",
     "settingsPanel": "Paramètres",
     "original": "Original",
-    "colors": "Couleurs",
+  "colors": "Couleurs",
+  "unclassified": "Non classés",
     "ifcModelViewer": "Visualiseur de modèle IFC",
     "uploadIFCFile": "Téléchargez un fichier IFC pour commencer ou choisissez un modèle de démonstration",
     "loadIFCFile": "Charger le fichier IFC",
@@ -167,6 +168,7 @@
         "modelUrls": "Gérez une liste d'URLs de modèles IFC. Vous pouvez ajouter des URLs personnalisées ou utiliser les modèles de démonstration.",
         "originalColors": "Afficher les couleurs originales du modèle (masque toutes les couleurs de classification).",
         "classificationColors": "Appliquer toutes les couleurs de classification au modèle.",
+        "unclassifiedOnly": "Afficher uniquement les éléments non classés.",
         "canvasSearch": "Filtrer les éléments par propriétés. Prend en charge le joker * et les regex.",
         "psetNameHelp": "Nom du jeu de propriétés contenant les valeurs de classification. Prend en charge le joker *",
         "propertyNameHelp": "Le nom exact de la propriété contenant le code de classification ou l'identifiant"

--- a/public/locales/it/common.json
+++ b/public/locales/it/common.json
@@ -49,7 +49,8 @@
     "rulesPanel": "Regole",
     "settingsPanel": "Impostazioni",
     "original": "Originale",
-    "colors": "Colori",
+  "colors": "Colori",
+  "unclassified": "Non classificato",
     "ifcModelViewer": "Visualizzatore modello IFC",
     "uploadIFCFile": "Carica un file IFC per iniziare o scegli un modello demo",
     "loadIFCFile": "Carica file IFC",
@@ -167,6 +168,7 @@
         "modelUrls": "Gestisci un elenco di URL di modelli IFC. Puoi aggiungere URL personalizzati o utilizzare i modelli demo.",
         "originalColors": "Mostra i colori originali del modello (nasconde tutti i colori di classificazione).",
         "classificationColors": "Applica tutti i colori di classificazione al modello.",
+        "unclassifiedOnly": "Mostra solo gli elementi non classificati.",
         "canvasSearch": "Filtra elementi per proprietà. Supporta jolly * e regex.",
         "psetNameHelp": "Nome del set di proprietà contenente i valori di classificazione. Supporta jolly *",
         "propertyNameHelp": "Il nome esatto della proprietà contenente il codice di classificazione o l'identificatore"


### PR DESCRIPTION
## Summary
- allow toggling visibility of unclassified objects
- fade unclassified objects when classification colours are on
- translate new UI strings

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch `Inter` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68708ec5344483208415be8d5a5e4412

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a toggle button in the classification panel to show only unclassified elements.
  * When enabled, only unclassified elements are displayed in the model viewer, with classified elements hidden.
  * Unclassified elements are visually distinguished with a semi-transparent gray appearance.

* **Localization**
  * Added translations for the new "unclassified" filter and tooltip in English, German, French, and Italian.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->