### PR TITLE
feat: add bSDD search for classifications

### DIFF
--- a/components/bsdd-classification-dialog.tsx
+++ b/components/bsdd-classification-dialog.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { useState } from "react";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { searchBSDDClasses, type BSDDClass } from "@/services/bsdd-service";
+import { useTranslation } from "react-i18next";
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSelect: (cls: BSDDClass) => void;
+}
+
+export function BSDDClassificationDialog({ open, onOpenChange, onSelect }: Props) {
+  const { t } = useTranslation();
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState<BSDDClass[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSearch = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const classes = await searchBSDDClasses(query);
+      setResults(classes);
+    } catch (e) {
+      setError((e as Error).message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>{t("classifications.bsddDialogTitle")}</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-3">
+          <div className="flex gap-2">
+            <Input
+              placeholder={t("classifications.bsddSearchPlaceholder")}
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") handleSearch();
+              }}
+            />
+            <Button onClick={handleSearch} disabled={loading}>
+              {t("buttons.search")}
+            </Button>
+          </div>
+          <ScrollArea className="h-64 border rounded">
+            {loading && (
+              <p className="p-2 text-sm">{t("buttons.loading")}</p>
+            )}
+            {error && (
+              <p className="p-2 text-sm text-destructive">{error}</p>
+            )}
+            {!loading && !error && results.length === 0 && (
+              <p className="p-2 text-sm text-muted-foreground">
+                {t("classifications.noSearchResults")}
+              </p>
+            )}
+            {!loading && !error && results.length > 0 && (
+              <ul className="divide-y">
+                {results.map((cls) => (
+                  <li key={cls.uri}>
+                    <Button
+                      variant="ghost"
+                      className="w-full justify-start font-normal"
+                      onClick={() => {
+                        onSelect(cls);
+                        onOpenChange(false);
+                      }}
+                    >
+                      <span className="mr-2 font-mono text-sm">{cls.code}</span>
+                      {cls.name}
+                    </Button>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </ScrollArea>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/classification-panel.tsx
+++ b/components/classification-panel.tsx
@@ -70,6 +70,7 @@ import {
   ArchiveRestore,
   Star,
   Cuboid,
+  Search,
 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import {
@@ -92,6 +93,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { useTranslation, Trans } from "react-i18next";
+import { BSDDClassificationDialog } from "@/components/bsdd-classification-dialog";
 
 // Helper function to compare two arrays of SelectedElementInfo (order-independent)
 function areElementArraysEqual(arr1: any[], arr2: any[]): boolean {
@@ -153,6 +155,7 @@ export function ClassificationPanel() {
     useState<ClassificationItem | null>(null);
   const [isMapFromModelDialogOpen, setIsMapFromModelDialogOpen] =
     useState(false);
+  const [isBSDDDialogOpen, setIsBSDDDialogOpen] = useState(false);
   const [mapPsetName, setMapPsetName] = useState("");
   const [mapPropertyName, setMapPropertyName] = useState("");
   const [isMapLoading, setIsMapLoading] = useState(false);
@@ -1141,14 +1144,18 @@ export function ClassificationPanel() {
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end">
-                <DropdownMenuItem onSelect={() => setIsAddDialogOpen(true)}>
-                  <Plus className="mr-2 h-4 w-4" />
-                  {t("classifications.addNew")}
-                </DropdownMenuItem>
-                <DropdownMenuSeparator />
-                <DropdownMenuLabel className="text-xs font-semibold text-muted-foreground px-2 py-1.5">
-                  {t("sections.defaultSets")}
-                </DropdownMenuLabel>
+              <DropdownMenuItem onSelect={() => setIsAddDialogOpen(true)}>
+                <Plus className="mr-2 h-4 w-4" />
+                {t("classifications.addNew")}
+              </DropdownMenuItem>
+              <DropdownMenuItem onSelect={() => setIsBSDDDialogOpen(true)}>
+                <Search className="mr-2 h-4 w-4" />
+                {t("buttons.searchBSDD")}
+              </DropdownMenuItem>
+              <DropdownMenuSeparator />
+              <DropdownMenuLabel className="text-xs font-semibold text-muted-foreground px-2 py-1.5">
+                {t("sections.defaultSets")}
+              </DropdownMenuLabel>
                 {isLoadingEBKPH && (
                   <DropdownMenuItem disabled>
                     {t("buttons.loadingEbkph")}
@@ -1418,6 +1425,13 @@ export function ClassificationPanel() {
             </DialogFooter>
           </DialogContent>
         </Dialog>
+        <BSDDClassificationDialog
+          open={isBSDDDialogOpen}
+          onOpenChange={setIsBSDDDialogOpen}
+          onSelect={(cls) =>
+            addClassification({ code: cls.code, name: cls.name, color: "#3b82f6" })
+          }
+        />
         {/* The old "Row 2 Management Dropdown section" is now fully replaced by the 3-dot menu in the header and this restored dialog. */}
         {/* The hidden file input for import is kept at the end of the component. */}
         <Dialog

--- a/public/locales/de/common.json
+++ b/public/locales/de/common.json
@@ -131,6 +131,7 @@
     "ecccBatError": "eCCC-Bat Fehler: {{message}}",
     "loadEcccBat": "eCCC-Bat laden ({{count}})",
     "noEcccBatFound": "Keine eCCC-Bat Elemente gefunden.",
+    "searchBSDD": "bSDD durchsuchen",
     "addCondition": "Bedingung hinzufügen",
     "saveRule": "Regel speichern",
     "copyRule": "Regel kopieren",
@@ -224,7 +225,9 @@
     "manageClassifications": "Klassifizierungen verwalten",
     "confirmRemoval": "Löschen bestätigen",
     "confirmRemoveMessage": "Sind Sie sicher, dass Sie die Klassifizierung <code>{{code}}</code> entfernen möchten? Diese Aktion kann nicht rückgängig gemacht werden.",
-    "confirmRemoveAllMessage": "Sind Sie sicher, dass Sie alle Klassifizierungen entfernen möchten? Diese Aktion kann nicht rückgängig gemacht werden."
+    "confirmRemoveAllMessage": "Sind Sie sicher, dass Sie alle Klassifizierungen entfernen möchten? Diese Aktion kann nicht rückgängig gemacht werden.",
+    "bsddDialogTitle": "bSDD-Klassifikation suchen",
+    "bsddSearchPlaceholder": "Klassen durchsuchen..."
   },
   "rules": {
     "addNew": "Neue Regel hinzufügen",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -131,6 +131,7 @@
     "ecccBatError": "eCCC-Bat Error: {{message}}",
     "loadEcccBat": "Load eCCC-Bat ({{count}})",
     "noEcccBatFound": "No eCCC-Bat items found.",
+    "searchBSDD": "Search bSDD",
     "addCondition": "Add Condition",
     "saveRule": "Save Rule",
     "copyRule": "Copy Rule",
@@ -222,7 +223,9 @@
     "manageClassifications": "Manage Classifications",
     "confirmRemoval": "Confirm Removal",
     "confirmRemoveMessage": "Are you sure you want to remove the classification <code>{{code}}</code>? This action cannot be undone.",
-    "confirmRemoveAllMessage": "Are you sure you want to remove all classifications? This action cannot be undone."
+    "confirmRemoveAllMessage": "Are you sure you want to remove all classifications? This action cannot be undone.",
+    "bsddDialogTitle": "Search bSDD Classification",
+    "bsddSearchPlaceholder": "Search classes..."
   },
   "rules": {
     "addNew": "Add New Rule",

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -131,6 +131,7 @@
         "ecccBatError": "Erreur eCCC-Bat : {{message}}",
         "loadEcccBat": "Charger eCCC-Bat ({{count}})",
         "noEcccBatFound": "Aucun élément eCCC-Bat trouvé.",
+        "searchBSDD": "Rechercher dans bSDD",
         "addCondition": "Ajouter une condition",
         "saveRule": "Enregistrer la règle",
         "copyRule": "Copier la règle",
@@ -222,7 +223,9 @@
         "manageClassifications": "Gérer les classifications",
         "confirmRemoval": "Confirmer la suppression",
         "confirmRemoveMessage": "Êtes-vous sûr de vouloir supprimer la classification <code>{{code}}</code> ? Cette action est irréversible.",
-        "confirmRemoveAllMessage": "Êtes-vous sûr de vouloir supprimer toutes les classifications ? Cette action est irréversible."
+        "confirmRemoveAllMessage": "Êtes-vous sûr de vouloir supprimer toutes les classifications ? Cette action est irréversible.",
+        "bsddDialogTitle": "Rechercher une classification bSDD",
+        "bsddSearchPlaceholder": "Rechercher des classes..."
     },
     "rules": {
         "addNew": "Ajouter une nouvelle règle",

--- a/public/locales/it/common.json
+++ b/public/locales/it/common.json
@@ -131,6 +131,7 @@
         "ecccBatError": "Errore eCCC-Bat: {{message}}",
         "loadEcccBat": "Carica eCCC-Bat ({{count}})",
         "noEcccBatFound": "Nessun elemento eCCC-Bat trovato.",
+        "searchBSDD": "Cerca su bSDD",
         "addCondition": "Aggiungi condizione",
         "saveRule": "Salva regola",
         "copyRule": "Copia regola",
@@ -222,7 +223,9 @@
         "manageClassifications": "Gestisci classificazioni",
         "confirmRemoval": "Conferma rimozione",
         "confirmRemoveMessage": "Sei sicuro di voler rimuovere la classificazione <code>{{code}}</code>? Questa azione non può essere annullata.",
-        "confirmRemoveAllMessage": "Sei sicuro di voler rimuovere tutte le classificazioni? Questa azione non può essere annullata."
+        "confirmRemoveAllMessage": "Sei sicuro di voler rimuovere tutte le classificazioni? Questa azione non può essere annullata.",
+        "bsddDialogTitle": "Cerca classificazione bSDD",
+        "bsddSearchPlaceholder": "Cerca classi..."
     },
     "rules": {
         "addNew": "Aggiungi nuova regola",

--- a/services/bsdd-service.ts
+++ b/services/bsdd-service.ts
@@ -1,0 +1,25 @@
+export interface BSDDClass {
+  uri: string;
+  code: string;
+  name: string;
+  classType?: string;
+  referenceCode?: string;
+  parentClassCode?: string;
+  descriptionPart?: string;
+}
+
+const BASE_URL = "https://api.bsdd.buildingsmart.org/api/Dictionary/v1/Classes?Uri=https%3A%2F%2Fidentifier.buildingsmart.org%2Furi%2Fnbs%2Funiclass2015%2F1&Limit=100";
+
+export async function searchBSDDClasses(searchText: string): Promise<BSDDClass[]> {
+  const url = searchText
+    ? `${BASE_URL}&SearchText=${encodeURIComponent(searchText)}`
+    : BASE_URL;
+  const res = await fetch(url, {
+    headers: { accept: "text/plain" },
+  });
+  if (!res.ok) {
+    throw new Error("Failed to fetch bSDD classes");
+  }
+  const data = await res.json();
+  return data.classes ?? [];
+}


### PR DESCRIPTION
## Summary
- add bSDD search modal for classifications
- integrate bSDD lookup in classification menu
- include translations and API service for bSDD classes

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b886e6478c8320801ded6b5682ef1d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added a modal to search and select bSDD classifications with live results, loading, error, and no-results states.
  * Integrated “Search bSDD” action into the classifications panel; selecting a result adds it to your classifications.

* Localization
  * Added new translations for the bSDD search UI in English, German, French, and Italian.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->