### PR TITLE
Add mobile layout with bottom navigation

### DIFF
--- a/components/ifc-viewer.tsx
+++ b/components/ifc-viewer.tsx
@@ -67,6 +67,8 @@ import {
   ImperativePanelHandle,
 } from "react-resizable-panels";
 import { useTranslation } from "react-i18next";
+import useIsMobile from "@/lib/hooks/useIsMobile";
+import MobileNav from "@/components/layout/MobileNav";
 // import { EffectComposer, Outline } from "@react-three/postprocessing"; // Comment out post-processing imports
 
 // Define the layer for outlines
@@ -1051,6 +1053,19 @@ function ViewerContent() {
   // Use state to track panel collapsed status for proper icon rendering
   const [leftPanelCollapsed, setLeftPanelCollapsed] = useState(false);
   const [rightPanelCollapsed, setRightPanelCollapsed] = useState(false);
+  const isMobile = useIsMobile();
+
+  useEffect(() => {
+    if (!ifcEngineReady) return;
+    if (isMobile) {
+      leftPanelRef.current?.collapse();
+      rightPanelRef.current?.collapse();
+    } else {
+      leftPanelRef.current?.expand();
+      rightPanelRef.current?.expand();
+    }
+  }, [isMobile, ifcEngineReady]);
+
 
   // Reset search progress when search is cleared
   useEffect(() => {
@@ -1794,53 +1809,57 @@ function ViewerContent() {
           marginTop: "4rem",
         }}
       >
-        {/* Left sidebar */}
-        <Panel
-          id="left-sidebar"
-          ref={leftPanelRef}
-          defaultSize={25}
-          minSize={15}
-          maxSize={40}
-          collapsible
-          className="bg-transparent pointer-events-auto" // MODIFIED: Panel itself is transparent
-        >
-          {/* Inner div has the gradient */}
-          <div className="h-full flex flex-col shadow-lg bg-gradient-to-r from-[hsl(var(--card))]">
-            <div className="p-2 border-b flex justify-between items-center shrink-0">
-              <h3 className="text-sm font-semibold px-2">{t('modelExplorer')}</h3>
-              <FileUpload key={`file-upload-sidebar-${settingsVersion}`} isAdding={true} />
-            </div>
-
-            {/* Vertical panel group for model tree and properties */}
-            <PanelGroup direction="vertical" className="flex-grow">
-              <Panel id="spatial-tree" defaultSize={70} minSize={30}>
-                <div className="h-full overflow-y-auto">
-                  <SpatialTreePanel />
+        {!isMobile && (
+          <>
+            {/* Left sidebar */}
+            <Panel
+              id="left-sidebar"
+              ref={leftPanelRef}
+              defaultSize={25}
+              minSize={15}
+              maxSize={40}
+              collapsible
+              className="bg-transparent pointer-events-auto"
+            >
+              {/* Inner div has the gradient */}
+              <div className="h-full flex flex-col shadow-lg bg-gradient-to-r from-[hsl(var(--card))]">
+                <div className="p-2 border-b flex justify-between items-center shrink-0">
+                  <h3 className="text-sm font-semibold px-2">{t('modelExplorer')}</h3>
+                  <FileUpload key={`file-upload-sidebar-${settingsVersion}`} isAdding={true} />
                 </div>
-              </Panel>
 
-              <ResizeHandleVertical />
+                {/* Vertical panel group for model tree and properties */}
+                <PanelGroup direction="vertical" className="flex-grow">
+                  <Panel id="spatial-tree" defaultSize={70} minSize={30}>
+                    <div className="h-full overflow-y-auto">
+                      <SpatialTreePanel />
+                    </div>
+                  </Panel>
 
-              <Panel id="properties-panel" defaultSize={30} minSize={20}>
-                <div className="h-full flex flex-col">
-                  <div className="p-1 border-b">
-                    <h3 className="text-sm font-semibold px-2">{t('properties')}</h3>
-                  </div>
-                  <div className="p-2 overflow-y-auto flex-grow">
-                    <ModelInfo />
-                  </div>
-                </div>
-              </Panel>
-            </PanelGroup>
-          </div>
-        </Panel>
+                  <ResizeHandleVertical />
 
-        <ResizeHandleHorizontal
-          onToggle={handleToggleLeftPanel}
-          collapsed={leftPanelCollapsed}
-          isLeftSide={true}
-          className="pointer-events-auto"
-        />
+                  <Panel id="properties-panel" defaultSize={30} minSize={20}>
+                    <div className="h-full flex flex-col">
+                      <div className="p-1 border-b">
+                        <h3 className="text-sm font-semibold px-2">{t('properties')}</h3>
+                      </div>
+                      <div className="p-2 overflow-y-auto flex-grow">
+                        <ModelInfo />
+                      </div>
+                    </div>
+                  </Panel>
+                </PanelGroup>
+              </div>
+            </Panel>
+
+            <ResizeHandleHorizontal
+              onToggle={handleToggleLeftPanel}
+              collapsed={leftPanelCollapsed}
+              isLeftSide={true}
+              className="pointer-events-auto"
+            />
+          </>
+        )}
 
         {/* Main content area - Canvas is NO LONGER here */}
         <Panel
@@ -2006,26 +2025,33 @@ function ViewerContent() {
           </div>
         </Panel>
 
-        <ResizeHandleHorizontal
-          onToggle={handleToggleRightPanel}
-          collapsed={rightPanelCollapsed}
-          isLeftSide={false}
-          className="pointer-events-auto"
-        />
+        {!isMobile && (
+          <>
+            <ResizeHandleHorizontal
+              onToggle={handleToggleRightPanel}
+              collapsed={rightPanelCollapsed}
+              isLeftSide={false}
+              className="pointer-events-auto"
+            />
 
-        {/* Right sidebar */}
-        <Panel
-          id="right-sidebar"
-          ref={rightPanelRef}
-          defaultSize={25}
-          minSize={15}
-          maxSize={40}
-          collapsible
-          className="bg-transparent pointer-events-auto"
-        >
-          <ResponsiveTabs onSettingsChanged={handleSettingsChanged} />
-        </Panel>
+            {/* Right sidebar */}
+            <Panel
+              id="right-sidebar"
+              ref={rightPanelRef}
+              defaultSize={25}
+              minSize={15}
+              maxSize={40}
+              collapsible
+              className="bg-transparent pointer-events-auto"
+            >
+              <ResponsiveTabs onSettingsChanged={handleSettingsChanged} />
+            </Panel>
+          </>
+        )}
       </PanelGroup>
+      {isMobile && (
+        <MobileNav onSettingsChanged={handleSettingsChanged} />
+      )}
     </div>
   );
 }

--- a/components/layout/MobileNav.tsx
+++ b/components/layout/MobileNav.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { ListTree, Layers, Filter, Settings } from "lucide-react";
+
+import { Sheet, SheetContent } from "@/components/ui/sheet";
+import { SpatialTreePanel } from "@/components/spatial-tree-panel";
+import { ModelInfo } from "@/components/model-info";
+import { ClassificationPanel } from "@/components/classification-panel";
+import { RulePanel } from "@/components/rule-panel";
+import { SettingsPanel } from "@/components/settings-panel";
+
+interface MobileNavProps {
+  onSettingsChanged: () => void;
+}
+
+export default function MobileNav({ onSettingsChanged }: MobileNavProps) {
+  const { t } = useTranslation();
+  const [active, setActive] = useState<null | "explore" | "classify" | "rules" | "settings">(null);
+
+  const close = () => setActive(null);
+
+  return (
+    <>
+      <nav className="md:hidden fixed bottom-0 left-0 right-0 z-40 flex justify-around border-t border-border bg-background/95 backdrop-blur">
+        <button onClick={() => setActive("explore")} className="flex flex-col items-center py-2 px-3 text-xs" aria-label={t('modelExplorer')}> 
+          <ListTree className="h-5 w-5" />
+          {t('modelExplorerShort') || t('modelExplorer')}
+        </button>
+        <button onClick={() => setActive("classify")} className="flex flex-col items-center py-2 px-3 text-xs" aria-label={t('navigation.classificationsTab')}>
+          <Layers className="h-5 w-5" />
+          {t('classifyShort') || t('navigation.classificationsTab')}
+        </button>
+        <button onClick={() => setActive("rules")} className="flex flex-col items-center py-2 px-3 text-xs" aria-label={t('rulesPanel')}>
+          <Filter className="h-5 w-5" />
+          {t('rulesShort') || t('rulesPanel')}
+        </button>
+        <button onClick={() => setActive("settings") } className="flex flex-col items-center py-2 px-3 text-xs" aria-label={t('settingsPanel')}>
+          <Settings className="h-5 w-5" />
+          {t('settingsShort') || t('settingsPanel')}
+        </button>
+      </nav>
+
+      <Sheet open={active === "explore"} onOpenChange={(o) => !o && close()}>
+        <SheetContent side="bottom" className="md:hidden h-[85vh] overflow-y-auto p-4">
+          <div className="mb-4">
+            <h3 className="text-sm font-semibold mb-2">{t('modelExplorer')}</h3>
+            <div className="h-60 overflow-y-auto border border-border rounded-md">
+              <SpatialTreePanel />
+            </div>
+          </div>
+          <div>
+            <h3 className="text-sm font-semibold mb-2">{t('properties')}</h3>
+            <div className="overflow-y-auto max-h-60 border border-border rounded-md p-2">
+              <ModelInfo />
+            </div>
+          </div>
+        </SheetContent>
+      </Sheet>
+
+      <Sheet open={active === "classify"} onOpenChange={(o) => !o && close()}>
+        <SheetContent side="bottom" className="md:hidden h-[85vh] overflow-y-auto p-4">
+          <ClassificationPanel />
+        </SheetContent>
+      </Sheet>
+
+      <Sheet open={active === "rules"} onOpenChange={(o) => !o && close()}>
+        <SheetContent side="bottom" className="md:hidden h-[85vh] overflow-y-auto p-4">
+          <RulePanel />
+        </SheetContent>
+      </Sheet>
+
+      <Sheet open={active === "settings"} onOpenChange={(o) => !o && close()}>
+        <SheetContent side="bottom" className="md:hidden h-[85vh] overflow-y-auto p-4">
+          <SettingsPanel onSettingsChanged={onSettingsChanged} />
+        </SheetContent>
+      </Sheet>
+    </>
+  );
+}

--- a/components/ui/sheet.tsx
+++ b/components/ui/sheet.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import * as React from "react";
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { X } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+const Sheet = DialogPrimitive.Root;
+const SheetTrigger = DialogPrimitive.Trigger;
+const SheetClose = DialogPrimitive.Close;
+
+interface SheetContentProps extends React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> {
+  side?: "bottom" | "top" | "left" | "right";
+}
+
+const SheetContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  SheetContentProps
+>(({ side = "bottom", className, children, ...props }, ref) => (
+  <DialogPrimitive.Portal>
+    <DialogPrimitive.Overlay className="fixed inset-0 z-50 bg-black/80 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0" />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed z-50 bg-background border border-border shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out",
+        side === "bottom" && "inset-x-0 bottom-0 mt-auto rounded-t-md",
+        side === "top" && "inset-x-0 top-0 mb-auto rounded-b-md",
+        side === "left" && "inset-y-0 left-0 mr-auto rounded-r-md",
+        side === "right" && "inset-y-0 right-0 ml-auto rounded-l-md",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2">
+        <X className="h-4 w-4" />
+        <span className="sr-only">Close</span>
+      </DialogPrimitive.Close>
+    </DialogPrimitive.Content>
+  </DialogPrimitive.Portal>
+));
+SheetContent.displayName = "SheetContent";
+
+export { Sheet, SheetTrigger, SheetClose, SheetContent };

--- a/lib/hooks/useIsMobile.ts
+++ b/lib/hooks/useIsMobile.ts
@@ -1,0 +1,14 @@
+import { useState, useEffect } from "react";
+
+export default function useIsMobile(breakpoint = 768) {
+  const [isMobile, setIsMobile] = useState(false);
+
+  useEffect(() => {
+    const handleResize = () => setIsMobile(window.innerWidth < breakpoint);
+    handleResize();
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
+  }, [breakpoint]);
+
+  return isMobile;
+}


### PR DESCRIPTION
## Summary
- implement `useIsMobile` hook
- add bottom sheet and navigation for mobile
- wrap side panels in desktop-only views
- show new `MobileNav` component on small screens

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687cb26532b083208b4a92d009530a72