### PR TITLE
Add missing UI translations

### DIFF
--- a/components/classification-panel.tsx
+++ b/components/classification-panel.tsx
@@ -91,7 +91,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { useTranslation } from "react-i18next";
+import { useTranslation, Trans } from "react-i18next";
 
 // Helper function to compare two arrays of SelectedElementInfo (order-independent)
 function areElementArraysEqual(arr1: any[], arr2: any[]): boolean {
@@ -1137,13 +1137,13 @@ export function ClassificationPanel() {
                   {" "}
                   {/* Subtle look */}
                   <MoreHorizontal className="w-5 h-5 text-muted-foreground" />
-                  <span className="sr-only">Manage Classifications</span>
+                  <span className="sr-only">{t("classifications.manageClassifications")}</span>
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end">
                 <DropdownMenuItem onSelect={() => setIsAddDialogOpen(true)}>
                   <Plus className="mr-2 h-4 w-4" />
-                  Add New Classification
+                  {t("classifications.addNew")}
                 </DropdownMenuItem>
                 <DropdownMenuSeparator />
                 <DropdownMenuLabel className="text-xs font-semibold text-muted-foreground px-2 py-1.5">
@@ -1643,9 +1643,11 @@ export function ClassificationPanel() {
                   setCurrentClassificationForEdit(null);
                 }}
               >
-                Cancel
+                {t("buttons.cancel")}
               </Button>
-              <Button onClick={handleUpdateClassification}>Save Changes</Button>
+              <Button onClick={handleUpdateClassification}>
+                {t("buttons.saveChanges")}
+              </Button>
             </DialogFooter>
           </DialogContent>
         </Dialog>
@@ -2094,16 +2096,17 @@ export function ClassificationPanel() {
               <div className="flex items-center space-x-2">
                 <AlertTriangle className="h-6 w-6 text-destructive" />
                 <DialogTitle className="text-lg font-medium">
-                  Confirm Removal
+                  {t("classifications.confirmRemoval")}
                 </DialogTitle>
               </div>
             </DialogHeader>
             <DialogDescription className="mt-2 text-sm text-muted-foreground">
-              Are you sure you want to remove the classification &nbsp;
-              <span className="font-semibold text-foreground">
-                {classificationCodeToRemove}
-              </span>
-              ? This action cannot be undone.
+              <Trans
+                t={t}
+                i18nKey="classifications.confirmRemoveMessage"
+                values={{ code: classificationCodeToRemove }}
+                components={{ code: <span className="font-semibold text-foreground" /> }}
+              />
             </DialogDescription>
             <DialogFooter className="mt-6 sm:justify-end gap-2">
               <Button
@@ -2111,7 +2114,7 @@ export function ClassificationPanel() {
                 onClick={() => setIsConfirmRemoveOpen(false)}
                 className="sm:w-auto w-full"
               >
-                Cancel
+                {t("buttons.cancel")}
               </Button>
               <Button
                 variant="destructive"
@@ -2122,7 +2125,7 @@ export function ClassificationPanel() {
                 }}
                 className="sm:w-auto w-full"
               >
-                Remove Classification
+                {t("classifications.removeClassification")}
               </Button>
             </DialogFooter>
           </DialogContent>
@@ -2138,13 +2141,12 @@ export function ClassificationPanel() {
               <div className="flex items-center space-x-2">
                 <AlertTriangle className="h-6 w-6 text-destructive" />
                 <DialogTitle className="text-lg font-medium">
-                  Confirm Removal
+                  {t("classifications.confirmRemoval")}
                 </DialogTitle>
               </div>
             </DialogHeader>
             <DialogDescription className="mt-2 text-sm text-muted-foreground">
-              Are you sure you want to remove all classifications? This action
-              cannot be undone.
+              {t("classifications.confirmRemoveAllMessage")}
             </DialogDescription>
             <DialogFooter className="mt-6 sm:justify-end gap-2">
               <Button
@@ -2152,7 +2154,7 @@ export function ClassificationPanel() {
                 onClick={() => setIsConfirmRemoveAllOpen(false)}
                 className="sm:w-auto w-full"
               >
-                Cancel
+                {t("buttons.cancel")}
               </Button>
               <Button
                 variant="destructive"
@@ -2162,7 +2164,7 @@ export function ClassificationPanel() {
                 }}
                 className="sm:w-auto w-full"
               >
-                Remove All
+                {t("buttons.removeAll")}
               </Button>
             </DialogFooter>
           </DialogContent>

--- a/components/spatial-tree-panel.tsx
+++ b/components/spatial-tree-panel.tsx
@@ -49,7 +49,7 @@ import {
 } from "@/components/ui/tooltip";
 import { Badge } from "@/components/ui/badge";
 import { useSchemaPreview } from "@/lib/useSchemaPreview";
-import { useTranslation } from "react-i18next";
+import { useTranslation, Trans } from "react-i18next";
 import { SchemaReader } from "./schema-reader";
 
 // Helper function to generate a unique key for a node
@@ -837,16 +837,17 @@ export function SpatialTreePanel() {
               <div className="flex items-center space-x-2">
                 <AlertTriangle className="h-6 w-6 text-destructive" />
                 <DialogTitle className="text-lg font-medium">
-                  Confirm Removal
+                  {t("models.confirmRemoval")}
                 </DialogTitle>
               </div>
             </DialogHeader>
             <DialogDescription className="mt-2 text-sm text-muted-foreground">
-              Are you sure you want to remove the model &quot;
-              <span className="font-semibold text-foreground">
-                {modelToRemove.name}
-              </span>
-              &quot; from the scene? This action cannot be undone.
+              <Trans
+                t={t}
+                i18nKey="models.confirmRemoveModel"
+                values={{ name: modelToRemove.name }}
+                components={{ name: <span className="font-semibold text-foreground" /> }}
+              />
             </DialogDescription>
             <DialogFooter className="mt-6 sm:justify-end gap-2">
               <Button
@@ -854,14 +855,14 @@ export function SpatialTreePanel() {
                 onClick={() => setIsConfirmRemoveOpen(false)}
                 className="sm:w-auto w-full"
               >
-                Cancel
+                {t("buttons.cancel")}
               </Button>
               <Button
                 variant="destructive"
                 onClick={confirmRemove}
                 className="sm:w-auto w-full"
               >
-                Remove Model
+                {t("buttons.removeModel", { name: modelToRemove.name })}
               </Button>
             </DialogFooter>
           </DialogContent>

--- a/public/locales/de/common.json
+++ b/public/locales/de/common.json
@@ -98,6 +98,7 @@
   },
   "buttons": {
     "save": "Speichern",
+    "saveChanges": "Änderungen speichern",
     "cancel": "Abbrechen",
     "apply": "Anwenden",
     "delete": "Löschen",
@@ -219,7 +220,11 @@
     "mapFromModelTitle": "Klassifizierungen aus Modell übernehmen",
     "mapFromModelDescription": "Extrahiere Klassifizierungen aus Eigenschaftswerten im Modell.",
     "psetName": "Eigenschaftssatz-Name",
-    "propertyName": "Eigenschaftsname"
+    "propertyName": "Eigenschaftsname",
+    "manageClassifications": "Klassifizierungen verwalten",
+    "confirmRemoval": "Löschen bestätigen",
+    "confirmRemoveMessage": "Sind Sie sicher, dass Sie die Klassifizierung <code>{{code}}</code> entfernen möchten? Diese Aktion kann nicht rückgängig gemacht werden.",
+    "confirmRemoveAllMessage": "Sind Sie sicher, dass Sie alle Klassifizierungen entfernen möchten? Diese Aktion kann nicht rückgängig gemacht werden."
   },
   "rules": {
     "addNew": "Neue Regel hinzufügen",
@@ -257,6 +262,10 @@
     "createNewClassification": "Neue Klassifizierung \"{{value}}\" erstellen",
     "searchPlaceholder": "Regeln durchsuchen...",
     "noSearchResults": "Keine Regeln entsprechen Ihrer Suche."
+  },
+  "models": {
+    "confirmRemoval": "Löschen bestätigen",
+    "confirmRemoveModel": "Sind Sie sicher, dass Sie das Modell <code>{{name}}</code> aus der Szene entfernen möchten? Diese Aktion kann nicht rückgängig gemacht werden."
   },
   "operators": {
     "equals": "Gleich",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -98,6 +98,7 @@
   },
   "buttons": {
     "save": "Save",
+    "saveChanges": "Save Changes",
     "cancel": "Cancel",
     "apply": "Apply",
     "delete": "Delete",
@@ -217,7 +218,11 @@
     "showMetadataFields": "Show metadata fields…",
     "editMetadata": "Edit…",
     "psetName": "PSet Name",
-    "propertyName": "Property Name"
+    "propertyName": "Property Name",
+    "manageClassifications": "Manage Classifications",
+    "confirmRemoval": "Confirm Removal",
+    "confirmRemoveMessage": "Are you sure you want to remove the classification <code>{{code}}</code>? This action cannot be undone.",
+    "confirmRemoveAllMessage": "Are you sure you want to remove all classifications? This action cannot be undone."
   },
   "rules": {
     "addNew": "Add New Rule",
@@ -255,6 +260,10 @@
     "createNewClassification": "Create new classification \"{{value}}\"",
     "searchPlaceholder": "Search rules...",
     "noSearchResults": "No rules match your search."
+  },
+  "models": {
+    "confirmRemoval": "Confirm Removal",
+    "confirmRemoveModel": "Are you sure you want to remove the model <code>{{name}}</code> from the scene? This action cannot be undone."
   },
   "operators": {
     "equals": "Equals",

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -98,6 +98,7 @@
     },
     "buttons": {
         "save": "Enregistrer",
+        "saveChanges": "Enregistrer les modifications",
         "cancel": "Annuler",
         "apply": "Appliquer",
         "delete": "Supprimer",
@@ -217,7 +218,11 @@
         "mapFromModelTitle": "Mapper les classifications depuis le modèle",
         "mapFromModelDescription": "Extraire les classifications des valeurs de propriétés dans le modèle",
         "psetName": "Nom du PSet",
-        "propertyName": "Nom de la propriété"
+        "propertyName": "Nom de la propriété",
+        "manageClassifications": "Gérer les classifications",
+        "confirmRemoval": "Confirmer la suppression",
+        "confirmRemoveMessage": "Êtes-vous sûr de vouloir supprimer la classification <code>{{code}}</code> ? Cette action est irréversible.",
+        "confirmRemoveAllMessage": "Êtes-vous sûr de vouloir supprimer toutes les classifications ? Cette action est irréversible."
     },
     "rules": {
         "addNew": "Ajouter une nouvelle règle",
@@ -255,6 +260,10 @@
         "createNewClassification": "Créer une nouvelle classification \"{{value}}\"",
         "searchPlaceholder": "Rechercher des règles...",
         "noSearchResults": "Aucune règle ne correspond à votre recherche."
+    },
+    "models": {
+        "confirmRemoval": "Confirmer la suppression",
+        "confirmRemoveModel": "Êtes-vous sûr de vouloir supprimer le modèle <code>{{name}}</code> de la scène ? Cette action est irréversible."
     },
     "operators": {
         "equals": "Égal à",

--- a/public/locales/it/common.json
+++ b/public/locales/it/common.json
@@ -98,6 +98,7 @@
     },
     "buttons": {
         "save": "Salva",
+        "saveChanges": "Salva modifiche",
         "cancel": "Annulla",
         "apply": "Applica",
         "delete": "Elimina",
@@ -217,7 +218,11 @@
         "mapFromModelTitle": "Mappa classificazioni dal modello",
         "mapFromModelDescription": "Estrai classificazioni dai valori delle proprietà nel modello",
         "psetName": "Nome PSet",
-        "propertyName": "Nome proprietà"
+        "propertyName": "Nome proprietà",
+        "manageClassifications": "Gestisci classificazioni",
+        "confirmRemoval": "Conferma rimozione",
+        "confirmRemoveMessage": "Sei sicuro di voler rimuovere la classificazione <code>{{code}}</code>? Questa azione non può essere annullata.",
+        "confirmRemoveAllMessage": "Sei sicuro di voler rimuovere tutte le classificazioni? Questa azione non può essere annullata."
     },
     "rules": {
         "addNew": "Aggiungi nuova regola",
@@ -255,6 +260,10 @@
         "createNewClassification": "Crea nuova classificazione \"{{value}}\"",
         "searchPlaceholder": "Cerca regole...",
         "noSearchResults": "Nessuna regola corrisponde alla tua ricerca."
+    },
+    "models": {
+        "confirmRemoval": "Conferma rimozione",
+        "confirmRemoveModel": "Sei sicuro di voler rimuovere il modello <code>{{name}}</code> dalla scena? Questa azione non può essere annullata."
     },
     "operators": {
         "equals": "Uguale",


### PR DESCRIPTION
## Summary
- localize classification management menu and save/update dialogs
- add translated confirmation prompts for removing classifications and models
- provide "Save Changes" and model-removal texts across all locales

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b3247fa5a083208d906b80f6b9110f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Internationalized UI in classification and spatial tree panels, including menus, screen-reader labels, and confirmation dialogs.
  - Localized removal confirmations for single/all classifications and models with translated button labels (Cancel, Remove, Remove All, Save Changes).

- Localization
  - Added/updated translations in English, German, French, and Italian to cover new labels and confirmation messages for managing classifications and models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->