### PR TITLE
Add unclassified element visibility controls

### DIFF
--- a/components/classification-panel.tsx
+++ b/components/classification-panel.tsx
@@ -125,6 +125,8 @@ export function ClassificationPanel() {
     highlightedClassificationCode,
     showAllClassificationColors,
     toggleShowAllClassificationColors,
+    isolateUnclassified,
+    toggleIsolateUnclassified,
     loadedModels,
     selectedElement,
     selectedElements,
@@ -880,26 +882,28 @@ export function ClassificationPanel() {
                     <Button
                       size="sm"
                       className={`px-2 py-1 h-auto rounded-full text-xs transition-all duration-150 ease-in-out flex items-center justify-center
-                        ${!showAllClassificationColors
+                        ${!showAllClassificationColors && !isolateUnclassified
                           ? "bg-primary text-primary-foreground shadow-sm"
                           : "bg-transparent text-muted-foreground hover:bg-accent hover:text-accent-foreground"
                         }`}
                       onClick={() => {
-                        if (showAllClassificationColors)
+                        if (showAllClassificationColors) {
                           toggleShowAllClassificationColors();
+                        } else if (isolateUnclassified) {
+                          toggleIsolateUnclassified();
+                        }
                       }}
                     >
-                      <CircleOff
-                        className={`w-4 h-4 flex-shrink-0 ${!showAllClassificationColors ? "md:mr-1.5" : ""
-                          }`}
-                      />
-                      <span
-                        className={
-                          !showAllClassificationColors
-                            ? "hidden md:inline"
-                            : "hidden"
-                        }
-                      >
+                        <CircleOff
+                          className={`w-4 h-4 flex-shrink-0 ${!showAllClassificationColors && !isolateUnclassified ? "md:mr-1.5" : ""}`}
+                        />
+                        <span
+                          className={
+                            !showAllClassificationColors && !isolateUnclassified
+                              ? "hidden md:inline"
+                              : "hidden"
+                          }
+                        >
                         {t("original")}
                       </span>
                       <span className="sr-only">
@@ -947,6 +951,28 @@ export function ClassificationPanel() {
                   </TooltipTrigger>
                   <TooltipContent>
                     <p>{t("tooltips.classificationColors")}</p>
+                  </TooltipContent>
+                </Tooltip>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      size="sm"
+                      className={`px-2 py-1 h-auto rounded-full text-xs transition-all duration-150 ease-in-out flex items-center justify-center
+                        ${isolateUnclassified ? "bg-primary text-primary-foreground shadow-sm" : "bg-transparent text-muted-foreground hover:bg-accent hover:text-accent-foreground"}
+                      `}
+                      onClick={() => {
+                        toggleIsolateUnclassified();
+                      }}
+                    >
+                      <Eye className={`w-4 h-4 flex-shrink-0 ${isolateUnclassified ? "md:mr-1.5" : ""}`} />
+                      <span className={isolateUnclassified ? "hidden md:inline" : "hidden"}>
+                        {t("unclassifiedOnly")}
+                      </span>
+                      <span className="sr-only">{t("tooltips.unclassifiedOnly")}</span>
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    <p>{t("tooltips.unclassifiedOnly")}</p>
                   </TooltipContent>
                 </Tooltip>
               </div>

--- a/components/ifc-model.tsx
+++ b/components/ifc-model.tsx
@@ -889,18 +889,36 @@ export function IFCModel({ modelData, outlineLayer }: IFCModelProps) {
                 targetMaterial = mesh.material; // Use existing material instance
               }
             }
-            if (!isCorrectMaterial) {
-              targetMaterial = new THREE.MeshStandardMaterial({
-                color: new THREE.Color(elementClassificationColor),
-                transparent: true,
-                opacity: 0.9,
-                side: THREE.DoubleSide,
-              });
+          if (!isCorrectMaterial) {
+            targetMaterial = new THREE.MeshStandardMaterial({
+              color: new THREE.Color(elementClassificationColor),
+              transparent: true,
+              opacity: 0.9,
+              side: THREE.DoubleSide,
+            });
+          }
+        } else {
+          let isCorrectMaterial = false;
+          if (mesh.material instanceof THREE.MeshStandardMaterial) {
+            if (
+              mesh.material.color.getHexString().toLowerCase() === "cccccc" &&
+              mesh.material.opacity === 0.1 &&
+              mesh.material.transparent
+            ) {
+              isCorrectMaterial = true;
+              targetMaterial = mesh.material;
             }
-          } else {
-            targetMaterial = trueOriginalMaterial;
+          }
+          if (!isCorrectMaterial) {
+            targetMaterial = new THREE.MeshStandardMaterial({
+              color: new THREE.Color("#cccccc"),
+              transparent: true,
+              opacity: 0.1,
+              side: THREE.DoubleSide,
+            });
           }
         }
+      }
 
         // Step 2: Apply single highlighted classification effects
         if (highlightedClassificationCode) {

--- a/context/ifc-context.tsx
+++ b/context/ifc-context.tsx
@@ -173,6 +173,8 @@ interface IFCContextType {
   getClassificationsForElement: (
     element: SelectedElementInfo | null,
   ) => ClassificationItem[];
+  isolateUnclassified: boolean;
+  toggleIsolateUnclassified: () => void;
   mapClassificationsFromModel: (
     psetName: string,
     propertyName: string,
@@ -200,6 +202,10 @@ export function IFCContextProvider({ children }: { children: ReactNode }) {
   const [showAllClassificationColors, setShowAllClassificationColors] =
     useState<boolean>(false);
   const [previewingRuleId, setPreviewingRuleId] = useState<string | null>(null); // Added state
+  const [isolateUnclassified, setIsolateUnclassified] = useState<boolean>(false);
+  const [isolationHiddenElements, setIsolationHiddenElements] = useState<
+    SelectedElementInfo[]
+  >([]);
   const [userHiddenElements, setUserHiddenElements] = useState<
     SelectedElementInfo[]
   >([]); // New state
@@ -1562,6 +1568,17 @@ export function IFCContextProvider({ children }: { children: ReactNode }) {
     [ifcApiInternal],
   );
 
+  const showElements = useCallback((elements: SelectedElementInfo[]) => {
+    setUserHiddenElements((prev) =>
+      prev.filter(
+        (el) =>
+          !elements.some(
+            (e) => e.modelID === el.modelID && e.expressID === el.expressID,
+          ),
+      ),
+    );
+  }, []);
+
   const toggleShowAllClassificationColors = useCallback(() => {
     setShowAllClassificationColors((prev) => {
       const newShowAllState = !prev;
@@ -1569,6 +1586,13 @@ export function IFCContextProvider({ children }: { children: ReactNode }) {
         setHighlightedClassificationCode(null);
         setHighlightedElements([]);
         setPreviewingRuleId(null); // Clear rule preview if showing all colors
+        if (isolateUnclassified) {
+          setIsolateUnclassified(false);
+          if (isolationHiddenElements.length > 0) {
+            showElements(isolationHiddenElements);
+            setIsolationHiddenElements([]);
+          }
+        }
       }
       // If turning off showAll, we don't automatically re-enable a specific preview or highlight.
       return newShowAllState;
@@ -1578,6 +1602,11 @@ export function IFCContextProvider({ children }: { children: ReactNode }) {
     setHighlightedClassificationCode,
     setHighlightedElements,
     setPreviewingRuleId,
+    isolateUnclassified,
+    isolationHiddenElements,
+    showElements,
+    setIsolateUnclassified,
+    setIsolationHiddenElements,
   ]);
 
   const addClassification = useCallback(
@@ -2045,16 +2074,45 @@ export function IFCContextProvider({ children }: { children: ReactNode }) {
     [selectedElement, setSelectedElement, setElementPropertiesInternal],
   );
 
-  const showElements = useCallback((elements: SelectedElementInfo[]) => {
-    setUserHiddenElements((prev) =>
-      prev.filter(
-        (el) =>
-          !elements.some(
-            (e) => e.modelID === el.modelID && e.expressID === el.expressID,
-          ),
-      ),
-    );
-  }, []);
+
+  const toggleIsolateUnclassified = useCallback(() => {
+    setIsolateUnclassified((prev) => {
+      const newState = !prev;
+      if (newState) {
+        setShowAllClassificationColors(false);
+        const allClassified: SelectedElementInfo[] = [];
+        Object.values(classifications).forEach((cls: any) => {
+          if (cls.elements) allClassified.push(...cls.elements);
+        });
+        const uniqueMap = new Map<string, SelectedElementInfo>();
+        allClassified.forEach((el) => {
+          const key = `${el.modelID}-${el.expressID}`;
+          if (!uniqueMap.has(key)) uniqueMap.set(key, el);
+        });
+        const toHide = Array.from(uniqueMap.values()).filter(
+          (el) =>
+            !userHiddenElements.some(
+              (h) => h.modelID === el.modelID && h.expressID === el.expressID,
+            ),
+        );
+        if (toHide.length > 0) hideElements(toHide);
+        setIsolationHiddenElements(toHide);
+      } else {
+        if (isolationHiddenElements.length > 0) {
+          showElements(isolationHiddenElements);
+        }
+        setIsolationHiddenElements([]);
+      }
+      return newState;
+    });
+  }, [
+    classifications,
+    userHiddenElements,
+    hideElements,
+    showElements,
+    isolationHiddenElements,
+    setShowAllClassificationColors,
+  ]);
 
   return (
     <IFCContext.Provider
@@ -2070,6 +2128,7 @@ export function IFCContextProvider({ children }: { children: ReactNode }) {
         ifcApi: ifcApiInternal,
         highlightedClassificationCode,
         showAllClassificationColors,
+        isolateUnclassified,
         previewingRuleId,
         userHiddenElements,
         hiddenModelIds,
@@ -2091,6 +2150,7 @@ export function IFCContextProvider({ children }: { children: ReactNode }) {
         setIfcApi,
         getElementPropertiesCached,
         toggleShowAllClassificationColors,
+        toggleIsolateUnclassified,
         baseCoordinationMatrix,
         setBaseCoordinationMatrix: setBaseCoordinationMatrixFn,
         addClassification,

--- a/public/locales/de/common.json
+++ b/public/locales/de/common.json
@@ -50,6 +50,7 @@
   "settingsPanel": "Einstellungen",
   "original": "Original",
   "colors": "Farben",
+  "unclassifiedOnly": "Nicht klassifiziert",
   "ifcModelViewer": "IFC Modell-Viewer",
   "uploadIFCFile": "Laden Sie eine IFC-Datei hoch oder wählen Sie ein Demomodell",
   "loadIFCFile": "IFC-Datei laden",
@@ -167,6 +168,7 @@
     "modelUrls": "Verwalten Sie eine Liste von IFC-Modell-URLs. Sie können benutzerdefinierte URLs hinzufügen oder Demo-Modelle verwenden.",
     "originalColors": "Zeigt die ursprünglichen Modellfarben an (blendet alle Klassifizierungsfarben aus).",
     "classificationColors": "Wendet alle Klassifizierungsfarben auf das Modell an.",
+    "unclassifiedOnly": "Nur nicht klassifizierte Elemente anzeigen.",
     "canvasSearch": "Elemente nach Eigenschaften filtern. Unterstützt * Platzhalter und Regex.",
     "psetNameHelp": "Name des Eigenschaftssatzes mit Klassifizierungswerten. Unterstützt * Platzhalter.",
     "propertyNameHelp": "Der exakte Name der Eigenschaft, die den Klassifizierungscode oder Kennung enthält."

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -50,6 +50,7 @@
   "settingsPanel": "Settings",
   "original": "Original",
   "colors": "Colors",
+  "unclassifiedOnly": "Unclassified",
   "ifcModelViewer": "IFC Model Viewer",
   "uploadIFCFile": "Upload an IFC file to get started or choose a demo model",
   "loadIFCFile": "Load IFC File",
@@ -167,6 +168,7 @@
     "modelUrls": "Manage a list of IFC model URLs. You can add custom URLs or use the demo models.",
     "originalColors": "Show original model colors (hides all classification colors).",
     "classificationColors": "Apply all classification colors to the model.",
+    "unclassifiedOnly": "Show only unclassified elements.",
     "canvasSearch": "Filter elements by properties. Supports * wildcard and regex.",
     "psetNameHelp": "Name of the property set containing classification values. Supports * wildcard",
     "propertyNameHelp": "The exact name of the property containing the classification code or identifier"

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -50,6 +50,7 @@
     "settingsPanel": "Paramètres",
     "original": "Original",
     "colors": "Couleurs",
+    "unclassifiedOnly": "Non classé",
     "ifcModelViewer": "Visualiseur de modèle IFC",
     "uploadIFCFile": "Téléchargez un fichier IFC pour commencer ou choisissez un modèle de démonstration",
     "loadIFCFile": "Charger le fichier IFC",
@@ -167,6 +168,7 @@
         "modelUrls": "Gérez une liste d'URLs de modèles IFC. Vous pouvez ajouter des URLs personnalisées ou utiliser les modèles de démonstration.",
         "originalColors": "Afficher les couleurs originales du modèle (masque toutes les couleurs de classification).",
         "classificationColors": "Appliquer toutes les couleurs de classification au modèle.",
+        "unclassifiedOnly": "Afficher uniquement les éléments non classés.",
         "canvasSearch": "Filtrer les éléments par propriétés. Prend en charge le joker * et les regex.",
         "psetNameHelp": "Nom du jeu de propriétés contenant les valeurs de classification. Prend en charge le joker *",
         "propertyNameHelp": "Le nom exact de la propriété contenant le code de classification ou l'identifiant"

--- a/public/locales/it/common.json
+++ b/public/locales/it/common.json
@@ -50,6 +50,7 @@
     "settingsPanel": "Impostazioni",
     "original": "Originale",
     "colors": "Colori",
+    "unclassifiedOnly": "Non classificato",
     "ifcModelViewer": "Visualizzatore modello IFC",
     "uploadIFCFile": "Carica un file IFC per iniziare o scegli un modello demo",
     "loadIFCFile": "Carica file IFC",
@@ -167,6 +168,7 @@
         "modelUrls": "Gestisci un elenco di URL di modelli IFC. Puoi aggiungere URL personalizzati o utilizzare i modelli demo.",
         "originalColors": "Mostra i colori originali del modello (nasconde tutti i colori di classificazione).",
         "classificationColors": "Applica tutti i colori di classificazione al modello.",
+        "unclassifiedOnly": "Mostra solo gli elementi non classificati.",
         "canvasSearch": "Filtra elementi per proprietà. Supporta jolly * e regex.",
         "psetNameHelp": "Nome del set di proprietà contenente i valori di classificazione. Supporta jolly *",
         "propertyNameHelp": "Il nome esatto della proprietà contenente il codice di classificazione o l'identificatore"


### PR DESCRIPTION
## Summary
- add isolate-unclassified option in IFC context
- expose unclassified toggle in classification panel UI
- fade unclassified items when showing classification colors
- localize new UI strings
- make unclassified isolation mutually exclusive with other color modes
- fix build error from using `showElements` before declaration

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68708ec5344483208415be8d5a5e4412

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a toggle to isolate and display only unclassified elements in the classification panel.
  * Updated panel controls to support mutual exclusivity between "show all classification colors" and "unclassified only" modes.

* **Improvements**
  * Enhanced material display logic for classified and unclassified elements for clearer visual distinction.

* **Localization**
  * Added translations for the new "Unclassified Only" toggle and tooltip in English, German, French, and Italian.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->