### PR TITLE
feat: add bSDD classification search modal

### DIFF
--- a/app/api/bsdd/dictionaries/route.ts
+++ b/app/api/bsdd/dictionaries/route.ts
@@ -1,0 +1,82 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const BSDD_BASE_URL = 'https://api.bsdd.buildingsmart.org';
+
+export async function GET(request: NextRequest) {
+    try {
+        const { searchParams } = new URL(request.url);
+
+        // Get optional parameters
+        const languageCode = searchParams.get('languageCode');
+        const includeTestDictionaries = searchParams.get('includeTestDictionaries') === 'true';
+
+        // Build the BSDD API URL
+        const bsddParams = new URLSearchParams();
+
+        if (languageCode) {
+            bsddParams.append('LanguageCode', languageCode);
+        }
+        if (includeTestDictionaries) {
+            bsddParams.append('IncludeTestDictionaries', 'true');
+        }
+
+        const bsddUrl = `${BSDD_BASE_URL}/api/Dictionary/v1${bsddParams.toString() ? '?' + bsddParams.toString() : ''}`;
+
+        // Make the request to BSDD API
+        const response = await fetch(bsddUrl, {
+            headers: {
+                'Accept': 'application/json',
+                'User-Agent': 'IFC-Classifier/1.0',
+            },
+            // Add timeout to prevent hanging requests
+            signal: AbortSignal.timeout(10000), // 10 second timeout
+        });
+
+        if (!response.ok) {
+            console.error(`BSDD API error: ${response.status} ${response.statusText}`);
+            return NextResponse.json(
+                { error: `BSDD API returned ${response.status}: ${response.statusText}` },
+                { status: response.status }
+            );
+        }
+
+        const data = await response.json();
+
+        // Return the response with proper CORS headers
+        return NextResponse.json(data, {
+            headers: {
+                'Access-Control-Allow-Origin': '*',
+                'Access-Control-Allow-Methods': 'GET, OPTIONS',
+                'Access-Control-Allow-Headers': 'Content-Type',
+            },
+        });
+
+    } catch (error) {
+        console.error('Error proxying BSDD dictionaries request:', error);
+
+        // Handle timeout errors specifically
+        if (error instanceof Error && error.name === 'AbortError') {
+            return NextResponse.json(
+                { error: 'Request to BSDD API timed out' },
+                { status: 408 }
+            );
+        }
+
+        return NextResponse.json(
+            { error: 'Internal server error while fetching from BSDD API' },
+            { status: 500 }
+        );
+    }
+}
+
+// Handle preflight requests for CORS
+export async function OPTIONS() {
+    return new NextResponse(null, {
+        status: 200,
+        headers: {
+            'Access-Control-Allow-Origin': '*',
+            'Access-Control-Allow-Methods': 'GET, OPTIONS',
+            'Access-Control-Allow-Headers': 'Content-Type',
+        },
+    });
+}

--- a/app/api/bsdd/dictionary-classes/route.ts
+++ b/app/api/bsdd/dictionary-classes/route.ts
@@ -1,0 +1,92 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const BSDD_BASE_URL = 'https://api.bsdd.buildingsmart.org';
+
+export async function GET(request: NextRequest) {
+    try {
+        const { searchParams } = new URL(request.url);
+
+        const uri = searchParams.get('Uri');
+        if (!uri) {
+            return NextResponse.json(
+                { error: 'Uri parameter is required' },
+                { status: 400 }
+            );
+        }
+
+        const bsddParams = new URLSearchParams();
+        bsddParams.append('Uri', uri);
+
+        const useNested = searchParams.get('UseNestedClasses');
+        const classType = searchParams.get('ClassType');
+        const searchText = searchParams.get('SearchText');
+        const relatedIfcEntity = searchParams.get('RelatedIfcEntity');
+        const relatedIfcEntities = searchParams.getAll('RelatedIfcEntities');
+        const offset = searchParams.get('Offset');
+        const limit = searchParams.get('Limit');
+        const languageCode = searchParams.get('languageCode');
+
+        if (useNested) bsddParams.append('UseNestedClasses', useNested);
+        if (classType) bsddParams.append('ClassType', classType);
+        if (searchText) bsddParams.append('SearchText', searchText);
+        if (relatedIfcEntity) bsddParams.append('RelatedIfcEntity', relatedIfcEntity);
+        if (relatedIfcEntities && relatedIfcEntities.length > 0) {
+            for (const e of relatedIfcEntities) bsddParams.append('RelatedIfcEntities', e);
+        }
+        if (offset) bsddParams.append('Offset', offset);
+        if (limit) bsddParams.append('Limit', limit);
+        if (languageCode) bsddParams.append('languageCode', languageCode);
+
+        const bsddUrl = `${BSDD_BASE_URL}/api/Dictionary/v1/Classes?${bsddParams.toString()}`;
+
+        const response = await fetch(bsddUrl, {
+            headers: {
+                'Accept': 'application/json',
+                'User-Agent': 'IFC-Classifier/1.0',
+            },
+            signal: AbortSignal.timeout(15000),
+        });
+
+        if (!response.ok) {
+            console.error(`BSDD API error: ${response.status} ${response.statusText}`);
+            return NextResponse.json(
+                { error: `BSDD API returned ${response.status}: ${response.statusText}` },
+                { status: response.status }
+            );
+        }
+
+        const data = await response.json();
+        return NextResponse.json(data, {
+            headers: {
+                'Access-Control-Allow-Origin': '*',
+                'Access-Control-Allow-Methods': 'GET, OPTIONS',
+                'Access-Control-Allow-Headers': 'Content-Type',
+            },
+        });
+    } catch (error) {
+        console.error('Error proxying BSDD dictionary classes request:', error);
+        if (error instanceof Error && error.name === 'AbortError') {
+            return NextResponse.json(
+                { error: 'Request to BSDD API timed out' },
+                { status: 408 }
+            );
+        }
+        return NextResponse.json(
+            { error: 'Internal server error while fetching from BSDD API' },
+            { status: 500 }
+        );
+    }
+}
+
+export async function OPTIONS() {
+    return new NextResponse(null, {
+        status: 200,
+        headers: {
+            'Access-Control-Allow-Origin': '*',
+            'Access-Control-Allow-Methods': 'GET, OPTIONS',
+            'Access-Control-Allow-Headers': 'Content-Type',
+        },
+    });
+}
+
+

--- a/app/api/bsdd/dictionary-properties/route.ts
+++ b/app/api/bsdd/dictionary-properties/route.ts
@@ -1,0 +1,82 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const BSDD_BASE_URL = 'https://api.bsdd.buildingsmart.org';
+
+export async function GET(request: NextRequest) {
+    try {
+        const { searchParams } = new URL(request.url);
+
+        const uri = searchParams.get('Uri');
+        if (!uri) {
+            return NextResponse.json(
+                { error: 'Uri parameter is required' },
+                { status: 400 }
+            );
+        }
+
+        const bsddParams = new URLSearchParams();
+        bsddParams.append('Uri', uri);
+
+        const searchText = searchParams.get('SearchText');
+        const offset = searchParams.get('Offset');
+        const limit = searchParams.get('Limit');
+        const languageCode = searchParams.get('languageCode');
+
+        if (searchText) bsddParams.append('SearchText', searchText);
+        if (offset) bsddParams.append('Offset', offset);
+        if (limit) bsddParams.append('Limit', limit);
+        if (languageCode) bsddParams.append('languageCode', languageCode);
+
+        const bsddUrl = `${BSDD_BASE_URL}/api/Dictionary/v1/Properties?${bsddParams.toString()}`;
+
+        const response = await fetch(bsddUrl, {
+            headers: {
+                'Accept': 'application/json',
+                'User-Agent': 'IFC-Classifier/1.0',
+            },
+            signal: AbortSignal.timeout(15000),
+        });
+
+        if (!response.ok) {
+            console.error(`BSDD API error: ${response.status} ${response.statusText}`);
+            return NextResponse.json(
+                { error: `BSDD API returned ${response.status}: ${response.statusText}` },
+                { status: response.status }
+            );
+        }
+
+        const data = await response.json();
+        return NextResponse.json(data, {
+            headers: {
+                'Access-Control-Allow-Origin': '*',
+                'Access-Control-Allow-Methods': 'GET, OPTIONS',
+                'Access-Control-Allow-Headers': 'Content-Type',
+            },
+        });
+    } catch (error) {
+        console.error('Error proxying BSDD dictionary properties request:', error);
+        if (error instanceof Error && error.name === 'AbortError') {
+            return NextResponse.json(
+                { error: 'Request to BSDD API timed out' },
+                { status: 408 }
+            );
+        }
+        return NextResponse.json(
+            { error: 'Internal server error while fetching from BSDD API' },
+            { status: 500 }
+        );
+    }
+}
+
+export async function OPTIONS() {
+    return new NextResponse(null, {
+        status: 200,
+        headers: {
+            'Access-Control-Allow-Origin': '*',
+            'Access-Control-Allow-Methods': 'GET, OPTIONS',
+            'Access-Control-Allow-Headers': 'Content-Type',
+        },
+    });
+}
+
+

--- a/app/api/bsdd/search/route.ts
+++ b/app/api/bsdd/search/route.ts
@@ -1,0 +1,101 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const BSDD_BASE_URL = 'https://api.bsdd.buildingsmart.org';
+const DEFAULT_DICTIONARY_URI = 'https://identifier.buildingsmart.org/uri/nbs/uniclass2015/1';
+
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url);
+    
+    // Get search parameters with defaults
+    const searchText = searchParams.get('searchText') || '';
+    const dictionaryUri = searchParams.get('dictionaryUri') || DEFAULT_DICTIONARY_URI;
+    const limit = searchParams.get('limit') || '100';
+    const languageCode = searchParams.get('languageCode');
+    const relatedIfcEntity = searchParams.get('relatedIfcEntity');
+    const offset = searchParams.get('offset') || '0';
+
+    // Validate required parameters
+    if (!searchText.trim()) {
+      return NextResponse.json(
+        { error: 'searchText parameter is required' },
+        { status: 400 }
+      );
+    }
+
+    // Build the BSDD API URL
+    const bsddParams = new URLSearchParams({
+      DictionaryUri: dictionaryUri,
+      SearchText: searchText,
+      Limit: limit,
+      Offset: offset,
+    });
+
+    // Add optional parameters if provided
+    if (languageCode) {
+      bsddParams.append('LanguageCode', languageCode);
+    }
+    if (relatedIfcEntity) {
+      bsddParams.append('RelatedIfcEntity', relatedIfcEntity);
+    }
+
+    const bsddUrl = `${BSDD_BASE_URL}/api/SearchInDictionary/v1?${bsddParams.toString()}`;
+
+    // Make the request to BSDD API
+    const response = await fetch(bsddUrl, {
+      headers: {
+        'Accept': 'application/json',
+        'User-Agent': 'IFC-Classifier/1.0',
+      },
+      // Add timeout to prevent hanging requests
+      signal: AbortSignal.timeout(10000), // 10 second timeout
+    });
+
+    if (!response.ok) {
+      console.error(`BSDD API error: ${response.status} ${response.statusText}`);
+      return NextResponse.json(
+        { error: `BSDD API returned ${response.status}: ${response.statusText}` },
+        { status: response.status }
+      );
+    }
+
+    const data = await response.json();
+
+    // Return the response with proper CORS headers
+    return NextResponse.json(data, {
+      headers: {
+        'Access-Control-Allow-Origin': '*',
+        'Access-Control-Allow-Methods': 'GET, OPTIONS',
+        'Access-Control-Allow-Headers': 'Content-Type',
+      },
+    });
+
+  } catch (error) {
+    console.error('Error proxying BSDD request:', error);
+    
+    // Handle timeout errors specifically
+    if (error instanceof Error && error.name === 'AbortError') {
+      return NextResponse.json(
+        { error: 'Request to BSDD API timed out' },
+        { status: 408 }
+      );
+    }
+    
+    return NextResponse.json(
+      { error: 'Internal server error while fetching from BSDD API' },
+      { status: 500 }
+    );
+  }
+}
+
+// Handle preflight requests for CORS
+export async function OPTIONS() {
+  return new NextResponse(null, {
+    status: 200,
+    headers: {
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Methods': 'GET, OPTIONS',
+      'Access-Control-Allow-Headers': 'Content-Type',
+    },
+  });
+}

--- a/app/api/bsdd/search/route.ts
+++ b/app/api/bsdd/search/route.ts
@@ -3,10 +3,19 @@ import { NextRequest, NextResponse } from 'next/server';
 const BSDD_BASE_URL = 'https://api.bsdd.buildingsmart.org';
 const DEFAULT_DICTIONARY_URI = 'https://identifier.buildingsmart.org/uri/nbs/uniclass2015/1';
 
+// Popular dictionaries for quick access
+const POPULAR_DICTIONARIES = [
+  'https://identifier.buildingsmart.org/uri/buildingsmart/ifc/4.3',
+  'https://identifier.buildingsmart.org/uri/nbs/uniclass2015/1',
+  'https://identifier.buildingsmart.org/uri/etim/etim/10.0',
+  'https://identifier.buildingsmart.org/uri/molio/cciconstruction/1.0',
+  'https://identifier.buildingsmart.org/uri/buildingsmart-de/LAFA1/1.0'
+];
+
 export async function GET(request: NextRequest) {
   try {
     const { searchParams } = new URL(request.url);
-    
+
     // Get search parameters with defaults
     const searchText = searchParams.get('searchText') || '';
     const dictionaryUri = searchParams.get('dictionaryUri') || DEFAULT_DICTIONARY_URI;
@@ -72,7 +81,7 @@ export async function GET(request: NextRequest) {
 
   } catch (error) {
     console.error('Error proxying BSDD request:', error);
-    
+
     // Handle timeout errors specifically
     if (error instanceof Error && error.name === 'AbortError') {
       return NextResponse.json(
@@ -80,7 +89,7 @@ export async function GET(request: NextRequest) {
         { status: 408 }
       );
     }
-    
+
     return NextResponse.json(
       { error: 'Internal server error while fetching from BSDD API' },
       { status: 500 }

--- a/app/api/bsdd/text-search/route.ts
+++ b/app/api/bsdd/text-search/route.ts
@@ -1,0 +1,124 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { searchBSDDGlobal } from '@/services/bsdd-service';
+
+const BSDD_BASE_URL = 'https://api.bsdd.buildingsmart.org';
+
+export async function GET(request: NextRequest) {
+    try {
+        const { searchParams } = new URL(request.url);
+
+        // Get search parameters with defaults
+        const searchText = searchParams.get('SearchText') || '';
+        const languageCode = searchParams.get('LanguageCode');
+        const relatedIfcEntity = searchParams.get('RelatedIfcEntity');
+        const offset = searchParams.get('Offset') || '0';
+        const limit = searchParams.get('Limit') || '100';
+        const typeFilter = searchParams.get('TypeFilter'); // 'Class', 'Property', 'Material', 'GroupOfProperties'
+
+        // Validate required parameters
+        if (!searchText.trim()) {
+            return NextResponse.json(
+                { error: 'SearchText parameter is required' },
+                { status: 400 }
+            );
+        }
+
+        // Convert typeFilter to the expected format
+        const typeFilterValue = typeFilter as 'Class' | 'Property' | 'Material' | 'GroupOfProperties' | undefined;
+
+        // For now, let's go back to the raw API call and see if that works
+        // Build the BSDD API URL for global text search
+        const bsddParams = new URLSearchParams({
+            SearchText: searchText,
+            Offset: offset,
+            Limit: limit,
+        });
+
+        // Add optional parameters if provided
+        if (languageCode) {
+            bsddParams.append('LanguageCode', languageCode);
+        }
+        if (relatedIfcEntity) {
+            bsddParams.append('RelatedIfcEntity', relatedIfcEntity);
+        }
+        if (typeFilter) {
+            bsddParams.append('TypeFilter', typeFilter);
+        }
+
+        const bsddUrl = `${BSDD_BASE_URL}/api/TextSearch/v2?${bsddParams.toString()}`;
+
+        // Make the request to BSDD API
+        const response = await fetch(bsddUrl, {
+            headers: {
+                'Accept': 'application/json',
+                'User-Agent': 'IFC-Classifier/1.0',
+            },
+            // Add timeout to prevent hanging requests
+            signal: AbortSignal.timeout(15000), // 15 second timeout for global search
+        });
+
+        if (!response.ok) {
+            console.error(`BSDD API error: ${response.status} ${response.statusText}`);
+            return NextResponse.json(
+                { error: `BSDD API returned ${response.status}: ${response.statusText}` },
+                { status: response.status }
+            );
+        }
+
+        const data = await response.json();
+
+        // Process the data to add dictionary names to classes
+        const dictionaryLookup: Record<string, string> = {};
+        (data.dictionaries ?? []).forEach((dict: any) => {
+            dictionaryLookup[dict.uri] = dict.name || 'Unknown';
+        });
+
+        // Add dictionary names to classes
+        const processedClasses = (data.classes ?? []).map((cls: any) => ({
+            ...cls,
+            dictionaryName: cls.dictionaryName || dictionaryLookup[cls.dictionaryUri] || null,
+        }));
+
+        const processedData = {
+            ...data,
+            classes: processedClasses,
+        };
+
+        // Return the response with proper CORS headers
+        return NextResponse.json(processedData, {
+            headers: {
+                'Access-Control-Allow-Origin': '*',
+                'Access-Control-Allow-Methods': 'GET, OPTIONS',
+                'Access-Control-Allow-Headers': 'Content-Type',
+            },
+        });
+
+    } catch (error) {
+        console.error('Error proxying BSDD text search request:', error);
+
+        // Handle timeout errors specifically
+        if (error instanceof Error && error.name === 'AbortError') {
+            return NextResponse.json(
+                { error: 'Request to BSDD API timed out' },
+                { status: 408 }
+            );
+        }
+
+        return NextResponse.json(
+            { error: 'Internal server error while fetching from BSDD API' },
+            { status: 500 }
+        );
+    }
+}
+
+// Handle preflight requests for CORS
+export async function OPTIONS() {
+    return new NextResponse(null, {
+        status: 200,
+        headers: {
+            'Access-Control-Allow-Origin': '*',
+            'Access-Control-Allow-Methods': 'GET, OPTIONS',
+            'Access-Control-Allow-Headers': 'Content-Type',
+        },
+    });
+}

--- a/components/bsdd-dialog.tsx
+++ b/components/bsdd-dialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback, useMemo } from "react";
 import {
   Dialog,
   DialogContent,
@@ -11,8 +11,36 @@ import {
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
-import { searchBSDDClasses, BsddClass } from "@/services/bsdd-service";
-import { Plus, Check, AlertCircle } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
+import {
+  searchBSDDInDictionaries,
+  getBSDDDictionaries,
+  POPULAR_DICTIONARIES,
+  BsddClass,
+  BsddDictionary
+} from "@/services/bsdd-service";
+import {
+  Plus,
+  Check,
+  AlertCircle,
+  Search,
+  Filter,
+  Globe,
+  X,
+  Loader2,
+  ExternalLink,
+  ChevronDown,
+  ChevronRight
+} from "lucide-react";
 import { useTranslation } from "react-i18next";
 
 interface BsddDialogProps {
@@ -20,6 +48,7 @@ interface BsddDialogProps {
   onOpenChange: (open: boolean) => void;
   onAdd: (item: { code: string; name: string; color: string }) => void;
   existingCodes: Set<string>;
+  onRemove?: (code: string) => void;
 }
 
 const generateRandomColor = () => {
@@ -54,39 +83,289 @@ const generateRandomColor = () => {
   return `#${toHex(r)}${toHex(g)}${toHex(b)}`;
 };
 
-export function BsddDialog({ open, onOpenChange, onAdd, existingCodes }: BsddDialogProps) {
+// Removed legacy search modes in favor of two-step flow
+
+export function BsddDialog({ open, onOpenChange, onAdd, existingCodes, onRemove }: BsddDialogProps) {
   const { t } = useTranslation();
+
+  // Step state
   const [query, setQuery] = useState("");
-  const [results, setResults] = useState<BsddClass[]>([]);
+  const [step, setStep] = useState<'select' | 'search'>("select");
+  const [selectedDictionaryUris, setSelectedDictionaryUris] = useState<string[]>([]);
+
+  // Results state
+  const [searchResults, setSearchResults] = useState<BsddClass[]>([]);
+  const [availableDictionaries, setAvailableDictionaries] = useState<BsddDictionary[]>([]);
+
+  // UI state
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [showFilters, setShowFilters] = useState(false);
+  const [dictionaryQuery, setDictionaryQuery] = useState("");
 
+  // Filter state
+  const [typeFilter, setTypeFilter] = useState<'all' | 'Class' | 'Property' | 'Material' | 'GroupOfProperties'>('all');
+  const [searchInFilter, setSearchInFilter] = useState<'all' | 'name' | 'definition' | 'code'>('all');
+  const [dictionaryFilter, setDictionaryFilter] = useState<string>('all');
+  const [sortBy, setSortBy] = useState<'relevance' | 'name' | 'dictionary'>('relevance');
+  const [expandedGroups, setExpandedGroups] = useState<Record<string, boolean>>({});
+  const [dictSortCategory, setDictSortCategory] = useState<'priority' | 'name' | 'code' | 'release' | 'updated' | 'status'>('priority');
+  const [dictSortAsc, setDictSortAsc] = useState<boolean>(true);
+
+  // Current results
+  const currentResults = searchResults;
+
+  // Extract unique dictionaries from current results for filtering
+  const availableDictionariesInResults = useMemo(() => {
+    const dictMap = new Map<string, { uri: string; name: string; version?: string }>();
+
+    currentResults.forEach(cls => {
+      if (cls.dictionaryUri) {
+        const existing = dictMap.get(cls.dictionaryUri);
+        if (!existing) {
+          // Try to find the full dictionary name from availableDictionaries first
+          const fullDict = availableDictionaries.find(dict => dict.uri === cls.dictionaryUri);
+          let dictName = 'Unknown';
+
+          if (fullDict) {
+            // Use the full name from availableDictionaries
+            dictName = fullDict.name;
+          } else if (cls.dictionaryName) {
+            // Fallback to classification's dictionary name
+            dictName = cls.dictionaryName;
+          } else if (cls.dictionaryUri) {
+            // Final fallback to URI extraction (same as display code)
+            const parts = cls.dictionaryUri.split('/');
+
+            // Get the dictionary identifier (second to last part usually)
+            let extractedName = '';
+            if (parts.length >= 2) {
+              extractedName = parts[parts.length - 2]; // cciconstruction, etim, ifc, etc.
+            }
+
+            // Remove version numbers if they're in the last part
+            const lastPart = parts[parts.length - 1] || '';
+            if (!/^(v?\d+\.?\d*|latest)$/i.test(lastPart)) {
+              extractedName = lastPart;
+            }
+
+            // Convert common abbreviations to readable names (same mapping as display code)
+            const nameMap: Record<string, string> = {
+              'ifc': 'IFC',
+              'etim': 'ETIM',
+              'uniclass2015': 'Uniclass',
+              'cciconstruction': 'CCI Construction',
+              'nlsfb2005': 'NL-SfB',
+              'buildingsmart': 'buildingSMART'
+            };
+
+            dictName = nameMap[extractedName.toLowerCase()] || extractedName || 'Unknown';
+          }
+
+          dictMap.set(cls.dictionaryUri, {
+            uri: cls.dictionaryUri,
+            name: dictName,
+            version: fullDict?.version
+          });
+        }
+      }
+    });
+
+    return Array.from(dictMap.values()).sort((a, b) => a.name.localeCompare(b.name));
+  }, [currentResults, availableDictionaries]);
+
+  const filteredDictionaries = useMemo(() => {
+    const q = dictionaryQuery.trim().toLowerCase();
+    if (!q) return availableDictionaries;
+    return availableDictionaries.filter((dict) => {
+      const name = (dict.name || "").toLowerCase();
+      const uri = (dict.uri || "").toLowerCase();
+      const org = (dict.organizationCode || "").toLowerCase();
+      const code = (dict.dictionaryCode || "").toLowerCase();
+      return name.includes(q) || uri.includes(q) || org.includes(q) || code.includes(q);
+    });
+  }, [availableDictionaries, dictionaryQuery]);
+
+  // Group dictionaries with same name; sort latest version first in each group
+  type DictGroup = { key: string; name: string; items: BsddDictionary[] };
+  const groupedDictionaries: DictGroup[] = useMemo(() => {
+    // Build groups keyed by normalized name
+    const groups = new Map<string, DictGroup>();
+
+    const normalize = (s?: string) => (s || '').trim().toLowerCase();
+    const deriveNameFromUri = (uri: string) => {
+      const parts = (uri || '').split('/');
+      let seg = '';
+      if (parts.length >= 2) seg = parts[parts.length - 2];
+      const last = parts[parts.length - 1] || '';
+      if (!/^(v?\d+\.?\d*|latest)$/i.test(last)) seg = last;
+      return seg || uri;
+    };
+
+    const parseVersion = (v?: string) => {
+      if (!v) return { major: -1, minor: -1, patch: -1 };
+      const m = v.replace(/^v/i, '').split('.').map((x) => Number(x));
+      return { major: m[0] || 0, minor: m[1] || 0, patch: m[2] || 0 };
+    };
+
+    for (const d of filteredDictionaries) {
+      const displayName = (d.name && d.name.trim()) || deriveNameFromUri(d.uri);
+      const key = normalize(displayName);
+      if (!groups.has(key)) {
+        groups.set(key, { key, name: displayName, items: [] });
+      }
+      groups.get(key)!.items.push(d);
+    }
+
+    // Sort versions in each group: newest first
+    const out: DictGroup[] = Array.from(groups.values()).map((g) => ({
+      ...g,
+      items: g.items.slice().sort((a, b) => {
+        const A = parseVersion(a.version);
+        const B = parseVersion(b.version);
+        if (B.major !== A.major) return B.major - A.major;
+        if (B.minor !== A.minor) return B.minor - A.minor;
+        if (B.patch !== A.patch) return B.patch - A.patch;
+        return (b.version || '').localeCompare(a.version || '');
+      })
+    }));
+
+    // Priority ordering based on availableDictionaries order (popular first)
+    const uriPriority = new Map<string, number>();
+    availableDictionaries.forEach((d, idx) => uriPriority.set(d.uri, idx));
+
+    // Sort groups per user setting
+    if (dictSortCategory === 'priority') {
+      out.sort((a, b) => {
+        const pa = Math.min(...a.items.map(it => uriPriority.get(it.uri) ?? Number.MAX_SAFE_INTEGER));
+        const pb = Math.min(...b.items.map(it => uriPriority.get(it.uri) ?? Number.MAX_SAFE_INTEGER));
+        if (pa !== pb) return pa - pb;
+        return a.name.localeCompare(b.name);
+      });
+    } else if (dictSortCategory === 'name') {
+      out.sort((a, b) => a.name.localeCompare(b.name) * (dictSortAsc ? 1 : -1));
+    } else if (dictSortCategory === 'code') {
+      const codeOf = (d: BsddDictionary) => (d.dictionaryCode || (d.uri.split('/').slice(-2, -1)[0] || d.uri)).toLowerCase();
+      const codeA = (g: DictGroup) => codeOf(g.items[0]);
+      out.sort((a, b) => codeA(a).localeCompare(codeA(b)) * (dictSortAsc ? 1 : -1));
+    } else if (dictSortCategory === 'release') {
+      const ts = (s?: string) => s ? Date.parse(s) || 0 : 0;
+      out.sort((a, b) => ((ts(b.items[0].releaseDate) - ts(a.items[0].releaseDate)) * (dictSortAsc ? 1 : -1)) || a.name.localeCompare(b.name));
+    } else if (dictSortCategory === 'updated') {
+      const ts = (s?: string) => s ? Date.parse(s) || 0 : 0;
+      out.sort((a, b) => ((ts(b.items[0].lastUpdatedUtc) - ts(a.items[0].lastUpdatedUtc)) * (dictSortAsc ? 1 : -1)) || a.name.localeCompare(b.name));
+    } else if (dictSortCategory === 'status') {
+      const val = (g: DictGroup) => (g.items[0].status || '').toLowerCase();
+      out.sort((a, b) => val(a).localeCompare(val(b)) * (dictSortAsc ? 1 : -1) || a.name.localeCompare(b.name));
+    }
+
+    return out;
+  }, [filteredDictionaries, availableDictionaries, dictSortCategory, dictSortAsc]);
+
+  // Load available dictionaries on open
   useEffect(() => {
     if (!open) return;
+
+    getBSDDDictionaries()
+      .then(apiDictionaries => {
+        // Prefer API data (authoritative names/codes), but keep Popular ordering on top
+        const apiMap = new Map<string, BsddDictionary>();
+        for (const d of apiDictionaries) apiMap.set(d.uri, d);
+
+        const popularOrdered: BsddDictionary[] = [];
+        for (const p of POPULAR_DICTIONARIES as BsddDictionary[]) {
+          const fromApi = apiMap.get(p.uri);
+          popularOrdered.push(fromApi ?? p);
+        }
+
+        // Append the rest of API dictionaries not already included
+        const rest = apiDictionaries.filter(d => !popularOrdered.some(x => x.uri === d.uri));
+
+        setAvailableDictionaries([...popularOrdered, ...rest]);
+      })
+      .catch(console.error);
+  }, [open]);
+
+  // Search effect across selected dictionaries
+  useEffect(() => {
+    if (!open || !query.trim()) {
+      setSearchResults([]);
+      setError(null);
+      return;
+    }
+
     const controller = new AbortController();
     const timer = setTimeout(() => {
-      if (!query.trim()) {
-        setResults([]);
+      setLoading(true);
+      setError(null);
+
+      // If no dictionaries selected yet, skip the search
+      if (selectedDictionaryUris.length === 0) {
+        setSearchResults([]);
+        setLoading(false);
         return;
       }
-      setLoading(true);
-      searchBSDDClasses(query, controller.signal)
-        .then((cls) => {
-          setResults(cls);
-          setError(null);
-        })
+
+      const searchPromise = searchBSDDInDictionaries(query, selectedDictionaryUris, {
+        limit: 250,
+        typeFilter: typeFilter === 'all' ? undefined : (typeFilter as 'Class' | 'Property' | 'Material' | 'GroupOfProperties'),
+        signal: controller.signal
+      }).then(result => {
+        // Apply client-side filtering based on searchInFilter
+        let filteredClasses = result.classes;
+
+        if (searchInFilter !== 'all') {
+          filteredClasses = result.classes.filter(cls => {
+            const searchTerm = query.toLowerCase();
+
+            switch (searchInFilter) {
+              case 'name':
+                return cls.name.toLowerCase().includes(searchTerm);
+              case 'definition':
+                return cls.definition && cls.definition.toLowerCase().includes(searchTerm);
+              case 'code':
+                return cls.code && cls.code.toLowerCase().includes(searchTerm);
+              default:
+                return true;
+            }
+          });
+        }
+
+        setSearchResults(filteredClasses);
+      });
+
+      searchPromise
         .catch((e) => {
-          setError(e instanceof Error ? e.message : String(e));
+          if (!controller.signal.aborted) {
+            setError(e instanceof Error ? e.message : String(e));
+          }
         })
-        .finally(() => setLoading(false));
+        .finally(() => {
+          if (!controller.signal.aborted) {
+            setLoading(false);
+          }
+        });
     }, 400);
+
     return () => {
       clearTimeout(timer);
       controller.abort();
     };
-  }, [query, open]);
+  }, [query, selectedDictionaryUris, typeFilter, searchInFilter, open]);
 
-  const handleAdd = (cls: BsddClass) => {
+  // No local selection state needed; rely on existingCodes from parent
+
+  // Reset dictionary filter if not present in current results
+  useEffect(() => {
+    if (dictionaryFilter !== 'all') {
+      const isFilterValid = availableDictionariesInResults.some(dict => dict.uri === dictionaryFilter);
+      if (!isFilterValid) {
+        setDictionaryFilter('all');
+      }
+    }
+  }, [availableDictionariesInResults, dictionaryFilter]);
+
+  const handleAdd = useCallback((cls: BsddClass) => {
     // Validate the classification object before adding
     if (!cls.code || !cls.name) {
       console.warn('Invalid BSDD classification: missing code or name', cls);
@@ -107,87 +386,674 @@ export function BsddDialog({ open, onOpenChange, onAdd, existingCodes }: BsddDia
       name: cls.name.trim() || cls.name,
       color: generateRandomColor()
     });
-    onOpenChange(false);
-  };
+  }, [onAdd]);
+
+  const handleRemove = useCallback((cls: BsddClass) => {
+    if (!cls.code) return;
+    if (typeof (onRemove) === 'function') {
+      onRemove(cls.code);
+    }
+  }, [onRemove]);
+
+  // Toggle add/remove directly
+  const handleToggleAddRemove = useCallback((cls: BsddClass) => {
+    if (existingCodes.has(cls.code)) {
+      handleRemove(cls);
+    } else {
+      handleAdd(cls);
+    }
+  }, [existingCodes, handleAdd, handleRemove]);
+
+  const [resultSortAsc, setResultSortAsc] = useState<boolean>(true);
+  const [hideAdded, setHideAdded] = useState<boolean>(false);
+
+  const filteredAndSortedResults = useMemo(() => {
+    let filtered = currentResults.filter(cls => {
+      // Dictionary filter on aggregated results
+      if (dictionaryFilter !== 'all') {
+        if (!cls.dictionaryUri?.includes(dictionaryFilter)) {
+          return false;
+        }
+      }
+      if (hideAdded && existingCodes.has(cls.code)) {
+        return false;
+      }
+      return true;
+    });
+
+    // Sort results
+    filtered.sort((a, b) => {
+      switch (sortBy) {
+        case 'name':
+          return a.name.localeCompare(b.name) * (resultSortAsc ? 1 : -1);
+        case 'dictionary':
+          // Extract clean dictionary names for sorting
+          const getDictionaryDisplayName = (cls: BsddClass) => {
+            if (cls.dictionaryName) return cls.dictionaryName;
+            if (cls.dictionaryUri) {
+              // Extract clean name from URI
+              // Example: https://identifier.buildingsmart.org/uri/molio/cciconstruction/1.0
+              const parts = cls.dictionaryUri.split('/');
+
+              // Get the dictionary identifier (second to last part usually)
+              let dictName = '';
+              if (parts.length >= 2) {
+                dictName = parts[parts.length - 2]; // cciconstruction, etim, ifc, etc.
+              }
+
+              // Remove version numbers if they're in the last part
+              const lastPart = parts[parts.length - 1] || '';
+              if (!/^(v?\d+\.?\d*|latest)$/i.test(lastPart)) {
+                dictName = lastPart;
+              }
+
+              // Convert common abbreviations to readable names
+              const nameMap: Record<string, string> = {
+                'ifc': 'IFC',
+                'etim': 'ETIM',
+                'uniclass2015': 'Uniclass 2015',
+                'cciconstruction': 'CCI Construction',
+                'nlsfb2005': 'NL-SfB 2005',
+                'buildingsmart': 'buildingSMART'
+              };
+
+              return nameMap[dictName.toLowerCase()] || dictName || 'Unknown';
+            }
+            return 'Unknown';
+          };
+
+          const dictA = getDictionaryDisplayName(a);
+          const dictB = getDictionaryDisplayName(b);
+
+          // First sort by dictionary name, then by classification name within dictionary
+          const dictComparison = dictA.localeCompare(dictB) * (resultSortAsc ? 1 : -1);
+          if (dictComparison !== 0) return dictComparison;
+          return a.name.localeCompare(b.name) * (resultSortAsc ? 1 : -1);
+
+        case 'relevance':
+        default:
+          // Keep original order (API relevance)
+          return 0;
+      }
+    });
+
+    return filtered;
+  }, [currentResults, dictionaryFilter, sortBy, resultSortAsc, hideAdded, existingCodes]);
+
+
+  const getDictionaryInfo = useCallback((cls: BsddClass): { code: string; name: string } => {
+    let code = '';
+    let name = '';
+
+    const found = cls.dictionaryUri ? availableDictionaries.find(d => d.uri === cls.dictionaryUri) : undefined;
+
+    // Prefer API-provided or looked-up human-friendly name
+    if (cls.dictionaryName && cls.dictionaryName.trim().length > 0) {
+      name = cls.dictionaryName;
+    } else if (found?.name && found.name.trim().length > 0) {
+      name = found.name;
+    }
+
+    // Determine code from lookup or URI
+    if (found?.dictionaryCode && found.dictionaryCode.trim().length > 0) {
+      code = found.dictionaryCode;
+    } else if (cls.dictionaryUri) {
+      const parts = cls.dictionaryUri.split('/');
+      let segment = '';
+      if (parts.length >= 2) {
+        segment = parts[parts.length - 2];
+      }
+      const lastPart = parts[parts.length - 1] || '';
+      if (!/^(v?\d+\.?\d*|latest)$/i.test(lastPart)) {
+        segment = lastPart;
+      }
+      code = segment || '';
+
+      // Provide nice fallback names for well-known codes when name missing
+      if (!name) {
+        const nameMap: Record<string, string> = {
+          'ifc': 'IFC',
+          'etim': 'ETIM',
+          'uniclass2015': 'Uniclass 2015',
+          'cciconstruction': 'CCI Construction',
+          'nlsfb2005': 'NL-SfB 2005',
+          'buildingsmart': 'buildingSMART'
+        };
+        name = nameMap[segment.toLowerCase()] || segment || 'Unknown';
+      }
+    }
+
+    return { code: code || 'Unknown', name: name || 'Unknown' };
+  }, [availableDictionaries]);
+
+
+  // No bulk add / select all
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-lg">
+      <DialogContent className="max-w-4xl max-h-[90vh] flex flex-col" aria-describedby="bsdd-dialog-description">
         <DialogHeader>
-          <DialogTitle>
-            {t("classifications.browseBSDDTitle", "Browse bSDD")}
+          <DialogTitle className="flex items-center gap-2">
+            <Globe className="h-5 w-5" />
+            {t("classifications.browseBSDDTitle", "Browse buildingSMART Data Dictionary")}
           </DialogTitle>
+          <div id="bsdd-dialog-description" className="sr-only">
+            Search and browse classifications from the buildingSMART Data Dictionary. You can search globally across all dictionaries or within specific standards.
+          </div>
         </DialogHeader>
-        <div className="flex flex-col gap-4 py-2">
-          <Input
-            placeholder={t(
-              "classifications.searchBSDDPlaceholder",
-              "Search bSDD...",
-            )}
-            value={query}
-            onChange={(e) => setQuery(e.target.value)}
-          />
-          <ScrollArea className="h-64 border rounded-md">
-            {loading && (
-              <div className="p-4 text-sm text-muted-foreground">
-                {t("buttons.loadingBSDD", "Loading bSDD...")}
+
+        <div className="flex-1 flex flex-col gap-4 py-2 min-h-0">
+          {/* Search Controls */}
+          <div className="flex flex-col gap-3">
+            {step === 'search' && (
+              <div className="flex gap-2 items-center">
+                <div className="flex-1 relative">
+                  <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+                  <Input
+                    placeholder={t("classifications.searchBSDDPlaceholder", "Search classifications...")}
+                    value={query}
+                    onChange={(e) => setQuery(e.target.value)}
+                    className="pl-9"
+                  />
+                </div>
+                <div className="hidden md:flex items-center gap-2 text-xs text-muted-foreground mr-1">
+                  <span>{sortBy === 'relevance' ? 'Relevance' : sortBy === 'name' ? 'Name' : 'Dictionary'}</span>
+                  {sortBy !== 'relevance' && (
+                    <Switch checked={resultSortAsc} onCheckedChange={setResultSortAsc} />
+                  )}
+                </div>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setShowFilters(!showFilters)}
+                >
+                  <Filter className="h-4 w-4 mr-1" />
+                  Filters
+                </Button>
+                <Button variant="ghost" size="sm" onClick={() => setStep('select')}>
+                  Change dictionaries
+                </Button>
               </div>
             )}
-            {error && (
-              <div className="p-4 text-sm text-destructive flex items-center gap-2">
-                <AlertCircle className="h-4 w-4" /> {error}
-              </div>
-            )}
-            {!loading && !error && !query.trim() && (
-              <div className="p-4 text-sm text-muted-foreground">
-                {t(
-                  "classifications.enterSearchTerm",
-                  "Enter a search term to browse bSDD.",
-                )}
-              </div>
-            )}
-            {!loading && !error && query.trim() && results.length === 0 && (
-              <div className="p-4 text-sm text-muted-foreground">
-                {t("classifications.noSearchResults")}
-              </div>
-            )}
-            {!loading && !error && results.length > 0 && (
-              <ul className="divide-y">
-                {results.map((cls) => {
-                  const added = existingCodes.has(cls.code);
-                  return (
-                    <li
-                      key={cls.code}
-                      className="flex items-center justify-between p-2"
-                    >
-                      <div className="mr-2">
-                        <div className="font-medium">{cls.code}</div>
-                        <div className="text-sm text-muted-foreground">
-                          {cls.name}
+
+            {/* Step 1: select dictionaries */}
+            {step === 'select' && (
+              <div className="flex flex-col gap-3">
+                <div className="text-sm text-muted-foreground">
+                  Choose one or more dictionaries to search in.
+                </div>
+                <div className="relative">
+                  <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+                  <Input
+                    value={dictionaryQuery}
+                    onChange={(e) => setDictionaryQuery(e.target.value)}
+                    placeholder="Filter dictionaries..."
+                    className="pl-9"
+                  />
+                </div>
+                <div className="border rounded-md">
+                  <ScrollArea className="h-[60vh]">
+                    <div className="flex items-center justify-end px-2 py-1 sticky top-0 bg-background/80 backdrop-blur supports-[backdrop-filter]:bg-background/60 border-b z-10">
+                      {dictSortCategory !== 'priority' && (
+                        <div className="flex items-center gap-2 mr-3">
+                          <div className="text-xs text-muted-foreground">{(dictSortCategory === 'release' || dictSortCategory === 'updated') ? (dictSortAsc ? 'Newest' : 'Oldest') : (dictSortAsc ? 'A-Z' : 'Z-A')}</div>
+                          <Switch checked={dictSortAsc} onCheckedChange={setDictSortAsc} />
                         </div>
-                      </div>
-                      {added ? (
-                        <Button variant="secondary" size="sm" disabled>
-                          <Check className="h-4 w-4 mr-1" />
-                          {t("buttons.added", "Added")}
-                        </Button>
-                      ) : (
-                        <Button size="sm" onClick={() => handleAdd(cls)}>
-                          <Plus className="h-4 w-4 mr-1" />
-                          {t("buttons.add")}
-                        </Button>
                       )}
-                    </li>
-                  );
-                })}
-              </ul>
+                      <div className="text-xs mr-2 text-muted-foreground">Sort</div>
+                      <Select value={dictSortCategory} onValueChange={(v) => setDictSortCategory(v as any)}>
+                        <SelectTrigger className="h-7 w-[180px]">
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="priority">Popular first</SelectItem>
+                          <SelectItem value="name">Name</SelectItem>
+                          <SelectItem value="code">Code</SelectItem>
+                          <SelectItem value="release">Release date</SelectItem>
+                          <SelectItem value="updated">Last updated</SelectItem>
+                          <SelectItem value="status">Status</SelectItem>
+                        </SelectContent>
+                      </Select>
+                    </div>
+                    <div className="p-1 grid grid-cols-1 gap-2">
+                      {groupedDictionaries.map((group) => {
+                        const latest = group.items[0];
+                        const latestChecked = selectedDictionaryUris.includes(latest.uri);
+                        const expanded = !!expandedGroups[group.key];
+                        const hasMultiple = group.items.length > 1;
+                        return (
+                          <div key={group.key} className="border rounded-md">
+                            <div className={`flex items-center gap-3 p-3 cursor-pointer hover:bg-muted/50 ${latestChecked ? 'bg-primary/5' : ''}`}
+                              tabIndex={0}
+                              role="button"
+                              onKeyDown={(e) => {
+                                if (e.key === 'Enter' || e.key === ' ') {
+                                  e.preventDefault();
+                                  if ((e.target as HTMLElement).closest('a')) return;
+                                  setSelectedDictionaryUris((prev) => {
+                                    if (!latestChecked) return [...prev, latest.uri];
+                                    return prev.filter(u => u !== latest.uri);
+                                  });
+                                }
+                              }}
+                              onClick={(e) => {
+                                if ((e.target as HTMLElement).closest('a')) return;
+                                setSelectedDictionaryUris((prev) => {
+                                  if (!latestChecked) return [...prev, latest.uri];
+                                  return prev.filter(u => u !== latest.uri);
+                                });
+                              }}
+                            >
+                              {hasMultiple && (
+                                <button type="button" className="p-1" onClick={(e) => { e.stopPropagation(); setExpandedGroups(prev => ({ ...prev, [group.key]: !expanded })); }}>
+                                  {expanded ? <ChevronDown className="h-4 w-4" /> : <ChevronRight className="h-4 w-4" />}
+                                </button>
+                              )}
+                              <Checkbox
+                                checked={latestChecked}
+                                onClick={(e) => { e.stopPropagation(); }}
+                                onCheckedChange={(value) => {
+                                  setSelectedDictionaryUris((prev) => {
+                                    if (value) {
+                                      if (prev.includes(latest.uri)) return prev;
+                                      return [...prev, latest.uri];
+                                    } else {
+                                      return prev.filter((u) => u !== latest.uri);
+                                    }
+                                  });
+                                }}
+                              />
+                              <div className="flex-1 min-w-0">
+                                <div className="flex items-center justify-between">
+                                  <div className="font-medium truncate">{group.name}</div>
+                                  <div className="flex items-center gap-2 ml-2 shrink-0">
+                                    <Badge variant="outline">{latest.version ? `v${latest.version}` : ' '}</Badge>
+                                    {(() => {
+                                      const parts = (latest.uri || '').split('/');
+                                      let segment = '';
+                                      if (parts.length >= 2) segment = parts[parts.length - 2];
+                                      const lastPart = parts[parts.length - 1] || '';
+                                      if (!/^(v?\d+\.?\d*|latest)$/i.test(lastPart)) segment = lastPart;
+                                      const codeValue = (latest.dictionaryCode || segment || '').trim();
+                                      return (
+                                        <Badge variant="secondary" className="text-xs" title="Dictionary code">
+                                          {codeValue || 'Unknown'}
+                                        </Badge>
+                                      );
+                                    })()}
+                                    <a
+                                      href={latest.uri}
+                                      target="_blank"
+                                      rel="noopener noreferrer"
+                                      onClick={(e) => e.stopPropagation()}
+                                      className="text-xs text-muted-foreground hover:text-primary inline-flex items-center gap-1"
+                                      title="Open dictionary"
+                                    >
+                                      <ExternalLink className="h-3 w-3" />
+                                    </a>
+                                  </div>
+                                </div>
+                                <div className="text-xs text-muted-foreground truncate" title={latest.uri}>{latest.uri}</div>
+                              </div>
+                            </div>
+                            {expanded && hasMultiple && group.items.slice(1).map((dict) => {
+                              const checked = selectedDictionaryUris.includes(dict.uri);
+                              return (
+                                <div key={dict.uri} className={`flex items-center gap-3 p-3 pl-8 cursor-pointer hover:bg-muted/50 ${checked ? 'bg-primary/5' : ''}`}
+                                  tabIndex={0}
+                                  role="button"
+                                  onKeyDown={(e) => {
+                                    if (e.key === 'Enter' || e.key === ' ') {
+                                      e.preventDefault();
+                                      if ((e.target as HTMLElement).closest('a')) return;
+                                      setSelectedDictionaryUris((prev) => {
+                                        if (!checked) return [...prev, dict.uri];
+                                        return prev.filter(u => u !== dict.uri);
+                                      });
+                                    }
+                                  }}
+                                  onClick={(e) => {
+                                    if ((e.target as HTMLElement).closest('a')) return;
+                                    setSelectedDictionaryUris((prev) => {
+                                      if (!checked) return [...prev, dict.uri];
+                                      return prev.filter(u => u !== dict.uri);
+                                    });
+                                  }}
+                                >
+                                  <Checkbox
+                                    checked={checked}
+                                    onClick={(e) => { e.stopPropagation(); }}
+                                    onCheckedChange={(value) => {
+                                      setSelectedDictionaryUris((prev) => {
+                                        if (value) {
+                                          if (prev.includes(dict.uri)) return prev;
+                                          return [...prev, dict.uri];
+                                        } else {
+                                          return prev.filter((u) => u !== dict.uri);
+                                        }
+                                      });
+                                    }}
+                                  />
+                                  <div className="flex-1 min-w-0">
+                                    <div className="flex items-center justify-between">
+                                      <div className="font-medium truncate">{dict.name}</div>
+                                      <div className="flex items-center gap-2 ml-2 shrink-0">
+                                        <Badge variant="outline">{dict.version ? `v${dict.version}` : ' '}</Badge>
+                                        {(() => {
+                                          const parts = (dict.uri || '').split('/');
+                                          let segment = '';
+                                          if (parts.length >= 2) segment = parts[parts.length - 2];
+                                          const lastPart = parts[parts.length - 1] || '';
+                                          if (!/^(v?\d+\.?\d*|latest)$/i.test(lastPart)) segment = lastPart;
+                                          const codeValue = (dict.dictionaryCode || segment || '').trim();
+                                          return (
+                                            <Badge variant="secondary" className="text-xs" title="Dictionary code">
+                                              {codeValue || 'Unknown'}
+                                            </Badge>
+                                          );
+                                        })()}
+                                        <a
+                                          href={dict.uri}
+                                          target="_blank"
+                                          rel="noopener noreferrer"
+                                          onClick={(e) => e.stopPropagation()}
+                                          className="text-xs text-muted-foreground hover:text-primary inline-flex items-center gap-1"
+                                          title="Open dictionary"
+                                        >
+                                          <ExternalLink className="h-3 w-3" />
+                                        </a>
+                                      </div>
+                                    </div>
+                                    <div className="text-xs text-muted-foreground truncate" title={dict.uri}>{dict.uri}</div>
+                                  </div>
+                                </div>
+                              );
+                            })}
+                          </div>
+                        );
+                      })}
+                    </div>
+                  </ScrollArea>
+                </div>
+
+                <div className="flex items-center justify-between">
+                  <div className="text-sm text-muted-foreground">
+                    {selectedDictionaryUris.length > 0 ? `${selectedDictionaryUris.length} selected` : 'No dictionary selected'}
+                  </div>
+                  <div className="flex gap-2">
+                    {selectedDictionaryUris.length > 0 && (
+                      <Button variant="ghost" size="sm" onClick={() => setSelectedDictionaryUris([])}>
+                        <X className="h-4 w-4 mr-1" /> Clear
+                      </Button>
+                    )}
+                    <Button size="sm" disabled={selectedDictionaryUris.length === 0} onClick={() => setStep('search')}>
+                      Continue
+                    </Button>
+                  </div>
+                </div>
+              </div>
             )}
-          </ScrollArea>
+
+            {/* Filters */}
+            {showFilters && step === 'search' && (
+              <div className="grid grid-cols-2 gap-3 p-3 bg-muted/50 rounded-lg">
+                <div className="grid grid-cols-2 gap-2">
+                  <div>
+                    <label className="text-sm font-medium mb-1 block">Type</label>
+                    <Select value={typeFilter} onValueChange={(value) => setTypeFilter(value as 'all' | 'Class' | 'Property' | 'Material' | 'GroupOfProperties')}>
+                      <SelectTrigger>
+                        <SelectValue placeholder="All types" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="all">All types</SelectItem>
+                        <SelectItem value="Class">Classes</SelectItem>
+                        <SelectItem value="Property">Properties</SelectItem>
+                        <SelectItem value="Material">Materials</SelectItem>
+                        <SelectItem value="GroupOfProperties">Property Groups</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </div>
+                  <div>
+                    <label className="text-sm font-medium mb-1 block">Sort by</label>
+                    <Select value={sortBy} onValueChange={(value) => setSortBy(value as 'relevance' | 'name' | 'dictionary')}>
+                      <SelectTrigger>
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="relevance">Relevance</SelectItem>
+                        <SelectItem value="name">Name A-Z</SelectItem>
+                        <SelectItem value="dictionary">Dictionary</SelectItem>
+                      </SelectContent>
+                    </Select>
+                    {sortBy !== 'relevance' && (
+                      <div className="mt-2 flex items-center gap-2 text-xs text-muted-foreground">
+                        <span>{resultSortAsc ? 'A-Z / A→Z' : 'Z-A / Z→A'}</span>
+                        <Switch checked={resultSortAsc} onCheckedChange={setResultSortAsc} />
+                      </div>
+                    )}
+                  </div>
+                </div>
+                <div className="grid grid-cols-2 gap-2">
+                  <div>
+                    <label className="text-sm font-medium mb-1 block">Search In</label>
+                    <Select value={searchInFilter} onValueChange={(value) => setSearchInFilter(value as 'all' | 'name' | 'definition' | 'code')}>
+                      <SelectTrigger>
+                        <SelectValue placeholder="Search everywhere" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="all">All fields</SelectItem>
+                        <SelectItem value="name">Name only</SelectItem>
+                        <SelectItem value="definition">Definition only</SelectItem>
+                        <SelectItem value="code">Code only</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </div>
+                  {availableDictionariesInResults.length > 0 && (
+                    <div>
+                      <label className="text-sm font-medium mb-1 block">Dictionary</label>
+                      <Select value={dictionaryFilter} onValueChange={setDictionaryFilter}>
+                        <SelectTrigger>
+                          <SelectValue placeholder="All dictionaries" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="all">All dictionaries</SelectItem>
+                          {availableDictionariesInResults.map((dict) => (
+                            <SelectItem key={dict.uri} value={dict.uri}>
+                              <div className="flex flex-col">
+                                <div className="font-medium">{dict.name}</div>
+                                <div className="text-xs text-muted-foreground">
+                                  {dict.version && `v${dict.version}`}
+                                </div>
+                              </div>
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                      <div className="mt-2 flex items-center gap-2 text-xs text-muted-foreground">
+                        <span>Hide added</span>
+                        <Switch checked={hideAdded} onCheckedChange={setHideAdded} />
+                      </div>
+                    </div>
+                  )}
+                </div>
+              </div>
+            )}
+          </div>
+
+          {/* Results */}
+          <div className="flex-1 flex flex-col min-h-0">
+            {step === 'search' && (
+              <>
+                {/* Bulk Actions */}
+                {/* No bulk actions */}
+
+                <div className="flex-1 border rounded-b-lg overflow-hidden">
+                  <ScrollArea className="h-[60vh]">
+                    {loading && (
+                      <div className="flex items-center justify-center p-8">
+                        <Loader2 className="h-6 w-6 animate-spin mr-2" />
+                        <span className="text-muted-foreground">
+                          {t("buttons.loadingBSDD", "Searching bSDD...")}
+                        </span>
+                      </div>
+                    )}
+
+                    {error && (
+                      <div className="p-4 text-sm text-destructive flex items-center gap-2">
+                        <AlertCircle className="h-4 w-4" /> {error}
+                      </div>
+                    )}
+
+                    {!loading && !error && !query.trim() && (
+                      <div className="p-8 text-center text-muted-foreground">
+                        <Search className="h-12 w-12 mx-auto mb-3 opacity-50" />
+                        <p className="text-lg font-medium mb-1">Search the bSDD</p>
+                        <p className="text-sm">Search within your selected dictionaries</p>
+                      </div>
+                    )}
+
+                    {!loading && !error && query.trim() && filteredAndSortedResults.length === 0 && (
+                      <div className="p-8 text-center text-muted-foreground">
+                        <AlertCircle className="h-12 w-12 mx-auto mb-3 opacity-50" />
+                        <p className="text-lg font-medium mb-1">No results found</p>
+                        <p className="text-sm">
+                          Try adjusting your search terms or filters
+                        </p>
+                      </div>
+                    )}
+
+                    {!loading && !error && filteredAndSortedResults.length > 0 && (
+                      <div className="divide-y">
+                        {filteredAndSortedResults.map((cls) => {
+                          const isAdded = existingCodes.has(cls.code);
+                          const isSelected = existingCodes.has(cls.code);
+
+                          return (
+                            <div
+                              key={cls.code}
+                              className={`flex items-start gap-3 p-4 hover:bg-muted/50 transition-colors ${isSelected ? 'bg-primary/5' : ''}`}
+                            >
+                              <Checkbox
+                                checked={isSelected}
+                                onClick={(e) => { e.stopPropagation(); handleToggleAddRemove(cls); }}
+                                onCheckedChange={() => handleToggleAddRemove(cls)}
+                                className="mt-1"
+                              />
+
+                              <div className="flex-1 min-w-0">
+                                <div className="flex items-start justify-between gap-3">
+                                  <div className="flex-1 min-w-0">
+                                    <div className="flex items-start justify-between gap-2 mb-1">
+                                      <div className="flex items-center gap-2 flex-wrap">
+                                        <code className="font-mono text-sm font-medium bg-muted px-2 py-0.5 rounded">
+                                          {cls.code}
+                                        </code>
+                                        {cls.classType && (
+                                          <Badge variant="outline" className="text-xs">
+                                            {cls.classType}
+                                          </Badge>
+                                        )}
+                                        {(cls.dictionaryName || cls.dictionaryUri) && (() => {
+                                          const info = getDictionaryInfo(cls);
+                                          const nameValue = (info.name || '').trim();
+                                          const codeValue = (info.code || '').trim();
+                                          const showCode = !!codeValue; // always show code if present
+                                          return (
+                                            <div className="flex items-center gap-2">
+                                              <Badge variant="secondary" className="text-xs shrink-0" title={cls.dictionaryUri}>
+                                                {info.name}
+                                              </Badge>
+                                              {showCode && (
+                                                <Badge variant="outline" className="text-xs shrink-0" title="Dictionary code">
+                                                  {info.code}
+                                                </Badge>
+                                              )}
+                                              {cls.uri && (
+                                                <a
+                                                  href={cls.uri}
+                                                  target="_blank"
+                                                  rel="noopener noreferrer"
+                                                  className="inline-flex items-center gap-1 text-xs text-primary hover:underline"
+                                                  title="Open in bSDD"
+                                                >
+                                                  View
+                                                  <ExternalLink className="h-3 w-3" />
+                                                </a>
+                                              )}
+                                            </div>
+                                          );
+                                        })()}
+                                      </div>
+                                    </div>
+                                    <p className="text-sm font-medium text-foreground mb-1">
+                                      {cls.name}
+                                    </p>
+                                    {cls.definition && (
+                                      <p className="text-xs text-muted-foreground line-clamp-2 mb-2">
+                                        {cls.definition}
+                                      </p>
+                                    )}
+                                    {cls.synonyms && cls.synonyms.length > 0 && (
+                                      <div className="flex flex-wrap gap-1 mt-2">
+                                        {cls.synonyms.slice(0, 2).map((synonym, idx) => (
+                                          <Badge key={idx} variant="outline" className="text-xs">
+                                            {synonym}
+                                          </Badge>
+                                        ))}
+                                        {cls.synonyms.length > 2 && (
+                                          <Badge variant="outline" className="text-xs">
+                                            +{cls.synonyms.length - 2} more
+                                          </Badge>
+                                        )}
+                                      </div>
+                                    )}
+                                  </div>
+
+                                  <div className="flex items-center gap-2">
+                                    {isAdded ? (
+                                      <Button variant="secondary" size="sm" onClick={(e) => { e.stopPropagation(); handleToggleAddRemove(cls); }}>
+                                        <Check className="h-4 w-4 mr-1" />
+                                        Remove
+                                      </Button>
+                                    ) : (
+                                      <Button size="sm" onClick={(e) => { e.stopPropagation(); handleToggleAddRemove(cls); }}>
+                                        <Plus className="h-4 w-4 mr-1" />
+                                        Add
+                                      </Button>
+                                    )}
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          );
+                        })}
+                      </div>
+                    )}
+                  </ScrollArea>
+                </div>
+              </>
+            )}
+          </div>
         </div>
+
         <DialogFooter>
-          <Button variant="outline" onClick={() => onOpenChange(false)}>
-            {t("buttons.cancel")}
-          </Button>
+          <div className="flex items-center justify-between w-full">
+            <div className="text-sm text-muted-foreground">
+              {filteredAndSortedResults.length > 0 && (
+                <span>
+                  {filteredAndSortedResults.length} result{filteredAndSortedResults.length === 1 ? '' : 's'}
+                  {dictionaryFilter !== 'all' && ' (filtered)'}
+                  {searchInFilter !== 'all' && ` (searching ${searchInFilter})`}
+                  {sortBy !== 'relevance' && ` (sorted by ${sortBy})`}
+                </span>
+              )}
+            </div>
+            <div className="flex gap-2">
+              <Button variant="outline" onClick={() => onOpenChange(false)}>
+                {t("buttons.cancel")}
+              </Button>
+            </div>
+          </div>
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/components/bsdd-dialog.tsx
+++ b/components/bsdd-dialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback, useMemo } from "react";
+import { useState, useEffect, useCallback, useMemo, useRef } from "react";
 import {
   Dialog,
   DialogContent,
@@ -26,7 +26,8 @@ import {
   getBSDDDictionaries,
   POPULAR_DICTIONARIES,
   BsddClass,
-  BsddDictionary
+  BsddDictionary,
+  fetchDictionaryClasses
 } from "@/services/bsdd-service";
 import {
   Plus,
@@ -95,11 +96,19 @@ export function BsddDialog({ open, onOpenChange, onAdd, existingCodes, onRemove 
 
   // Results state
   const [searchResults, setSearchResults] = useState<BsddClass[]>([]);
+  const [prefetchedResults, setPrefetchedResults] = useState<BsddClass[]>([]);
   const [availableDictionaries, setAvailableDictionaries] = useState<BsddDictionary[]>([]);
 
   // UI state
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [prefetchLoading, setPrefetchLoading] = useState(false);
+  const [prefetchError, setPrefetchError] = useState<string | null>(null);
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
+  const loadingMoreRef = useRef(false);
+  const prefetchOffsetsRef = useRef<Record<string, number>>({});
+  const lastPrefetchKeyRef = useRef<string>("");
+  const selectionKey = useMemo(() => selectedDictionaryUris.slice().sort().join('|'), [selectedDictionaryUris]);
   const [showFilters, setShowFilters] = useState(false);
   const [dictionaryQuery, setDictionaryQuery] = useState("");
 
@@ -113,7 +122,9 @@ export function BsddDialog({ open, onOpenChange, onAdd, existingCodes, onRemove 
   const [dictSortAsc, setDictSortAsc] = useState<boolean>(true);
 
   // Current results
-  const currentResults = searchResults;
+  const currentResults = useMemo(() => (query.trim() ? searchResults : prefetchedResults), [query, searchResults, prefetchedResults]);
+  const overallLoading = query.trim() ? loading : prefetchLoading;
+  const overallError = query.trim() ? error : prefetchError;
 
   // Extract unique dictionaries from current results for filtering
   const availableDictionariesInResults = useMemo(() => {
@@ -288,8 +299,10 @@ export function BsddDialog({ open, onOpenChange, onAdd, existingCodes, onRemove 
 
   // Search effect across selected dictionaries
   useEffect(() => {
-    if (!open || !query.trim()) {
-      setSearchResults([]);
+    if (!open) return;
+    if (!query.trim()) {
+      // switching back to empty query: use prefetched list, stop loading
+      setLoading(false);
       setError(null);
       return;
     }
@@ -352,6 +365,143 @@ export function BsddDialog({ open, onOpenChange, onAdd, existingCodes, onRemove 
       controller.abort();
     };
   }, [query, selectedDictionaryUris, typeFilter, searchInFilter, open]);
+
+  // Prefetch classes from selected dictionaries when entering search step with empty query
+  useEffect(() => {
+    if (!open) return;
+    if (step !== 'search') return;
+    if (query.trim()) return; // if user already typed, don't prefetch
+    if (selectedDictionaryUris.length === 0) {
+      setPrefetchedResults([]);
+      setPrefetchError(null);
+      return;
+    }
+
+    // If selection unchanged and we already have data, don't reload
+    if (lastPrefetchKeyRef.current === selectionKey && prefetchedResults.length > 0) {
+      setPrefetchLoading(false);
+      return;
+    }
+
+    const controller = new AbortController();
+    setPrefetchLoading(true);
+    setPrefetchError(null);
+    prefetchOffsetsRef.current = Object.fromEntries(selectedDictionaryUris.map(u => [u, 0]));
+    lastPrefetchKeyRef.current = selectionKey;
+
+    Promise.allSettled(selectedDictionaryUris.map(async (uri) => {
+      // Fetch first page (up to 1000) of classes per dictionary for initial browse
+      const data = await fetchDictionaryClasses({ uri, limit: 1000, offset: 0, signal: controller.signal });
+      const classes = (data.classes ?? []);
+      // Map to BsddClass
+      return classes.map((cls: any) => {
+        let finalCode = cls.referenceCode ?? cls.code ?? "";
+        if (!finalCode.trim()) {
+          const name = cls.name || "";
+          if (name) {
+            finalCode = name.split(' ').slice(0, 3).map((w: string) => w.substring(0, 3).toUpperCase()).join('-').replace(/[^A-Z0-9\-]/g, '');
+          }
+        }
+        const dict = availableDictionaries.find(d => d.uri === uri);
+        return {
+          uri: cls.uri,
+          code: finalCode,
+          name: cls.name ?? "",
+          classType: cls.classType ?? "",
+          referenceCode: cls.referenceCode,
+          dictionaryName: dict?.name,
+          dictionaryUri: uri,
+          definition: cls.definition ?? cls.descriptionPart,
+          synonyms: cls.synonyms,
+        } as BsddClass;
+      }).filter((c: BsddClass) => c.name && c.name.trim().length > 0);
+    }))
+      .then((results) => {
+        const agg: BsddClass[] = [];
+        const seen = new Set<string>();
+        for (const r of results) {
+          if (r.status === 'fulfilled') {
+            for (const c of r.value) {
+              const key = c.uri || `${c.dictionaryUri}::${c.code}`;
+              if (!seen.has(key)) {
+                seen.add(key);
+                agg.push(c);
+              }
+            }
+          }
+        }
+        setPrefetchedResults(agg);
+      })
+      .catch((e) => {
+        if (!controller.signal.aborted) setPrefetchError(e instanceof Error ? e.message : String(e));
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) setPrefetchLoading(false);
+      });
+
+    return () => controller.abort();
+  }, [open, step, query, selectedDictionaryUris, availableDictionaries]);
+
+  const maybeLoadMorePrefetch = useCallback(async () => {
+    if (!open) return;
+    if (step !== 'search') return;
+    if (query.trim()) return;
+    if (isLoadingMore || loadingMoreRef.current) return;
+    loadingMoreRef.current = true;
+    setIsLoadingMore(true);
+
+    const controller = new AbortController();
+    try {
+      const results = await Promise.allSettled(selectedDictionaryUris.map(async (uri) => {
+        const currentOffset = prefetchOffsetsRef.current[uri] ?? 0;
+        const nextOffset = currentOffset + 1000;
+        prefetchOffsetsRef.current[uri] = nextOffset;
+        const data = await fetchDictionaryClasses({ uri, limit: 1000, offset: nextOffset, signal: controller.signal });
+        const classes = (data.classes ?? []);
+        const dict = availableDictionaries.find(d => d.uri === uri);
+        return classes.map((cls: any) => {
+          let finalCode = cls.referenceCode ?? cls.code ?? "";
+          if (!finalCode.trim()) {
+            const name = cls.name || "";
+            if (name) {
+              finalCode = name.split(' ').slice(0, 3).map((w: string) => w.substring(0, 3).toUpperCase()).join('-').replace(/[^A-Z0-9\-]/g, '');
+            }
+          }
+          return {
+            uri: cls.uri,
+            code: finalCode,
+            name: cls.name ?? "",
+            classType: cls.classType ?? "",
+            referenceCode: cls.referenceCode,
+            dictionaryName: dict?.name,
+            dictionaryUri: uri,
+            definition: cls.definition ?? cls.descriptionPart,
+            synonyms: cls.synonyms,
+          } as BsddClass;
+        }).filter((c: BsddClass) => c.name && c.name.trim().length > 0);
+      }));
+
+      const more: BsddClass[] = [];
+      const seen = new Set<string>(prefetchedResults.map(c => c.uri || `${c.dictionaryUri}::${c.code}`));
+      for (const r of results) {
+        if (r.status === 'fulfilled') {
+          for (const c of r.value) {
+            const key = c.uri || `${c.dictionaryUri}::${c.code}`;
+            if (!seen.has(key)) {
+              seen.add(key);
+              more.push(c);
+            }
+          }
+        }
+      }
+      if (more.length > 0) setPrefetchedResults(prev => [...prev, ...more]);
+    } catch (e) {
+      // ignore
+    } finally {
+      setIsLoadingMore(false);
+      loadingMoreRef.current = false;
+    }
+  }, [open, step, query, selectedDictionaryUris, prefetchedResults, availableDictionaries, isLoadingMore]);
 
   // No local selection state needed; rely on existingCodes from parent
 
@@ -888,23 +1038,30 @@ export function BsddDialog({ open, onOpenChange, onAdd, existingCodes, onRemove 
                 {/* No bulk actions */}
 
                 <div className="flex-1 border rounded-b-lg overflow-hidden">
-                  <ScrollArea className="h-[60vh]">
-                    {loading && (
+                  <ScrollArea className="h-[60vh]" viewportProps={{
+                    onScroll: (e) => {
+                      const tgt = e.currentTarget;
+                      if (tgt.scrollHeight - tgt.scrollTop - tgt.clientHeight < 200) {
+                        maybeLoadMorePrefetch();
+                      }
+                    }
+                  }}>
+                    {overallLoading && (
                       <div className="flex items-center justify-center p-8">
                         <Loader2 className="h-6 w-6 animate-spin mr-2" />
                         <span className="text-muted-foreground">
-                          {t("buttons.loadingBSDD", "Searching bSDD...")}
+                          {query.trim() ? t("buttons.loadingBSDD", "Searching bSDD...") : 'Loading dictionary content...'}
                         </span>
                       </div>
                     )}
 
-                    {error && (
+                    {overallError && (
                       <div className="p-4 text-sm text-destructive flex items-center gap-2">
-                        <AlertCircle className="h-4 w-4" /> {error}
+                        <AlertCircle className="h-4 w-4" /> {overallError}
                       </div>
                     )}
 
-                    {!loading && !error && !query.trim() && (
+                    {!overallLoading && !overallError && !query.trim() && (
                       <div className="p-8 text-center text-muted-foreground">
                         <Search className="h-12 w-12 mx-auto mb-3 opacity-50" />
                         <p className="text-lg font-medium mb-1">Search the bSDD</p>
@@ -912,7 +1069,7 @@ export function BsddDialog({ open, onOpenChange, onAdd, existingCodes, onRemove 
                       </div>
                     )}
 
-                    {!loading && !error && query.trim() && filteredAndSortedResults.length === 0 && (
+                    {!overallLoading && !overallError && query.trim() && filteredAndSortedResults.length === 0 && (
                       <div className="p-8 text-center text-muted-foreground">
                         <AlertCircle className="h-12 w-12 mx-auto mb-3 opacity-50" />
                         <p className="text-lg font-medium mb-1">No results found</p>
@@ -922,7 +1079,7 @@ export function BsddDialog({ open, onOpenChange, onAdd, existingCodes, onRemove 
                       </div>
                     )}
 
-                    {!loading && !error && filteredAndSortedResults.length > 0 && (
+                    {!overallLoading && !overallError && filteredAndSortedResults.length > 0 && (
                       <div className="divide-y">
                         {filteredAndSortedResults.map((cls) => {
                           const isAdded = existingCodes.has(cls.code);

--- a/components/bsdd-dialog.tsx
+++ b/components/bsdd-dialog.tsx
@@ -1,0 +1,164 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { fetchBSDDClasses, BsddClass } from "@/services/bsdd-service";
+import { Plus, Check, AlertCircle } from "lucide-react";
+import { useTranslation } from "react-i18next";
+
+interface BsddDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onAdd: (item: { code: string; name: string; color: string }) => void;
+  existingCodes: Set<string>;
+}
+
+const generateRandomColor = () => {
+  const hue = Math.floor(Math.random() * 360);
+  const saturation = 70 + Math.floor(Math.random() * 20);
+  const lightness = 45 + Math.floor(Math.random() * 10);
+  const h = hue / 360;
+  const s = saturation / 100;
+  const l = lightness / 100;
+  let r: number, g: number, b: number;
+  if (s === 0) {
+    r = g = b = l;
+  } else {
+    const hue2rgb = (p: number, q: number, t: number): number => {
+      if (t < 0) t += 1;
+      if (t > 1) t -= 1;
+      if (t < 1 / 6) return p + (q - p) * 6 * t;
+      if (t < 1 / 2) return q;
+      if (t < 2 / 3) return p + (q - p) * (2 / 3 - t) * 6;
+      return p;
+    };
+    const q = l < 0.5 ? l * (1 + s) : l + s - l * s;
+    const p = 2 * l - q;
+    r = hue2rgb(p, q, h + 1 / 3);
+    g = hue2rgb(p, q, h);
+    b = hue2rgb(p, q, h - 1 / 3);
+  }
+  const toHex = (x: number): string => {
+    const hex = Math.round(x * 255).toString(16);
+    return hex.length === 1 ? "0" + hex : hex;
+  };
+  return `#${toHex(r)}${toHex(g)}${toHex(b)}`;
+};
+
+export function BsddDialog({ open, onOpenChange, onAdd, existingCodes }: BsddDialogProps) {
+  const { t } = useTranslation();
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState<BsddClass[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const controller = new AbortController();
+    const timer = setTimeout(() => {
+      setLoading(true);
+      fetchBSDDClasses(query, controller.signal)
+        .then((cls) => {
+          setResults(cls);
+          setError(null);
+        })
+        .catch((e) => {
+          setError(e instanceof Error ? e.message : String(e));
+        })
+        .finally(() => setLoading(false));
+    }, 400);
+    return () => {
+      clearTimeout(timer);
+      controller.abort();
+    };
+  }, [query, open]);
+
+  const handleAdd = (cls: BsddClass) => {
+    onAdd({ code: cls.code, name: cls.name, color: generateRandomColor() });
+    onOpenChange(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>
+            {t("classifications.browseBSDDTitle", "Browse bSDD")}
+          </DialogTitle>
+        </DialogHeader>
+        <div className="flex flex-col gap-4 py-2">
+          <Input
+            placeholder={t(
+              "classifications.searchBSDDPlaceholder",
+              "Search bSDD...",
+            )}
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+          />
+          <ScrollArea className="h-64 border rounded-md">
+            {loading && (
+              <div className="p-4 text-sm text-muted-foreground">
+                {t("buttons.loadingBSDD", "Loading bSDD...")}
+              </div>
+            )}
+            {error && (
+              <div className="p-4 text-sm text-destructive flex items-center gap-2">
+                <AlertCircle className="h-4 w-4" /> {error}
+              </div>
+            )}
+            {!loading && !error && results.length === 0 && (
+              <div className="p-4 text-sm text-muted-foreground">
+                {t("classifications.noSearchResults")}
+              </div>
+            )}
+            {!loading && !error && results.length > 0 && (
+              <ul className="divide-y">
+                {results.map((cls) => {
+                  const added = existingCodes.has(cls.code);
+                  return (
+                    <li
+                      key={cls.code}
+                      className="flex items-center justify-between p-2"
+                    >
+                      <div className="mr-2">
+                        <div className="font-medium">{cls.code}</div>
+                        <div className="text-sm text-muted-foreground">
+                          {cls.name}
+                        </div>
+                      </div>
+                      {added ? (
+                        <Button variant="secondary" size="sm" disabled>
+                          <Check className="h-4 w-4 mr-1" />
+                          {t("buttons.added", "Added")}
+                        </Button>
+                      ) : (
+                        <Button size="sm" onClick={() => handleAdd(cls)}>
+                          <Plus className="h-4 w-4 mr-1" />
+                          {t("buttons.add")}
+                        </Button>
+                      )}
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+          </ScrollArea>
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            {t("buttons.cancel")}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/bsdd-dialog.tsx
+++ b/components/bsdd-dialog.tsx
@@ -87,7 +87,26 @@ export function BsddDialog({ open, onOpenChange, onAdd, existingCodes }: BsddDia
   }, [query, open]);
 
   const handleAdd = (cls: BsddClass) => {
-    onAdd({ code: cls.code, name: cls.name, color: generateRandomColor() });
+    // Validate the classification object before adding
+    if (!cls.code || !cls.name) {
+      console.warn('Invalid BSDD classification: missing code or name', cls);
+      setError('Invalid classification data from BSDD');
+      return;
+    }
+
+    // Ensure code is trimmed and not empty after trimming
+    const trimmedCode = cls.code.trim();
+    if (!trimmedCode) {
+      console.warn('Invalid BSDD classification: empty code after trimming', cls);
+      setError('Classification code cannot be empty');
+      return;
+    }
+
+    onAdd({
+      code: trimmedCode,
+      name: cls.name.trim() || cls.name,
+      color: generateRandomColor()
+    });
     onOpenChange(false);
   };
 

--- a/components/bsdd-dialog.tsx
+++ b/components/bsdd-dialog.tsx
@@ -11,7 +11,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
-import { fetchBSDDClasses, BsddClass } from "@/services/bsdd-service";
+import { searchBSDDClasses, BsddClass } from "@/services/bsdd-service";
 import { Plus, Check, AlertCircle } from "lucide-react";
 import { useTranslation } from "react-i18next";
 
@@ -65,8 +65,12 @@ export function BsddDialog({ open, onOpenChange, onAdd, existingCodes }: BsddDia
     if (!open) return;
     const controller = new AbortController();
     const timer = setTimeout(() => {
+      if (!query.trim()) {
+        setResults([]);
+        return;
+      }
       setLoading(true);
-      fetchBSDDClasses(query, controller.signal)
+      searchBSDDClasses(query, controller.signal)
         .then((cls) => {
           setResults(cls);
           setError(null);
@@ -115,7 +119,15 @@ export function BsddDialog({ open, onOpenChange, onAdd, existingCodes }: BsddDia
                 <AlertCircle className="h-4 w-4" /> {error}
               </div>
             )}
-            {!loading && !error && results.length === 0 && (
+            {!loading && !error && !query.trim() && (
+              <div className="p-4 text-sm text-muted-foreground">
+                {t(
+                  "classifications.enterSearchTerm",
+                  "Enter a search term to browse bSDD.",
+                )}
+              </div>
+            )}
+            {!loading && !error && query.trim() && results.length === 0 && (
               <div className="p-4 text-sm text-muted-foreground">
                 {t("classifications.noSearchResults")}
               </div>

--- a/components/classification-panel.tsx
+++ b/components/classification-panel.tsx
@@ -1419,23 +1419,26 @@ export function ClassificationPanel() {
               >
                 {t("buttons.cancel")}
               </Button>
-          <Button onClick={handleAddClassification}>
-            {t("buttons.add")}
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
-    <BsddDialog
-      open={isBsddDialogOpen}
-      onOpenChange={setIsBsddDialogOpen}
-      onAdd={(item) => addClassification(item)}
-      existingCodes={new Set(Object.keys(classifications))}
-    />
-    {/* The old "Row 2 Management Dropdown section" is now fully replaced by the 3-dot menu in the header and this restored dialog. */}
-    {/* The hidden file input for import is kept at the end of the component. */}
-    <Dialog
-      open={isMapFromModelDialogOpen}
-      onOpenChange={(open) => {
+              <Button onClick={handleAddClassification}>
+                {t("buttons.add")}
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+        <BsddDialog
+          open={isBsddDialogOpen}
+          onOpenChange={setIsBsddDialogOpen}
+          onAdd={(item) => addClassification({
+            ...item,
+            elements: [] // Ensure elements array is present for BSDD classifications
+          } as ClassificationItem)}
+          existingCodes={new Set(Object.keys(classifications))}
+        />
+        {/* The old "Row 2 Management Dropdown section" is now fully replaced by the 3-dot menu in the header and this restored dialog. */}
+        {/* The hidden file input for import is kept at the end of the component. */}
+        <Dialog
+          open={isMapFromModelDialogOpen}
+          onOpenChange={(open) => {
             setIsMapFromModelDialogOpen(open);
             if (!open) {
               // Reset form state when closing

--- a/components/classification-panel.tsx
+++ b/components/classification-panel.tsx
@@ -146,6 +146,7 @@ export function ClassificationPanel() {
   const { t } = useTranslation();
   const [isAddDialogOpen, setIsAddDialogOpen] = useState(false);
   const [isBsddDialogOpen, setIsBsddDialogOpen] = useState(false);
+  const [bsddFeatureSeen, setBsddFeatureSeen] = useState(false);
   const [newClassification, setNewClassification] = useState({
     code: "",
     name: "",
@@ -416,6 +417,13 @@ export function ClassificationPanel() {
   }, [exportableModels, selectedModelIdForExport]);
 
   useEffect(() => {
+    // Feature highlight: show pulse on 3-dot menu until user opens it once
+    try {
+      const seen = localStorage.getItem("bsddFeatureSeen");
+      setBsddFeatureSeen(seen === "true");
+    } catch (e) {
+      // ignore
+    }
     const fetchUniclassData = async () => {
       setIsLoadingUniclass(true);
       setErrorLoadingUniclass(null);
@@ -1134,12 +1142,28 @@ export function ClassificationPanel() {
               </div>
             </TooltipProvider>
             {/* 3-dot Manage Menu */}
-            <DropdownMenu>
+            <DropdownMenu onOpenChange={(open) => {
+              if (open && !bsddFeatureSeen) {
+                try { localStorage.setItem("bsddFeatureSeen", "true"); } catch { }
+                setBsddFeatureSeen(true);
+              }
+            }}>
               <DropdownMenuTrigger asChild>
-                <Button variant="ghost" size="sm" className="p-1.5 h-auto">
+                <Button variant="ghost" size="sm" className={`p-1.5 h-auto relative overflow-visible`}>
                   {" "}
                   {/* Subtle look */}
                   <MoreHorizontal className="w-5 h-5 text-muted-foreground" />
+                  {!bsddFeatureSeen && (
+                    <>
+                      {/* Glow ping dot */}
+                      <span className="pointer-events-none absolute -top-1.5 -right-1.5 w-3.5 h-3.5 rounded-full bg-primary/70 animate-ping" />
+                      <span className="pointer-events-none absolute -top-1.5 -right-1.5 w-3.5 h-3.5 rounded-full bg-primary shadow-sm" />
+                      {/* Floating label */}
+                      <span className="pointer-events-none select-none absolute right-6 top-full mt-1 bg-primary text-primary-foreground text-[10px] leading-none px-2 py-1 rounded-full shadow-md animate-bounce">
+                        bSDD search
+                      </span>
+                    </>
+                  )}
                   <span className="sr-only">{t("classifications.manageClassifications")}</span>
                 </Button>
               </DropdownMenuTrigger>
@@ -1148,14 +1172,15 @@ export function ClassificationPanel() {
                   <Plus className="mr-2 h-4 w-4" />
                   {t("classifications.addNew")}
                 </DropdownMenuItem>
-                <DropdownMenuItem onSelect={() => setIsBsddDialogOpen(true)}>
-                  <Search className="mr-2 h-4 w-4" />
-                  {t("buttons.browseBSDD", "Browse bSDD")}
-                </DropdownMenuItem>
                 <DropdownMenuSeparator />
                 <DropdownMenuLabel className="text-xs font-semibold text-muted-foreground px-2 py-1.5">
                   {t("sections.defaultSets")}
                 </DropdownMenuLabel>
+                <DropdownMenuItem onSelect={() => setIsBsddDialogOpen(true)}>
+                  <Search className="mr-2 h-4 w-4" />
+                  {t("buttons.browseBSDD", "Browse bSDD")}
+                  <Badge className="ml-2" variant="secondary">New</Badge>
+                </DropdownMenuItem>
                 {isLoadingEBKPH && (
                   <DropdownMenuItem disabled>
                     {t("buttons.loadingEbkph")}
@@ -1433,6 +1458,7 @@ export function ClassificationPanel() {
             elements: [] // Ensure elements array is present for BSDD classifications
           } as ClassificationItem)}
           existingCodes={new Set(Object.keys(classifications))}
+          onRemove={(code) => removeClassification(code)}
         />
         {/* The old "Row 2 Management Dropdown section" is now fully replaced by the 3-dot menu in the header and this restored dialog. */}
         {/* The hidden file input for import is kept at the end of the component. */}

--- a/components/classification-panel.tsx
+++ b/components/classification-panel.tsx
@@ -70,6 +70,7 @@ import {
   ArchiveRestore,
   Star,
   Cuboid,
+  Search,
 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import {
@@ -78,6 +79,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { BsddDialog } from "@/components/bsdd-dialog";
 import {
   exportIfcWithClassificationsService,
   downloadFile,
@@ -143,6 +145,7 @@ export function ClassificationPanel() {
   } = useIFCContext();
   const { t } = useTranslation();
   const [isAddDialogOpen, setIsAddDialogOpen] = useState(false);
+  const [isBsddDialogOpen, setIsBsddDialogOpen] = useState(false);
   const [newClassification, setNewClassification] = useState({
     code: "",
     name: "",
@@ -1145,6 +1148,10 @@ export function ClassificationPanel() {
                   <Plus className="mr-2 h-4 w-4" />
                   {t("classifications.addNew")}
                 </DropdownMenuItem>
+                <DropdownMenuItem onSelect={() => setIsBsddDialogOpen(true)}>
+                  <Search className="mr-2 h-4 w-4" />
+                  {t("buttons.browseBSDD", "Browse bSDD")}
+                </DropdownMenuItem>
                 <DropdownMenuSeparator />
                 <DropdownMenuLabel className="text-xs font-semibold text-muted-foreground px-2 py-1.5">
                   {t("sections.defaultSets")}
@@ -1412,17 +1419,23 @@ export function ClassificationPanel() {
               >
                 {t("buttons.cancel")}
               </Button>
-              <Button onClick={handleAddClassification}>
-                {t("buttons.add")}
-              </Button>
-            </DialogFooter>
-          </DialogContent>
-        </Dialog>
-        {/* The old "Row 2 Management Dropdown section" is now fully replaced by the 3-dot menu in the header and this restored dialog. */}
-        {/* The hidden file input for import is kept at the end of the component. */}
-        <Dialog
-          open={isMapFromModelDialogOpen}
-          onOpenChange={(open) => {
+          <Button onClick={handleAddClassification}>
+            {t("buttons.add")}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+    <BsddDialog
+      open={isBsddDialogOpen}
+      onOpenChange={setIsBsddDialogOpen}
+      onAdd={(item) => addClassification(item)}
+      existingCodes={new Set(Object.keys(classifications))}
+    />
+    {/* The old "Row 2 Management Dropdown section" is now fully replaced by the 3-dot menu in the header and this restored dialog. */}
+    {/* The hidden file input for import is kept at the end of the component. */}
+    <Dialog
+      open={isMapFromModelDialogOpen}
+      onOpenChange={(open) => {
             setIsMapFromModelDialogOpen(open);
             if (!open) {
               // Reset form state when closing

--- a/components/ui/scroll-area.tsx
+++ b/components/ui/scroll-area.tsx
@@ -5,16 +5,20 @@ import * as ScrollAreaPrimitive from "@radix-ui/react-scroll-area"
 
 import { cn } from "@/lib/utils"
 
+type ScrollAreaProps = React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.Root> & {
+  viewportProps?: React.HTMLAttributes<HTMLDivElement>
+}
+
 const ScrollArea = React.forwardRef<
   React.ElementRef<typeof ScrollAreaPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.Root>
->(({ className, children, ...props }, ref) => (
+  ScrollAreaProps
+>(({ className, children, viewportProps, ...props }, ref) => (
   <ScrollAreaPrimitive.Root
     ref={ref}
     className={cn("relative overflow-hidden", className)}
     {...props}
   >
-    <ScrollAreaPrimitive.Viewport className="h-full w-full rounded-[inherit]">
+    <ScrollAreaPrimitive.Viewport className="h-full w-full rounded-[inherit]" {...viewportProps}>
       {children}
     </ScrollAreaPrimitive.Viewport>
     <ScrollBar />
@@ -33,9 +37,9 @@ const ScrollBar = React.forwardRef<
     className={cn(
       "flex touch-none select-none transition-colors",
       orientation === "vertical" &&
-        "h-full w-2.5 border-l border-l-transparent p-[1px]",
+      "h-full w-2.5 border-l border-l-transparent p-[1px]",
       orientation === "horizontal" &&
-        "h-2.5 flex-col border-t border-t-transparent p-[1px]",
+      "h-2.5 flex-col border-t border-t-transparent p-[1px]",
       className
     )}
     {...props}

--- a/components/ui/scroll-area.tsx
+++ b/components/ui/scroll-area.tsx
@@ -18,9 +18,17 @@ const ScrollArea = React.forwardRef<
     className={cn("relative overflow-hidden", className)}
     {...props}
   >
-    <ScrollAreaPrimitive.Viewport className="h-full w-full rounded-[inherit]" {...viewportProps}>
-      {children}
-    </ScrollAreaPrimitive.Viewport>
+    {(() => {
+      const { className: vpClassName, ...vpRest } = viewportProps ?? {}
+      return (
+        <ScrollAreaPrimitive.Viewport
+          className={cn("h-full w-full rounded-[inherit]", vpClassName)}
+          {...vpRest}
+        >
+          {children}
+        </ScrollAreaPrimitive.Viewport>
+      )
+    })()}
     <ScrollBar />
     <ScrollAreaPrimitive.Corner />
   </ScrollAreaPrimitive.Root>

--- a/public/locales/de/common.json
+++ b/public/locales/de/common.json
@@ -138,7 +138,10 @@
     "deleteRule": "Regel löschen",
     "previewRule": "Regelauswirkung anzeigen",
     "clearPreview": "Vorschau zurücksetzen",
-    "mapFromModel": "Aus Modell übernehmen"
+    "mapFromModel": "Aus Modell übernehmen",
+    "browseBSDD": "bSDD durchsuchen",
+    "loadingBSDD": "bSDD wird geladen...",
+    "added": "Hinzugefügt"
   },
   "messages": {
     "loading": "Wird geladen...",
@@ -215,6 +218,8 @@
     "classificationPlural": "Klassifikationen",
     "searchPlaceholder": "Klassifizierungen durchsuchen...",
     "noSearchResults": "Keine Klassifizierungen entsprechen Ihrer Suche.",
+    "browseBSDDTitle": "bSDD durchsuchen",
+    "searchBSDDPlaceholder": "bSDD durchsuchen...",
     "noClassificationFound": "Keine Klassifizierung gefunden. Tippen Sie, um zu erstellen.",
     "createNewClassification": "Neue Klassifizierung \"{{value}}\" erstellen",
     "mapFromModelTitle": "Klassifizierungen aus Modell übernehmen",

--- a/public/locales/de/common.json
+++ b/public/locales/de/common.json
@@ -220,6 +220,7 @@
     "noSearchResults": "Keine Klassifizierungen entsprechen Ihrer Suche.",
     "browseBSDDTitle": "bSDD durchsuchen",
     "searchBSDDPlaceholder": "bSDD durchsuchen...",
+    "enterSearchTerm": "Suchbegriff eingeben, um im bSDD zu stöbern.",
     "noClassificationFound": "Keine Klassifizierung gefunden. Tippen Sie, um zu erstellen.",
     "createNewClassification": "Neue Klassifizierung \"{{value}}\" erstellen",
     "mapFromModelTitle": "Klassifizierungen aus Modell übernehmen",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -216,6 +216,7 @@
     "noSearchResults": "No classifications match your search.",
     "browseBSDDTitle": "Browse bSDD",
     "searchBSDDPlaceholder": "Search bSDD...",
+    "enterSearchTerm": "Enter a search term to browse bSDD.",
     "mapFromModelTitle": "Map Classifications from Model",
     "mapFromModelDescription": "Extract classifications from property values in the model",
     "export": "Export",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -138,7 +138,10 @@
     "deleteRule": "Delete Rule",
     "previewRule": "Preview Rule Impact",
     "clearPreview": "Clear Preview",
-    "mapFromModel": "Map From Model"
+    "mapFromModel": "Map From Model",
+    "browseBSDD": "Browse bSDD",
+    "loadingBSDD": "Loading bSDD...",
+    "added": "Added"
   },
   "messages": {
     "loading": "Loading...",
@@ -211,6 +214,8 @@
     "classificationPlural": "classifications",
     "searchPlaceholder": "Search classifications...",
     "noSearchResults": "No classifications match your search.",
+    "browseBSDDTitle": "Browse bSDD",
+    "searchBSDDPlaceholder": "Search bSDD...",
     "mapFromModelTitle": "Map Classifications from Model",
     "mapFromModelDescription": "Extract classifications from property values in the model",
     "export": "Export",

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -138,7 +138,10 @@
         "deleteRule": "Supprimer la règle",
         "previewRule": "Prévisualiser l'impact de la règle",
         "clearPreview": "Effacer la prévisualisation",
-        "mapFromModel": "Mapper depuis le modèle"
+        "mapFromModel": "Mapper depuis le modèle",
+        "browseBSDD": "Parcourir bSDD",
+        "loadingBSDD": "Chargement bSDD...",
+        "added": "Ajouté"
     },
     "messages": {
         "loading": "Chargement...",
@@ -215,6 +218,8 @@
         "classificationPlural": "classifications",
         "searchPlaceholder": "Rechercher des classifications...",
         "noSearchResults": "Aucune classification ne correspond à votre recherche.",
+        "browseBSDDTitle": "Parcourir bSDD",
+        "searchBSDDPlaceholder": "Rechercher dans bSDD...",
         "mapFromModelTitle": "Mapper les classifications depuis le modèle",
         "mapFromModelDescription": "Extraire les classifications des valeurs de propriétés dans le modèle",
         "psetName": "Nom du PSet",

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -220,6 +220,7 @@
         "noSearchResults": "Aucune classification ne correspond à votre recherche.",
         "browseBSDDTitle": "Parcourir bSDD",
         "searchBSDDPlaceholder": "Rechercher dans bSDD...",
+        "enterSearchTerm": "Saisissez un terme de recherche pour parcourir le bSDD.",
         "mapFromModelTitle": "Mapper les classifications depuis le modèle",
         "mapFromModelDescription": "Extraire les classifications des valeurs de propriétés dans le modèle",
         "psetName": "Nom du PSet",

--- a/public/locales/it/common.json
+++ b/public/locales/it/common.json
@@ -138,7 +138,10 @@
         "deleteRule": "Elimina regola",
         "previewRule": "Anteprima impatto regola",
         "clearPreview": "Cancella anteprima",
-        "mapFromModel": "Mappa dal modello"
+        "mapFromModel": "Mappa dal modello",
+        "browseBSDD": "Sfoglia bSDD",
+        "loadingBSDD": "Caricamento bSDD...",
+        "added": "Aggiunto"
     },
     "messages": {
         "loading": "Caricamento...",
@@ -215,6 +218,8 @@
         "classificationPlural": "classificazioni",
         "searchPlaceholder": "Cerca classificazioni...",
         "noSearchResults": "Nessuna classificazione corrisponde alla tua ricerca.",
+        "browseBSDDTitle": "Sfoglia bSDD",
+        "searchBSDDPlaceholder": "Cerca in bSDD...",
         "mapFromModelTitle": "Mappa classificazioni dal modello",
         "mapFromModelDescription": "Estrai classificazioni dai valori delle proprietà nel modello",
         "psetName": "Nome PSet",

--- a/public/locales/it/common.json
+++ b/public/locales/it/common.json
@@ -220,6 +220,7 @@
         "noSearchResults": "Nessuna classificazione corrisponde alla tua ricerca.",
         "browseBSDDTitle": "Sfoglia bSDD",
         "searchBSDDPlaceholder": "Cerca in bSDD...",
+        "enterSearchTerm": "Inserisci un termine di ricerca per esplorare il bSDD.",
         "mapFromModelTitle": "Mappa classificazioni dal modello",
         "mapFromModelDescription": "Estrai classificazioni dai valori delle proprietà nel modello",
         "psetName": "Nome PSet",

--- a/services/bsdd-service.ts
+++ b/services/bsdd-service.ts
@@ -3,10 +3,75 @@ export interface BsddClass {
   code: string;
   name: string;
   classType: string;
+  referenceCode?: string;
+  dictionaryName?: string;
+  dictionaryUri?: string;
+  definition?: string;
+  synonyms?: string[];
+}
+
+export interface BsddDictionary {
+  uri: string;
+  name: string;
+  version?: string;
+  organizationCode?: string;
+  organizationNameOwner?: string;
+  dictionaryCode?: string;
+  qualityAssuranceProcedure?: string;
+  status?: string;
+  isLatestVersion?: boolean;
+  isVerified?: boolean;
+  isPrivate?: boolean;
+  releaseDate?: string;
+  lastUpdatedUtc?: string;
+}
+
+export interface BsddSearchResult {
+  classes: BsddClass[];
+  totalCount: number;
+  offset: number;
+  count: number;
+}
+
+export interface BsddGlobalSearchResult {
+  classes: BsddClass[];
+  dictionaries: BsddDictionary[];
+  totalCount: number;
+  offset: number;
+  count: number;
 }
 
 const BSDD_DICTIONARY_URI =
   "https://identifier.buildingsmart.org/uri/nbs/uniclass2015/1";
+
+// Popular dictionaries for quick selection
+export const POPULAR_DICTIONARIES = [
+  {
+    uri: 'https://identifier.buildingsmart.org/uri/buildingsmart/ifc/4.3',
+    name: 'IFC 4.3',
+    description: 'Industry Foundation Classes'
+  },
+  {
+    uri: 'https://identifier.buildingsmart.org/uri/nbs/uniclass2015/1',
+    name: 'Uniclass 2015',
+    description: 'UK Classification System'
+  },
+  {
+    uri: 'https://identifier.buildingsmart.org/uri/etim/etim/10.0',
+    name: 'ETIM 10.0',
+    description: 'Technical Information Model'
+  },
+  {
+    uri: 'https://identifier.buildingsmart.org/uri/molio/cciconstruction/1.0',
+    name: 'CCI Construction',
+    description: 'Molio Construction Classification'
+  },
+  {
+    uri: 'https://identifier.buildingsmart.org/uri/buildingsmart-de/LAFA1/1.0',
+    name: 'LAFA1',
+    description: 'German Building Classification'
+  }
+];
 
 export async function searchBSDDClasses(
   search: string,
@@ -41,19 +106,44 @@ export async function searchBSDDClasses(
     const data = await res.json();
     const classes = data.dictionary?.classes ?? [];
 
-    return classes.map((cls: any) => ({
-      uri: cls.uri,
-      code: cls.referenceCode ?? cls.code ?? "",
-      name: cls.name ?? "",
-      classType: cls.classType ?? "",
-    })).filter((cls) => {
-      // Filter out invalid classifications
-      const hasValidCode = cls.code && cls.code.trim().length > 0;
+    return classes.map((cls: any) => {
+      // Improved code fallback logic
+      let finalCode = cls.referenceCode ?? cls.code ?? "";
+
+      // If still no code, generate a synthetic one from the name
+      if (!finalCode.trim()) {
+        const name = cls.name || "";
+        if (name) {
+          // Create a code from the first few words of the name
+          finalCode = name.split(' ')
+            .slice(0, 3)
+            .map((word: string) => word.substring(0, 3).toUpperCase())
+            .join('-')
+            .replace(/[^A-Z0-9\-]/g, ''); // Remove special characters
+        }
+      }
+
+      return {
+        uri: cls.uri,
+        code: finalCode,
+        name: cls.name ?? "",
+        classType: cls.classType ?? "",
+        referenceCode: cls.referenceCode,
+        definition: cls.definition,
+        synonyms: cls.synonyms,
+      } as BsddClass;
+    }).filter((cls: BsddClass) => {
+      // More lenient filtering - allow classifications without codes if they have names
       const hasValidName = cls.name && cls.name.trim().length > 0;
 
-      if (!hasValidCode || !hasValidName) {
-        console.warn('Filtered out invalid BSDD classification:', cls);
+      if (!hasValidName) {
+        console.warn('Filtered out BSDD classification with no name:', cls);
         return false;
+      }
+
+      // If no code, generate a fallback
+      if (!cls.code || !cls.code.trim()) {
+        console.warn('BSDD classification missing code, using generated fallback:', cls);
       }
 
       return true;
@@ -66,8 +156,372 @@ export async function searchBSDDClasses(
   }
 }
 
-// Additional function to get available dictionaries
-export async function getBSDDDictionaries(signal?: AbortSignal): Promise<any[]> {
+// Global text search across all BSDD dictionaries
+export async function searchBSDDGlobal(
+  search: string,
+  options: {
+    limit?: number;
+    offset?: number;
+    typeFilter?: 'Class' | 'Property' | 'Material' | 'GroupOfProperties';
+    relatedIfcEntity?: string;
+    signal?: AbortSignal;
+  } = {}
+): Promise<BsddGlobalSearchResult> {
+  const query = search.trim();
+  if (!query) {
+    return { classes: [], dictionaries: [], totalCount: 0, offset: 0, count: 0 };
+  }
+
+  const params = new URLSearchParams({
+    SearchText: query,
+    Limit: (options.limit ?? 50).toString(),
+    Offset: (options.offset ?? 0).toString(),
+  });
+
+  if (options.typeFilter) {
+    params.append('TypeFilter', options.typeFilter);
+  }
+  if (options.relatedIfcEntity) {
+    params.append('RelatedIfcEntity', options.relatedIfcEntity);
+  }
+
+  const url = `/api/bsdd/text-search?${params.toString()}`;
+
+  try {
+    const res = await fetch(url, {
+      headers: {
+        'Accept': 'application/json',
+        'Content-Type': 'application/json'
+      },
+      signal: options.signal,
+    });
+
+    if (!res.ok) {
+      const errorData = await res.json().catch(() => ({ error: 'Unknown error' }));
+      throw new Error(errorData.error || `HTTP ${res.status}: ${res.statusText}`);
+    }
+
+    const data = await res.json();
+
+    // Create a lookup object for dictionary names
+    const dictionaryLookup: Record<string, string> = {};
+    (data.dictionaries ?? []).forEach((dict: any) => {
+      dictionaryLookup[dict.uri] = dict.name || 'Unknown';
+    });
+
+    const classes = (data.classes ?? []).map((cls: any) => {
+      // Improved code fallback logic for global search
+      let finalCode = cls.referenceCode ?? cls.code ?? "";
+
+      // If still no code, generate a synthetic one from the name
+      if (!finalCode.trim()) {
+        const name = cls.name || "";
+        if (name) {
+          // Create a code from the first few words of the name
+          finalCode = name.split(' ')
+            .slice(0, 3)
+            .map((word: string) => word.substring(0, 3).toUpperCase())
+            .join('-')
+            .replace(/[^A-Z0-9\-]/g, ''); // Remove special characters
+        }
+      }
+
+      // Fallback to URI parsing if lookup fails
+      let finalDictionaryName = cls.dictionaryName || dictionaryLookup[cls.dictionaryUri] || null;
+
+      // If still no name, try parsing the URI
+      if (!finalDictionaryName && cls.dictionaryUri) {
+        const parts = cls.dictionaryUri.split('/');
+        let dictName = '';
+        if (parts.length >= 2) {
+          dictName = parts[parts.length - 2];
+        }
+
+        const lastPart = parts[parts.length - 1] || '';
+        if (!/^(v?\d+\.?\d*|latest)$/i.test(lastPart)) {
+          dictName = lastPart;
+        }
+
+        const nameMap: Record<string, string> = {
+          'ifc': 'IFC',
+          'etim': 'ETIM',
+          'uniclass2015': 'Uniclass 2015',
+          'cciconstruction': 'CCI Construction',
+          'nlsfb2005': 'NL-SfB 2005',
+          'buildingsmart': 'buildingSMART'
+        };
+
+        finalDictionaryName = nameMap[dictName.toLowerCase()] || dictName || 'Unknown';
+      }
+
+      return {
+        uri: cls.uri,
+        code: finalCode,
+        name: cls.name ?? "",
+        classType: cls.classType ?? "",
+        referenceCode: cls.referenceCode,
+        dictionaryName: finalDictionaryName,
+        dictionaryUri: cls.dictionaryUri,
+        definition: cls.definition,
+        synonyms: cls.synonyms,
+      } as BsddClass;
+    }).filter((cls: BsddClass) => {
+      // More lenient filtering for global search
+      const hasValidName = cls.name && cls.name.trim().length > 0;
+
+      if (!hasValidName) {
+        console.warn('Filtered out BSDD classification with no name:', cls);
+        return false;
+      }
+
+      // Allow classifications with generated codes
+      if (!cls.code || !cls.code.trim()) {
+        console.warn('BSDD classification using generated code:', cls);
+      }
+
+      return true;
+    });
+
+    const dictionaries = (data.dictionaries ?? []).map((dict: any) => ({
+      uri: dict.uri,
+      name: dict.name ?? "",
+      version: dict.version,
+      organizationCode: dict.organizationCode,
+      dictionaryCode: dict.dictionaryCode,
+      qualityAssuranceProcedure: dict.qualityAssuranceProcedure,
+      status: dict.status,
+    }));
+
+    return {
+      classes,
+      dictionaries,
+      totalCount: data.totalCount ?? 0,
+      offset: data.offset ?? 0,
+      count: data.count ?? 0,
+    };
+  } catch (error) {
+    if (error instanceof Error && error.name === 'AbortError') {
+      throw new Error('Global search request was cancelled');
+    }
+    throw error;
+  }
+}
+
+// Search within a specific dictionary (enhanced version)
+export async function searchBSDDInDictionary(
+  search: string,
+  dictionaryUri: string,
+  options: {
+    limit?: number;
+    offset?: number;
+    relatedIfcEntity?: string;
+    signal?: AbortSignal;
+  } = {}
+): Promise<BsddSearchResult> {
+  const query = search.trim();
+  if (!query) {
+    return { classes: [], totalCount: 0, offset: 0, count: 0 };
+  }
+
+  const params = new URLSearchParams({
+    searchText: query,
+    dictionaryUri,
+    limit: (options.limit ?? 100).toString(),
+    offset: (options.offset ?? 0).toString(),
+  });
+
+  if (options.relatedIfcEntity) {
+    params.append('relatedIfcEntity', options.relatedIfcEntity);
+  }
+
+  const url = `/api/bsdd/search?${params.toString()}`;
+
+  try {
+    const res = await fetch(url, {
+      headers: {
+        'Accept': 'application/json',
+        'Content-Type': 'application/json'
+      },
+      signal: options.signal,
+    });
+
+    if (!res.ok) {
+      const errorData = await res.json().catch(() => ({ error: 'Unknown error' }));
+      throw new Error(errorData.error || `HTTP ${res.status}: ${res.statusText}`);
+    }
+
+    const data = await res.json();
+    const classes = data.dictionary?.classes ?? [];
+
+    const processedClasses = classes.map((cls: any) => ({
+      uri: cls.uri,
+      code: cls.referenceCode ?? cls.code ?? "",
+      name: cls.name ?? "",
+      classType: cls.classType ?? "",
+      referenceCode: cls.referenceCode,
+      dictionaryName: data.dictionary?.name,
+      dictionaryUri: dictionaryUri,
+      definition: cls.definition,
+      synonyms: cls.synonyms,
+    } as BsddClass)).filter((cls: BsddClass) => {
+      const hasValidCode = cls.code && cls.code.trim().length > 0;
+      const hasValidName = cls.name && cls.name.trim().length > 0;
+
+      if (!hasValidCode || !hasValidName) {
+        console.warn('Filtered out invalid BSDD classification:', cls);
+        return false;
+      }
+
+      return true;
+    });
+
+    return {
+      classes: processedClasses,
+      totalCount: data.totalCount ?? 0,
+      offset: data.offset ?? 0,
+      count: data.count ?? 0,
+    };
+  } catch (error) {
+    if (error instanceof Error && error.name === 'AbortError') {
+      throw new Error('Dictionary search request was cancelled');
+    }
+    throw error;
+  }
+}
+
+// Search in multiple dictionaries and aggregate the results
+export async function searchBSDDInDictionaries(
+  search: string,
+  dictionaryUris: string[],
+  options: {
+    limit?: number; // total limit across all results (applied after aggregation)
+    offset?: number; // not currently used across aggregated results
+    relatedIfcEntity?: string;
+    signal?: AbortSignal;
+    typeFilter?: 'Class' | 'Property' | 'Material' | 'GroupOfProperties'; // client-side filter for per-dictionary searches
+  } = {}
+): Promise<BsddSearchResult> {
+  const trimmed = search.trim();
+  if (!trimmed || dictionaryUris.length === 0) {
+    return { classes: [], totalCount: 0, offset: 0, count: 0 };
+  }
+
+  // Run searches in parallel
+  const results = await Promise.allSettled(
+    dictionaryUris.map((uri) =>
+      searchBSDDInDictionary(trimmed, uri, {
+        // Use a reasonably high per-dictionary limit so client-side filters can work well
+        limit: Math.max(options.limit ?? 100, 100),
+        offset: options.offset ?? 0,
+        relatedIfcEntity: options.relatedIfcEntity,
+        signal: options.signal,
+      })
+    )
+  );
+
+  // Flatten successful results
+  const allClasses: BsddClass[] = [];
+  let total = 0;
+
+  for (const res of results) {
+    if (res.status === 'fulfilled') {
+      total += res.value.totalCount ?? res.value.classes.length;
+      allClasses.push(...res.value.classes);
+    }
+  }
+
+  // Client-side type filter for per-dictionary searches (since API lacks TypeFilter here)
+  let filtered = allClasses;
+  if (options.typeFilter && options.typeFilter !== (undefined as any)) {
+    filtered = filtered.filter((cls) => cls.classType === options.typeFilter);
+  }
+
+  // Dedupe by URI if available, otherwise by dictionaryUri+code
+  const seen = new Set<string>();
+  const deduped: BsddClass[] = [];
+  for (const cls of filtered) {
+    const key = cls.uri || `${cls.dictionaryUri}::${cls.code}`;
+    if (!seen.has(key)) {
+      seen.add(key);
+      deduped.push(cls);
+    }
+  }
+
+  // Apply global limit after aggregation
+  const limited = (options.limit && options.limit > 0) ? deduped.slice(0, options.limit) : deduped;
+
+  return {
+    classes: limited,
+    totalCount: total,
+    offset: 0,
+    count: limited.length,
+  };
+}
+
+// Analyze dictionary field availability
+export interface DictionaryFieldAnalysis {
+  dictionaryUri: string;
+  dictionaryName: string;
+  totalClasses: number;
+  hasCodeField: number;
+  hasReferenceCodeField: number;
+  hasDefinitionField: number;
+  hasSynonymsField: number;
+  bothCodesAvailable: number;
+  neitherCodeAvailable: number;
+}
+
+export async function analyzeDictionaryFields(searchTerm: string = 'wall', limit: number = 50): Promise<DictionaryFieldAnalysis[]> {
+  try {
+    // Get global search results
+    const result = await searchBSDDGlobal(searchTerm, { limit });
+
+    // Group by dictionary and analyze fields
+    const dictAnalysis = new Map<string, DictionaryFieldAnalysis>();
+
+    result.classes.forEach(cls => {
+      const dictUri = cls.dictionaryUri || 'unknown';
+      const dictName = cls.dictionaryName || dictUri.split('/').pop() || 'Unknown';
+
+      if (!dictAnalysis.has(dictUri)) {
+        dictAnalysis.set(dictUri, {
+          dictionaryUri: dictUri,
+          dictionaryName: dictName,
+          totalClasses: 0,
+          hasCodeField: 0,
+          hasReferenceCodeField: 0,
+          hasDefinitionField: 0,
+          hasSynonymsField: 0,
+          bothCodesAvailable: 0,
+          neitherCodeAvailable: 0,
+        });
+      }
+
+      const analysis = dictAnalysis.get(dictUri)!;
+      analysis.totalClasses++;
+
+      // Analyze field availability
+      const hasCode = cls.code && cls.code.trim().length > 0;
+      const hasReferenceCode = cls.referenceCode && cls.referenceCode.trim().length > 0;
+
+      if (hasCode) analysis.hasCodeField++;
+      if (hasReferenceCode) analysis.hasReferenceCodeField++;
+      if (cls.definition && cls.definition.trim().length > 0) analysis.hasDefinitionField++;
+      if (cls.synonyms && cls.synonyms.length > 0) analysis.hasSynonymsField++;
+
+      if (hasCode && hasReferenceCode) analysis.bothCodesAvailable++;
+      if (!hasCode && !hasReferenceCode) analysis.neitherCodeAvailable++;
+    });
+
+    return Array.from(dictAnalysis.values()).sort((a, b) => b.totalClasses - a.totalClasses);
+  } catch (error) {
+    console.error('Error analyzing dictionary fields:', error);
+    return [];
+  }
+}
+
+// Get available dictionaries
+export async function getBSDDDictionaries(signal?: AbortSignal): Promise<BsddDictionary[]> {
   try {
     const res = await fetch('/api/bsdd/dictionaries', {
       headers: { 'Accept': 'application/json' },
@@ -79,7 +533,23 @@ export async function getBSDDDictionaries(signal?: AbortSignal): Promise<any[]> 
     }
 
     const data = await res.json();
-    return data.dictionaries ?? [];
+    const dictionaries = data.dictionaries ?? [];
+
+    return dictionaries.map((dict: any) => ({
+      uri: dict.uri,
+      name: dict.name ?? "",
+      version: dict.version,
+      organizationCode: dict.organizationCode ?? dict.organizationCodeOwner, // support both
+      organizationNameOwner: dict.organizationNameOwner,
+      dictionaryCode: dict.dictionaryCode ?? dict.code,
+      qualityAssuranceProcedure: dict.qualityAssuranceProcedure,
+      status: dict.status,
+      isLatestVersion: dict.isLatestVersion,
+      isVerified: dict.isVerified,
+      isPrivate: dict.isPrivate,
+      releaseDate: dict.releaseDate,
+      lastUpdatedUtc: dict.lastUpdatedUtc,
+    } as BsddDictionary));
   } catch (error) {
     if (error instanceof Error && error.name === 'AbortError') {
       throw new Error('Dictionary request was cancelled');

--- a/services/bsdd-service.ts
+++ b/services/bsdd-service.ts
@@ -15,25 +15,75 @@ export async function searchBSDDClasses(
   const query = search.trim();
   if (!query) return [];
 
+  // Use our Next.js API route as proxy instead of direct BSDD API call
   const params = new URLSearchParams({
-    DictionaryUri: BSDD_DICTIONARY_URI,
-    SearchText: query,
-    Limit: "100",
+    searchText: query,
+    dictionaryUri: BSDD_DICTIONARY_URI,
+    limit: "100",
   });
-  const url = `https://api.bsdd.buildingsmart.org/api/SearchInDictionary/v1?${params.toString()}`;
-  const res = await fetch(url, {
-    headers: { accept: "text/plain" },
-    signal,
-  });
-  if (!res.ok) {
-    throw new Error("Failed to fetch bSDD classes");
+
+  const url = `/api/bsdd/search?${params.toString()}`;
+
+  try {
+    const res = await fetch(url, {
+      headers: {
+        'Accept': 'application/json',
+        'Content-Type': 'application/json'
+      },
+      signal,
+    });
+
+    if (!res.ok) {
+      const errorData = await res.json().catch(() => ({ error: 'Unknown error' }));
+      throw new Error(errorData.error || `HTTP ${res.status}: ${res.statusText}`);
+    }
+
+    const data = await res.json();
+    const classes = data.dictionary?.classes ?? [];
+
+    return classes.map((cls: any) => ({
+      uri: cls.uri,
+      code: cls.referenceCode ?? cls.code ?? "",
+      name: cls.name ?? "",
+      classType: cls.classType ?? "",
+    })).filter((cls) => {
+      // Filter out invalid classifications
+      const hasValidCode = cls.code && cls.code.trim().length > 0;
+      const hasValidName = cls.name && cls.name.trim().length > 0;
+
+      if (!hasValidCode || !hasValidName) {
+        console.warn('Filtered out invalid BSDD classification:', cls);
+        return false;
+      }
+
+      return true;
+    });
+  } catch (error) {
+    if (error instanceof Error && error.name === 'AbortError') {
+      throw new Error('Search request was cancelled');
+    }
+    throw error;
   }
-  const data = await res.json();
-  const classes = data.dictionary?.classes ?? [];
-  return classes.map((cls: any) => ({
-    uri: cls.uri,
-    code: cls.referenceCode ?? cls.code ?? "",
-    name: cls.name,
-    classType: cls.classType,
-  }));
+}
+
+// Additional function to get available dictionaries
+export async function getBSDDDictionaries(signal?: AbortSignal): Promise<any[]> {
+  try {
+    const res = await fetch('/api/bsdd/dictionaries', {
+      headers: { 'Accept': 'application/json' },
+      signal,
+    });
+
+    if (!res.ok) {
+      throw new Error('Failed to fetch BSDD dictionaries');
+    }
+
+    const data = await res.json();
+    return data.dictionaries ?? [];
+  } catch (error) {
+    if (error instanceof Error && error.name === 'AbortError') {
+      throw new Error('Dictionary request was cancelled');
+    }
+    throw error;
+  }
 }

--- a/services/bsdd-service.ts
+++ b/services/bsdd-service.ts
@@ -1,0 +1,34 @@
+export interface BsddClass {
+  uri: string;
+  code: string;
+  name: string;
+  classType: string;
+  referenceCode: string;
+  parentClassCode?: string;
+  descriptionPart?: string;
+}
+
+const BSDD_DICTIONARY_URI = "https://identifier.buildingsmart.org/uri/nbs/uniclass2015/1";
+
+export async function fetchBSDDClasses(
+  search: string,
+  signal?: AbortSignal,
+): Promise<BsddClass[]> {
+  const params = new URLSearchParams({
+    Uri: BSDD_DICTIONARY_URI,
+    Limit: "100",
+  });
+  if (search) {
+    params.set("SearchText", search);
+  }
+  const url = `https://api.bsdd.buildingsmart.org/api/Dictionary/v1/Classes?${params.toString()}`;
+  const res = await fetch(url, {
+    headers: { accept: "text/plain" },
+    signal,
+  });
+  if (!res.ok) {
+    throw new Error("Failed to fetch bSDD classes");
+  }
+  const data = await res.json();
+  return data.classes ?? [];
+}

--- a/services/bsdd-service.ts
+++ b/services/bsdd-service.ts
@@ -3,25 +3,24 @@ export interface BsddClass {
   code: string;
   name: string;
   classType: string;
-  referenceCode: string;
-  parentClassCode?: string;
-  descriptionPart?: string;
 }
 
-const BSDD_DICTIONARY_URI = "https://identifier.buildingsmart.org/uri/nbs/uniclass2015/1";
+const BSDD_DICTIONARY_URI =
+  "https://identifier.buildingsmart.org/uri/nbs/uniclass2015/1";
 
-export async function fetchBSDDClasses(
+export async function searchBSDDClasses(
   search: string,
   signal?: AbortSignal,
 ): Promise<BsddClass[]> {
+  const query = search.trim();
+  if (!query) return [];
+
   const params = new URLSearchParams({
-    Uri: BSDD_DICTIONARY_URI,
+    DictionaryUri: BSDD_DICTIONARY_URI,
+    SearchText: query,
     Limit: "100",
   });
-  if (search) {
-    params.set("SearchText", search);
-  }
-  const url = `https://api.bsdd.buildingsmart.org/api/Dictionary/v1/Classes?${params.toString()}`;
+  const url = `https://api.bsdd.buildingsmart.org/api/SearchInDictionary/v1?${params.toString()}`;
   const res = await fetch(url, {
     headers: { accept: "text/plain" },
     signal,
@@ -30,5 +29,11 @@ export async function fetchBSDDClasses(
     throw new Error("Failed to fetch bSDD classes");
   }
   const data = await res.json();
-  return data.classes ?? [];
+  const classes = data.dictionary?.classes ?? [];
+  return classes.map((cls: any) => ({
+    uri: cls.uri,
+    code: cls.referenceCode ?? cls.code ?? "",
+    name: cls.name,
+    classType: cls.classType,
+  }));
 }

--- a/services/bsdd-service.ts
+++ b/services/bsdd-service.ts
@@ -10,6 +10,13 @@ export interface BsddClass {
   synonyms?: string[];
 }
 
+export interface BsddProperty {
+  uri: string;
+  code: string;
+  name: string;
+  descriptionPart?: string;
+}
+
 export interface BsddDictionary {
   uri: string;
   name: string;
@@ -555,5 +562,153 @@ export async function getBSDDDictionaries(signal?: AbortSignal): Promise<BsddDic
       throw new Error('Dictionary request was cancelled');
     }
     throw error;
+  }
+}
+
+// Fetch classes for a dictionary (supports nested or paginated flat)
+export async function fetchDictionaryClasses(options: {
+  uri: string;
+  useNested?: boolean;
+  classType?: 'Class' | 'GroupOfProperties' | 'AlternativeUse' | 'Material';
+  relatedIfcEntity?: string;
+  offset?: number;
+  limit?: number;
+  languageCode?: string;
+  signal?: AbortSignal;
+}): Promise<{
+  classes: any[];
+  classesTotalCount?: number;
+  classesOffset?: number;
+  classesCount?: number;
+  totalCount?: number;
+  offset?: number;
+  count?: number;
+}> {
+  const params = new URLSearchParams();
+  params.set('Uri', options.uri);
+  if (options.useNested) params.set('UseNestedClasses', 'true');
+  if (options.classType) params.set('ClassType', options.classType);
+  if (options.relatedIfcEntity) params.set('RelatedIfcEntity', options.relatedIfcEntity);
+  if (options.offset !== undefined) params.set('Offset', String(options.offset));
+  if (options.limit !== undefined) params.set('Limit', String(options.limit));
+  if (options.languageCode) params.set('languageCode', options.languageCode);
+
+  const res = await fetch(`/api/bsdd/dictionary-classes?${params.toString()}`, {
+    headers: { 'Accept': 'application/json' },
+    signal: options.signal,
+  });
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({}));
+    throw new Error(err.error || `Failed to fetch dictionary classes: ${res.statusText}`);
+  }
+  return res.json();
+}
+
+// Fetch properties for a dictionary (paginated)
+export async function fetchDictionaryProperties(options: {
+  uri: string;
+  searchText?: string;
+  offset?: number;
+  limit?: number;
+  languageCode?: string;
+  signal?: AbortSignal;
+}): Promise<{
+  properties: BsddProperty[];
+  propertiesTotalCount?: number;
+  propertiesOffset?: number;
+  propertiesCount?: number;
+}> {
+  const params = new URLSearchParams();
+  params.set('Uri', options.uri);
+  if (options.searchText) params.set('SearchText', options.searchText);
+  if (options.offset !== undefined) params.set('Offset', String(options.offset));
+  if (options.limit !== undefined) params.set('Limit', String(options.limit));
+  if (options.languageCode) params.set('languageCode', options.languageCode);
+
+  const res = await fetch(`/api/bsdd/dictionary-properties?${params.toString()}`, {
+    headers: { 'Accept': 'application/json' },
+    signal: options.signal,
+  });
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({}));
+    throw new Error(err.error || `Failed to fetch dictionary properties: ${res.statusText}`);
+  }
+  const data = await res.json();
+  const properties = (data.properties ?? []).map((p: any) => ({
+    uri: p.uri,
+    code: p.code,
+    name: p.name,
+    descriptionPart: p.descriptionPart,
+  })) as BsddProperty[];
+  return { ...data, properties };
+}
+
+// Convenience: fetch many pages of classes (flat) and build a simple parent map
+export async function fetchAllDictionaryClassesFlat(options: {
+  uri: string;
+  classType?: 'Class' | 'GroupOfProperties' | 'AlternativeUse' | 'Material';
+  languageCode?: string;
+  maxPages?: number; // safety cap
+  signal?: AbortSignal;
+}): Promise<any[]> {
+  const pageSize = 1000;
+  const maxPages = options.maxPages ?? 5;
+  const out: any[] = [];
+  let offset = 0;
+  for (let i = 0; i < maxPages; i++) {
+    const page = await fetchDictionaryClasses({
+      uri: options.uri,
+      classType: options.classType,
+      offset,
+      limit: pageSize,
+      languageCode: options.languageCode,
+      signal: options.signal,
+    });
+    const batch = page.classes ?? [];
+    out.push(...batch);
+    const count = page.classesCount ?? batch.length;
+    if (count < pageSize) break;
+    offset += count;
+  }
+  return out;
+}
+
+// Try nested, fallback to flat if fails
+export async function fetchDictionaryClassesTree(options: {
+  uri: string;
+  classType?: 'Class' | 'GroupOfProperties' | 'AlternativeUse' | 'Material';
+  languageCode?: string;
+  signal?: AbortSignal;
+}): Promise<{ root: any[]; byCode: Map<string, any> }> {
+  try {
+    const nested = await fetchDictionaryClasses({
+      uri: options.uri,
+      useNested: true,
+      classType: options.classType,
+      languageCode: options.languageCode,
+      signal: options.signal,
+    });
+    // When nested, items may include children identifiers; pass through
+    const byCode = new Map<string, any>();
+    (nested.classes ?? []).forEach((c: any) => { if (c.code) byCode.set(c.code, c); });
+    return { root: nested.classes ?? [], byCode };
+  } catch {
+    const flat = await fetchAllDictionaryClassesFlat({
+      uri: options.uri,
+      classType: options.classType,
+      languageCode: options.languageCode,
+      signal: options.signal,
+    });
+    // Build tree from parentClassCode
+    const byCode = new Map<string, any>();
+    flat.forEach((c: any) => { if (c.code) { byCode.set(c.code, { ...c, children: [] }); } });
+    const roots: any[] = [];
+    flat.forEach((c: any) => {
+      const node = byCode.get(c.code);
+      const parent = c.parentClassCode ? byCode.get(c.parentClassCode) : null;
+      if (parent && node) parent.children.push(node);
+      else if (node) roots.push(node);
+    });
+    return { root: roots, byCode };
   }
 }


### PR DESCRIPTION
## Summary
- add bSDD classification lookup modal with search
- integrate modal into classification menu
- localize new bSDD strings

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b886e6478c8320801ded6b5682ef1d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Browse bSDD from the Classification panel (3‑dot menu) with a highlighted "New" badge and first‑time ping.
  * Two‑step dialog: select dictionaries (grouped/versioned) then search with debounced queries, filters, sorting, load‑more, and clear loading/error/no‑results states.
  * Rich results: code badge, type, dictionary info, definition/synonyms, Add/Remove actions; added items show "Added" and receive an auto‑assigned color.

* **Translations**
  * Added bSDD UI labels/placeholders in English, German, French, and Italian.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->