### PR TITLE
Add mobile tab navigation

### DIFF
--- a/components/ifc-viewer.tsx
+++ b/components/ifc-viewer.tsx
@@ -18,6 +18,7 @@ import { IFCModel } from "@/components/ifc-model";
 import { ClassificationPanel } from "@/components/classification-panel";
 import { RulePanel } from "@/components/rule-panel";
 import { SettingsPanel } from "@/components/settings-panel";
+import MobileTabs from "@/components/mobile-tabs";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
@@ -1802,7 +1803,7 @@ function ViewerContent() {
           minSize={15}
           maxSize={40}
           collapsible
-          className="bg-transparent pointer-events-auto" // MODIFIED: Panel itself is transparent
+          className="hidden bg-transparent pointer-events-auto md:block" // hide on mobile
         >
           {/* Inner div has the gradient */}
           <div className="h-full flex flex-col shadow-lg bg-gradient-to-r from-[hsl(var(--card))]">
@@ -1839,7 +1840,7 @@ function ViewerContent() {
           onToggle={handleToggleLeftPanel}
           collapsed={leftPanelCollapsed}
           isLeftSide={true}
-          className="pointer-events-auto"
+          className="hidden pointer-events-auto md:block"
         />
 
         {/* Main content area - Canvas is NO LONGER here */}
@@ -2010,7 +2011,7 @@ function ViewerContent() {
           onToggle={handleToggleRightPanel}
           collapsed={rightPanelCollapsed}
           isLeftSide={false}
-          className="pointer-events-auto"
+          className="hidden pointer-events-auto md:block"
         />
 
         {/* Right sidebar */}
@@ -2021,11 +2022,12 @@ function ViewerContent() {
           minSize={15}
           maxSize={40}
           collapsible
-          className="bg-transparent pointer-events-auto"
+          className="hidden bg-transparent pointer-events-auto md:block"
         >
           <ResponsiveTabs onSettingsChanged={handleSettingsChanged} />
         </Panel>
       </PanelGroup>
+      <MobileTabs onSettingsChanged={handleSettingsChanged} />
     </div>
   );
 }

--- a/components/mobile-tabs.tsx
+++ b/components/mobile-tabs.tsx
@@ -1,0 +1,71 @@
+"use client"
+
+import { useState } from "react";
+import { Layers, Filter, Settings } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet";
+import { ClassificationPanel } from "@/components/classification-panel";
+import { RulePanel } from "@/components/rule-panel";
+import { SettingsPanel } from "@/components/settings-panel";
+
+interface MobileTabsProps {
+  onSettingsChanged: () => void;
+}
+
+export default function MobileTabs({ onSettingsChanged }: MobileTabsProps) {
+  const { t } = useTranslation();
+  const [openTab, setOpenTab] = useState<
+    "classifications" | "rules" | "settings" | null
+  >(null);
+
+  return (
+    <div className="md:hidden">
+      <div className="fixed inset-x-0 bottom-0 z-40 flex h-12 border-t border-border bg-background text-foreground">
+        <Sheet
+          open={openTab === "classifications"}
+          onOpenChange={(o) => setOpenTab(o ? "classifications" : null)}
+        >
+          <SheetTrigger asChild>
+            <button className="flex flex-1 flex-col items-center justify-center text-xs">
+              <Layers className="h-5 w-5" />
+              <span className="leading-none">
+                {t("navigation.classificationsTab")}
+              </span>
+            </button>
+          </SheetTrigger>
+          <SheetContent className="h-[80vh] overflow-y-auto p-2">
+            <ClassificationPanel />
+          </SheetContent>
+        </Sheet>
+        <Sheet
+          open={openTab === "rules"}
+          onOpenChange={(o) => setOpenTab(o ? "rules" : null)}
+        >
+          <SheetTrigger asChild>
+            <button className="flex flex-1 flex-col items-center justify-center text-xs">
+              <Filter className="h-5 w-5" />
+              <span className="leading-none">{t("rulesPanel")}</span>
+            </button>
+          </SheetTrigger>
+          <SheetContent className="h-[80vh] overflow-y-auto p-2">
+            <RulePanel />
+          </SheetContent>
+        </Sheet>
+        <Sheet
+          open={openTab === "settings"}
+          onOpenChange={(o) => setOpenTab(o ? "settings" : null)}
+        >
+          <SheetTrigger asChild>
+            <button className="flex flex-1 flex-col items-center justify-center text-xs">
+              <Settings className="h-5 w-5" />
+              <span className="leading-none">{t("settingsPanel")}</span>
+            </button>
+          </SheetTrigger>
+          <SheetContent className="h-[80vh] overflow-y-auto p-2">
+            <SettingsPanel onSettingsChanged={onSettingsChanged} />
+          </SheetContent>
+        </Sheet>
+      </div>
+    </div>
+  );
+}

--- a/components/ui/sheet.tsx
+++ b/components/ui/sheet.tsx
@@ -1,0 +1,51 @@
+"use client"
+
+import * as React from "react";
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { X } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+const Sheet = DialogPrimitive.Root;
+const SheetTrigger = DialogPrimitive.Trigger;
+const SheetPortal = DialogPrimitive.Portal;
+
+const SheetOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn(
+      "fixed inset-0 z-50 bg-black/50 backdrop-blur-sm",
+      className
+    )}
+    {...props}
+  />
+));
+SheetOverlay.displayName = DialogPrimitive.Overlay.displayName;
+
+const SheetContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <SheetPortal>
+    <SheetOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed inset-x-0 bottom-0 z-50 mt-24 flex flex-col border border-border bg-background rounded-t-md animate-in slide-in-from-bottom-10",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2">
+        <X className="h-4 w-4" />
+        <span className="sr-only">Close</span>
+      </DialogPrimitive.Close>
+    </DialogPrimitive.Content>
+  </SheetPortal>
+));
+SheetContent.displayName = DialogPrimitive.Content.displayName;
+
+export { Sheet, SheetTrigger, SheetContent };


### PR DESCRIPTION
## Summary
- add drawer-style sheet UI component
- add bottom mobile tabs for classifications, rules and settings
- hide sidebars on small screens and show mobile nav

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687cb26532b083208b4a92d009530a72