### PR TITLE
Add tutorial video placeholder

### DIFF
--- a/components/docs/DocumentationModal.tsx
+++ b/components/docs/DocumentationModal.tsx
@@ -138,19 +138,71 @@ const DocumentationModal: React.FC<DocumentationModalProps> = ({ onClose }) => {
                 </p>
 
                 <div className="prose prose-sm sm:prose-base dark:prose-invert max-w-none text-foreground/90 prose-headings:text-primary prose-a:text-primary prose-strong:text-primary/90 prose-code:bg-muted prose-code:p-1 prose-code:rounded prose-code:text-primary prose-code:before:content-none prose-code:after:content-none prose-p:leading-relaxed prose-li:leading-relaxed">
-                  <ReactMarkdown
-                    remarkPlugins={[remarkGfm]}
-                    components={{
-                      a: ({ node, ...props }) => (
-                        <a {...props} target="_blank" rel="noopener noreferrer" className="inline-flex items-center">
-                          {props.children}
-                          <ExternalLink className="ml-1 h-3 w-3 opacity-70" />
-                        </a>
-                      ),
-                    }}
-                  >
-                    {currentSection.content}
-                  </ReactMarkdown>
+                  {(() => {
+                    const placeholder = "{{VIDEO}}";
+                    if (currentSection.videoUrl && currentSection.content.includes(placeholder)) {
+                      const [before, after] = currentSection.content.split(placeholder);
+                      return (
+                        <>
+                          <ReactMarkdown
+                            remarkPlugins={[remarkGfm]}
+                            components={{
+                              a: ({ node, ...props }) => (
+                                <a {...props} target="_blank" rel="noopener noreferrer" className="inline-flex items-center">
+                                  {props.children}
+                                  <ExternalLink className="ml-1 h-3 w-3 opacity-70" />
+                                </a>
+                              ),
+                            }}
+                          >
+                            {before}
+                          </ReactMarkdown>
+                          <div className="mt-6 w-full">
+                            <div className="relative w-full" style={{ paddingBottom: "56.25%" }}>
+                              <iframe
+                                src={currentSection.videoUrl}
+                                title="Video walkthrough"
+                                className="absolute top-0 left-0 w-full h-full rounded-md"
+                                frameBorder="0"
+                                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                                allowFullScreen
+                              />
+                            </div>
+                          </div>
+                          {after && (
+                            <ReactMarkdown
+                              remarkPlugins={[remarkGfm]}
+                              components={{
+                                a: ({ node, ...props }) => (
+                                  <a {...props} target="_blank" rel="noopener noreferrer" className="inline-flex items-center">
+                                    {props.children}
+                                    <ExternalLink className="ml-1 h-3 w-3 opacity-70" />
+                                  </a>
+                                ),
+                              }}
+                            >
+                              {after}
+                            </ReactMarkdown>
+                          )}
+                        </>
+                      );
+                    }
+                    return (
+                      <ReactMarkdown
+                        remarkPlugins={[remarkGfm]}
+                        components={{
+                          a: ({ node, ...props }) => (
+                            <a {...props} target="_blank" rel="noopener noreferrer" className="inline-flex items-center">
+                              {props.children}
+                              <ExternalLink className="ml-1 h-3 w-3 opacity-70" />
+                            </a>
+                          ),
+                        }}
+                      >
+                        {currentSection.content}
+                      </ReactMarkdown>
+                    );
+                  })()}
                 </div>
               </div>
             </div>

--- a/components/docs/docsContent.tsx
+++ b/components/docs/docsContent.tsx
@@ -10,14 +10,56 @@ import workflow from "@/docs/workflow";
 import { Language } from "@/lib/i18n";
 import { translations } from "@/lib/i18n";
 
-export const getDocSections = (lang: Language) => [
-  { id: "general", title: translations[lang].doc_welcome_title, icon: <Home className="h-5 w-5" />, content: welcome[lang] },
-  { id: "getting-started", title: translations[lang].doc_getting_started_title, icon: <Zap className="h-5 w-5" />, content: gettingStarted[lang] },
-  { id: "ui", title: translations[lang].doc_ui_title, icon: <LayoutDashboard className="h-5 w-5" />, content: ui[lang] },
-  { id: "classifications", title: translations[lang].doc_classifications_title, icon: <Tags className="h-5 w-5 flex-shrink-0" />, content: classifications[lang] },
-  { id: "rules", title: translations[lang].doc_rules_title, icon: <ChevronsRight className="h-5 w-5" />, content: rules[lang] },
-  { id: "settings", title: translations[lang].doc_settings_title, icon: <Cog className="h-5 w-5" />, content: settings[lang] },
-  { id: "workflow", title: translations[lang].doc_workflow_title, icon: <Info className="h-5 w-5" />, content: workflow[lang] },
-] as const;
+export interface DocSection {
+  id: string;
+  title: string;
+  icon: React.ReactNode;
+  content: string;
+  videoUrl?: string;
+}
+export const getDocSections = (lang: Language): DocSection[] => [
+  {
+    id: "general",
+    title: translations[lang].doc_welcome_title,
+    icon: <Home className="h-5 w-5" />,
+    content: welcome[lang],
+    videoUrl: "https://www.youtube.com/embed/VUEGCefgqkY?si=0FFKAZ14qd518raN",
+  },
+  {
+    id: "getting-started",
+    title: translations[lang].doc_getting_started_title,
+    icon: <Zap className="h-5 w-5" />,
+    content: gettingStarted[lang],
+  },
+  {
+    id: "ui",
+    title: translations[lang].doc_ui_title,
+    icon: <LayoutDashboard className="h-5 w-5" />,
+    content: ui[lang],
+  },
+  {
+    id: "classifications",
+    title: translations[lang].doc_classifications_title,
+    icon: <Tags className="h-5 w-5 flex-shrink-0" />,
+    content: classifications[lang],
+  },
+  {
+    id: "rules",
+    title: translations[lang].doc_rules_title,
+    icon: <ChevronsRight className="h-5 w-5" />,
+    content: rules[lang],
+  },
+  {
+    id: "settings",
+    title: translations[lang].doc_settings_title,
+    icon: <Cog className="h-5 w-5" />,
+    content: settings[lang],
+  },
+  {
+    id: "workflow",
+    title: translations[lang].doc_workflow_title,
+    icon: <Info className="h-5 w-5" />,
+    content: workflow[lang],
+  },
+];
 
-export type DocSection = ReturnType<typeof getDocSections>[number];

--- a/docs/welcome.ts
+++ b/docs/welcome.ts
@@ -18,6 +18,12 @@ Assigning classification codes in IFC shouldn't slow you down—it should just w
 
 Try it out on your own models and let us know how it works for you!
 
+### Video Walkthrough
+
+Watch the quick-start video for an overview.
+
+{{VIDEO}}
+
 ## Privacy & Security
 
 **Your IFC data never leaves your device.** The application processes all files locally in your browser using [**WebAssembly**](https://webassembly.org/) technology:
@@ -49,6 +55,12 @@ Die Zuordnung von Klassifizierungscodes zu IFC-Elementen soll dich nicht ausbrem
   - **Im Browser** und vollständig Open Source
 
 Probiere es mit eigenen Modellen aus und gib uns Feedback!
+
+### Video-Überblick
+
+Schau dir das kurze Einführungsvideo an.
+
+{{VIDEO}}
 
 ## Datenschutz & Sicherheit
 
@@ -82,6 +94,12 @@ L'attribution de codes de classification dans IFC ne devrait pas vous ralentir�
 
 Essayez-le sur vos propres modèles et dites-nous comment cela fonctionne pour vous !
 
+### Présentation vidéo
+
+Regardez la courte vidéo d'introduction.
+
+{{VIDEO}}
+
 ## Confidentialité et sécurité
 
 **Vos données IFC ne quittent jamais votre appareil.** L'application traite tous les fichiers localement dans votre navigateur en utilisant la technologie [**WebAssembly**](https://webassembly.org/) :
@@ -113,6 +131,12 @@ L'assegnazione di codici di classificazione in IFC non dovrebbe rallentarti—do
   - **Basato su browser** e completamente open source
 
 Provalo sui tuoi modelli e facci sapere come funziona per te!
+
+### Video introduttivo
+
+Guarda il breve video introduttivo.
+
+{{VIDEO}}
 
 ## Privacy e sicurezza
 


### PR DESCRIPTION
## Summary
- move video embed so it appears under the video section heading
- place `{{VIDEO}}` placeholders in all welcome docs translations
- render docs content split by `{{VIDEO}}` so video appears inline

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68875c1cf40c8320b75e2950b1a1d941