### PR TITLE
Add video tutorial to docs modal

### DIFF
--- a/components/docs/DocumentationModal.tsx
+++ b/components/docs/DocumentationModal.tsx
@@ -151,6 +151,19 @@ const DocumentationModal: React.FC<DocumentationModalProps> = ({ onClose }) => {
                   >
                     {currentSection.content}
                   </ReactMarkdown>
+                  {currentSection.videoUrl && (
+                    <div className="mt-4">
+                      <iframe
+                        className="w-full rounded-lg"
+                        style={{ aspectRatio: "16/9" }}
+                        src={currentSection.videoUrl}
+                        title="Video tutorial"
+                        frameBorder="0"
+                        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+                        allowFullScreen
+                      />
+                    </div>
+                  )}
                 </div>
               </div>
             </div>

--- a/components/docs/docsContent.tsx
+++ b/components/docs/docsContent.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Home, Zap, LayoutDashboard, ChevronsRight, Cog, Info, Tags } from "lucide-react";
+import { Home, Zap, LayoutDashboard, ChevronsRight, Cog, Info, Tags, Video } from "lucide-react";
 import welcome from "@/docs/welcome";
 import gettingStarted from "@/docs/getting-started";
 import ui from "@/docs/ui";
@@ -7,11 +7,26 @@ import classifications from "@/docs/classifications";
 import rules from "@/docs/rules";
 import settings from "@/docs/settings";
 import workflow from "@/docs/workflow";
+import video from "@/docs/video";
 import { Language } from "@/lib/i18n";
 import { translations } from "@/lib/i18n";
 
-export const getDocSections = (lang: Language) => [
+export interface DocSection {
+  id: string;
+  title: string;
+  icon: React.ReactNode;
+  content: string;
+  videoUrl?: string;
+}
+export const getDocSections = (lang: Language): DocSection[] => [
   { id: "general", title: translations[lang].doc_welcome_title, icon: <Home className="h-5 w-5" />, content: welcome[lang] },
+  {
+    id: "video",
+    title: translations[lang].doc_video_title,
+    icon: <Video className="h-5 w-5" />,
+    content: video[lang],
+    videoUrl: "https://www.youtube.com/embed/VUEGCefgqkY?si=0FFKAZ14qd518raN",
+  },
   { id: "getting-started", title: translations[lang].doc_getting_started_title, icon: <Zap className="h-5 w-5" />, content: gettingStarted[lang] },
   { id: "ui", title: translations[lang].doc_ui_title, icon: <LayoutDashboard className="h-5 w-5" />, content: ui[lang] },
   { id: "classifications", title: translations[lang].doc_classifications_title, icon: <Tags className="h-5 w-5 flex-shrink-0" />, content: classifications[lang] },

--- a/docs/video.ts
+++ b/docs/video.ts
@@ -1,0 +1,7 @@
+const content = {
+  en: `## Video Walkthrough\n\nNeed a quick demo? Watch this video for a short introduction to IFC Classifier.`,
+  de: `## Video-Anleitung\n\nDu willst einen schnellen Überblick? In diesem Video findest du eine kurze Einführung in den IFC Classifier.`,
+  fr: `## Tutoriel vidéo\n\nVous voulez une démo rapide ? Regardez cette vidéo pour une brève introduction à IFC Classifier.`,
+  it: `## Video tutorial\n\nVuoi una demo rapida? Guarda questo video per una breve introduzione a IFC Classifier.`,
+};
+export default content;

--- a/public/locales/de/common.json
+++ b/public/locales/de/common.json
@@ -10,6 +10,7 @@
   "doc_rules_title": "Regeln",
   "doc_settings_title": "Einstellungen",
   "doc_workflow_title": "Typischer Ablauf",
+  "doc_video_title": "Video-Anleitung",
   "closeDocs": "Dokumentation schließen",
   "viewSchema": "Schema anzeigen",
   "pageNotFoundTitle": "404 - Seite nicht gefunden",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -10,6 +10,7 @@
   "doc_rules_title": "Rules",
   "doc_settings_title": "Settings",
   "doc_workflow_title": "Typical Workflow",
+  "doc_video_title": "Video Tutorial",
   "closeDocs": "Close documentation",
   "viewSchema": "View Schema",
   "pageNotFoundTitle": "404 - Page Not Found",

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -10,6 +10,7 @@
     "doc_rules_title": "Règles",
     "doc_settings_title": "Paramètres",
     "doc_workflow_title": "Flux de travail typique",
+    "doc_video_title": "Tutoriel vidéo",
     "closeDocs": "Fermer la documentation",
     "viewSchema": "Voir le schéma",
     "pageNotFoundTitle": "404 - Page introuvable",

--- a/public/locales/it/common.json
+++ b/public/locales/it/common.json
@@ -10,6 +10,7 @@
     "doc_rules_title": "Regole",
     "doc_settings_title": "Impostazioni",
     "doc_workflow_title": "Flusso di lavoro tipico",
+    "doc_video_title": "Video tutorial",
     "closeDocs": "Chiudi documentazione",
     "viewSchema": "Visualizza schema",
     "pageNotFoundTitle": "404 - Pagina non trovata",


### PR DESCRIPTION
## Summary
- add new docs content `video.ts`
- enhance docs menu with a Video section and embed the YouTube tutorial
- expose new translation key `doc_video_title` in all languages

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68875c1cf40c8320b75e2950b1a1d941

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a video tutorial section in the documentation modal, displaying an embedded video when available.
  * Added localized titles and content for the video tutorial section in English, German, French, and Italian.

* **Documentation**
  * Expanded documentation with a new "Video Tutorial" section, including a brief introduction and an embedded demo video.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->