### PR TITLE
Add mobile navigation with bottom sheet panels

### DIFF
--- a/components/ifc-viewer.tsx
+++ b/components/ifc-viewer.tsx
@@ -67,6 +67,8 @@ import {
   ImperativePanelHandle,
 } from "react-resizable-panels";
 import { useTranslation } from "react-i18next";
+import MobileNav from "@/components/layout/MobileNav";
+import useMediaQuery from "@/lib/use-media-query";
 // import { EffectComposer, Outline } from "@react-three/postprocessing"; // Comment out post-processing imports
 
 // Define the layer for outlines
@@ -270,6 +272,7 @@ interface ViewToolbarProps {
   onUnhideAll: () => void;
   onUnhideLast: () => void;
   onSelectAllVisible: () => void;
+  shiftForBottomNav?: boolean;
 }
 
 function ViewToolbar({
@@ -279,6 +282,7 @@ function ViewToolbar({
   onUnhideAll,
   onUnhideLast,
   onSelectAllVisible,
+  shiftForBottomNav = false,
 }: ViewToolbarProps) {
   const {
     selectedElements,
@@ -305,7 +309,12 @@ function ViewToolbar({
   };
 
   return (
-    <div className="absolute bottom-4 left-1/2 transform -translate-x-1/2 z-20 pointer-events-auto">
+    <div
+      className={cn(
+        "absolute left-1/2 transform -translate-x-1/2 z-20 pointer-events-auto",
+        shiftForBottomNav ? "bottom-16" : "bottom-4"
+      )}
+    >
       <div className="flex items-center gap-1 p-2 bg-background/95 backdrop-blur-md border border-border rounded-xl shadow-2xl">
         {/* Camera Controls Group */}
         <div className="flex items-center gap-1 px-1">
@@ -934,6 +943,7 @@ function ViewerContent() {
     clearSelection,
   } = useIFCContext();
   const { t } = useTranslation();
+  const isMobile = useMediaQuery("(max-width: 640px)");
   const [ifcEngineReady, setIfcEngineReady] = useState(false);
   const [webGLContextLost, setWebGLContextLost] = useState(false);
   const [canvasSearch, setCanvasSearch] = useState("");
@@ -1802,7 +1812,7 @@ function ViewerContent() {
           minSize={15}
           maxSize={40}
           collapsible
-          className="bg-transparent pointer-events-auto" // MODIFIED: Panel itself is transparent
+          className="bg-transparent pointer-events-auto hidden sm:block" // MODIFIED: hide on mobile
         >
           {/* Inner div has the gradient */}
           <div className="h-full flex flex-col shadow-lg bg-gradient-to-r from-[hsl(var(--card))]">
@@ -1839,7 +1849,7 @@ function ViewerContent() {
           onToggle={handleToggleLeftPanel}
           collapsed={leftPanelCollapsed}
           isLeftSide={true}
-          className="pointer-events-auto"
+          className="pointer-events-auto hidden sm:flex"
         />
 
         {/* Main content area - Canvas is NO LONGER here */}
@@ -2000,6 +2010,7 @@ function ViewerContent() {
                 onUnhideAll={customUnhideAllElements}
                 onUnhideLast={customUnhideLastElement}
                 onSelectAllVisible={handleSelectAllVisible}
+                shiftForBottomNav={isMobile}
               />
             )}
             <SelectionListOverlay />
@@ -2010,7 +2021,7 @@ function ViewerContent() {
           onToggle={handleToggleRightPanel}
           collapsed={rightPanelCollapsed}
           isLeftSide={false}
-          className="pointer-events-auto"
+          className="pointer-events-auto hidden sm:flex"
         />
 
         {/* Right sidebar */}
@@ -2021,11 +2032,12 @@ function ViewerContent() {
           minSize={15}
           maxSize={40}
           collapsible
-          className="bg-transparent pointer-events-auto"
+          className="bg-transparent pointer-events-auto hidden sm:block"
         >
           <ResponsiveTabs onSettingsChanged={handleSettingsChanged} />
         </Panel>
       </PanelGroup>
+      {isMobile && <MobileNav onSettingsChanged={handleSettingsChanged} />}
     </div>
   );
 }

--- a/components/layout/MobileNav.tsx
+++ b/components/layout/MobileNav.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { useState } from "react";
+import { Layers, Filter, Settings as SettingsIcon } from "lucide-react";
+import { Sheet, SheetContent } from "@/components/ui/sheet";
+import { ClassificationPanel } from "@/components/classification-panel";
+import { RulePanel } from "@/components/rule-panel";
+import { SettingsPanel } from "@/components/settings-panel";
+import { useTranslation } from "react-i18next";
+
+interface MobileNavProps {
+  onSettingsChanged: () => void;
+}
+
+export default function MobileNav({ onSettingsChanged }: MobileNavProps) {
+  const { t } = useTranslation();
+  const [active, setActive] = useState<"classifications" | "rules" | "settings" | null>(null);
+
+  const close = () => setActive(null);
+
+  return (
+    <>
+      <div className="sm:hidden fixed bottom-0 inset-x-0 z-30 bg-background/95 backdrop-blur flex border-t">
+        <button
+          onClick={() => setActive("classifications")}
+          className="flex-1 flex flex-col items-center justify-center py-2 text-xs"
+          aria-label={t("navigation.classificationsTab")}
+        >
+          <Layers className="w-5 h-5" />
+          {t("navigation.classificationsTab")}
+        </button>
+        <button
+          onClick={() => setActive("rules")}
+          className="flex-1 flex flex-col items-center justify-center py-2 text-xs"
+          aria-label={t("rulesPanel")}
+        >
+          <Filter className="w-5 h-5" />
+          {t("rulesPanel")}
+        </button>
+        <button
+          onClick={() => setActive("settings")}
+          className="flex-1 flex flex-col items-center justify-center py-2 text-xs"
+          aria-label={t("settingsPanel")}
+        >
+          <SettingsIcon className="w-5 h-5" />
+          {t("settingsPanel")}
+        </button>
+      </div>
+
+      <Sheet open={active !== null} onOpenChange={(o) => !o && close()}>
+        <SheetContent className="sm:hidden p-0">
+          {active === "classifications" && (
+            <div className="h-full overflow-y-auto p-2">
+              <ClassificationPanel />
+            </div>
+          )}
+          {active === "rules" && (
+            <div className="h-full overflow-y-auto p-2">
+              <RulePanel />
+            </div>
+          )}
+          {active === "settings" && (
+            <div className="h-full overflow-y-auto p-2">
+              <SettingsPanel onSettingsChanged={onSettingsChanged} />
+            </div>
+          )}
+        </SheetContent>
+      </Sheet>
+    </>
+  );
+}

--- a/components/ui/sheet.tsx
+++ b/components/ui/sheet.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import * as React from "react";
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { X } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+const Sheet = DialogPrimitive.Root;
+const SheetTrigger = DialogPrimitive.Trigger;
+const SheetPortal = DialogPrimitive.Portal;
+const SheetClose = DialogPrimitive.Close;
+
+const SheetContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <SheetPortal>
+    <DialogPrimitive.Overlay className="fixed inset-0 z-50 bg-black/40 backdrop-blur-sm" />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed inset-x-0 bottom-0 top-16 z-50 mt-auto flex flex-col border-t bg-background outline-none data-[state=open]:animate-in data-[state=open]:slide-in-from-bottom-16 data-[state=closed]:animate-out data-[state=closed]:slide-out-to-bottom-16",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <SheetClose className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2">
+        <X className="h-4 w-4" />
+        <span className="sr-only">Close</span>
+      </SheetClose>
+    </DialogPrimitive.Content>
+  </SheetPortal>
+));
+SheetContent.displayName = "SheetContent";
+
+export { Sheet, SheetTrigger, SheetPortal, SheetClose, SheetContent };

--- a/lib/use-media-query.ts
+++ b/lib/use-media-query.ts
@@ -1,0 +1,16 @@
+import { useState, useEffect } from "react";
+
+export default function useMediaQuery(query: string) {
+  const [matches, setMatches] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const media = window.matchMedia(query);
+    const listener = () => setMatches(media.matches);
+    listener();
+    media.addEventListener("change", listener);
+    return () => media.removeEventListener("change", listener);
+  }, [query]);
+
+  return matches;
+}


### PR DESCRIPTION
## Summary
- add `useMediaQuery` hook
- introduce bottom sheet primitives for dialogs
- create `MobileNav` component for small screens
- shift toolbars when bottom nav is visible
- hide sidebars on mobile and integrate mobile navigation

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font `Inter` due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_687cb26532b083208b4a92d009530a72