### PR TITLE
feat: add bSDD search for classifications

### DIFF
--- a/components/classification-panel.tsx
+++ b/components/classification-panel.tsx
@@ -70,6 +70,7 @@ import {
   ArchiveRestore,
   Star,
   Cuboid,
+  Globe,
 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import {
@@ -107,6 +108,16 @@ function areElementArraysEqual(arr1: any[], arr2: any[]): boolean {
 
 // Define sortable keys
 type SortableKey = "code" | "name" | "elementsCount";
+
+interface BsddClass {
+  uri: string;
+  code: string;
+  name: string;
+  classType: string;
+  referenceCode: string;
+  parentClassCode?: string;
+  descriptionPart?: string;
+}
 
 // Define AppSettings interface locally or import if available globally
 interface AppSettings {
@@ -190,7 +201,51 @@ export function ClassificationPanel() {
     null
   );
 
+  // State for bSDD search
+  const [isBsddDialogOpen, setIsBsddDialogOpen] = useState(false);
+  const [bsddSearch, setBsddSearch] = useState("");
+  const [bsddResults, setBsddResults] = useState<BsddClass[]>([]);
+  const [isBsddLoading, setIsBsddLoading] = useState(false);
+  const [bsddError, setBsddError] = useState<string | null>(null);
+
   const [hasAutoLoaded, setHasAutoLoaded] = useState(false);
+
+  const fetchBsdd = useCallback(async (search: string) => {
+    setIsBsddLoading(true);
+    setBsddError(null);
+    try {
+      const params = new URLSearchParams({
+        Uri: "https://identifier.buildingsmart.org/uri/nbs/uniclass2015/1",
+        Limit: "100",
+      });
+      if (search) params.set("SearchText", search);
+      const response = await fetch(
+        `https://api.bsdd.buildingsmart.org/api/Dictionary/v1/Classes?${params.toString()}`,
+        { headers: { accept: "application/json" } },
+      );
+      if (!response.ok)
+        throw new Error(`Failed to fetch bSDD data: ${response.statusText}`);
+      const data = (await response.json()) as { classes: BsddClass[] };
+      setBsddResults(data.classes || []);
+    } catch (error) {
+      console.error("Error loading bSDD data:", error);
+      setBsddError(error instanceof Error ? error.message : "Unknown error");
+    } finally {
+      setIsBsddLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!isBsddDialogOpen) return;
+    if (bsddSearch === "") {
+      fetchBsdd("");
+      return;
+    }
+    const handler = setTimeout(() => {
+      fetchBsdd(bsddSearch);
+    }, 500);
+    return () => clearTimeout(handler);
+  }, [bsddSearch, isBsddDialogOpen, fetchBsdd]);
 
   // ----- Export classification system metadata -----
   const presetMeta: Record<"ebkp" | "cfc" | "eccc_bat" | "uniclass", ClassificationSystemMeta> = {
@@ -622,6 +677,14 @@ export function ClassificationPanel() {
     });
     console.log(`Added ${addedCount} eCCC-Bat classifications.`);
   }, [defaultECCC_Bat, classifications, addClassification]);
+
+  const handleAddBsddClass = useCallback(
+    (cls: BsddClass) => {
+      if (classifications[cls.code]) return;
+      addClassification({ code: cls.code, name: cls.name, color: "#3b82f6" });
+    },
+    [classifications, addClassification],
+  );
 
   const areAllUniclassAdded = useCallback(() => {
     if (
@@ -1276,6 +1339,10 @@ export function ClassificationPanel() {
                       {t("buttons.noUniclassFound")}
                     </DropdownMenuItem>
                   )}
+                <DropdownMenuItem onSelect={() => setIsBsddDialogOpen(true)}>
+                  <Globe className="mr-2 h-4 w-4" />
+                  {t("buttons.searchBsdd")}
+                </DropdownMenuItem>
                 <DropdownMenuSeparator />
                 <DropdownMenuLabel className="text-xs font-semibold text-muted-foreground px-2 py-1.5">
                   {t("sections.manageData")}
@@ -1652,6 +1719,83 @@ export function ClassificationPanel() {
           </DialogContent>
         </Dialog>
       )}
+
+      <Dialog open={isBsddDialogOpen} onOpenChange={setIsBsddDialogOpen}>
+        <DialogContent className="sm:max-w-[700px]">
+          <DialogHeader>
+            <DialogTitle>{t("bsdd.title")}</DialogTitle>
+            <DialogDescription>
+              {t("buttons.searchBsdd")}
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4">
+            <Input
+              placeholder={t("bsdd.searchPlaceholder")}
+              value={bsddSearch}
+              onChange={(e) => setBsddSearch(e.target.value)}
+            />
+            {isBsddLoading ? (
+              <p>{t("buttons.loadingBsdd")}</p>
+            ) : bsddError ? (
+              <p className="text-destructive">
+                {t("buttons.bsddError", { message: bsddError })}
+              </p>
+            ) : (
+              <div className="max-h-64 overflow-y-auto border rounded-md">
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>{t("classifications.code")}</TableHead>
+                      <TableHead>{t("classifications.name")}</TableHead>
+                      <TableHead className="w-24"></TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {bsddResults.length === 0 ? (
+                      <TableRow>
+                        <TableCell colSpan={3}>
+                          {t("bsdd.noResults")}
+                        </TableCell>
+                      </TableRow>
+                    ) : (
+                      bsddResults.map((cls) => {
+                        const added = !!classifications[cls.code];
+                        return (
+                          <TableRow key={cls.code}>
+                            <TableCell className="font-mono text-xs">
+                              {cls.code}
+                            </TableCell>
+                            <TableCell>{cls.name}</TableCell>
+                            <TableCell className="text-right">
+                              <Button
+                                size="sm"
+                                onClick={() => handleAddBsddClass(cls)}
+                                disabled={added}
+                              >
+                                {added
+                                  ? t("buttons.added")
+                                  : t("buttons.add")}
+                              </Button>
+                            </TableCell>
+                          </TableRow>
+                        );
+                      })
+                    )}
+                  </TableBody>
+                </Table>
+              </div>
+            )}
+          </div>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setIsBsddDialogOpen(false)}
+            >
+              {t("buttons.cancel")}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
 
       {selectedElements.length > 0 && (
         <div className="mt-4 space-y-2 border-t pt-4">

--- a/public/locales/de/common.json
+++ b/public/locales/de/common.json
@@ -131,6 +131,10 @@
     "ecccBatError": "eCCC-Bat Fehler: {{message}}",
     "loadEcccBat": "eCCC-Bat laden ({{count}})",
     "noEcccBatFound": "Keine eCCC-Bat Elemente gefunden.",
+    "searchBsdd": "bSDD durchsuchen",
+    "loadingBsdd": "bSDD wird geladen...",
+    "bsddError": "bSDD Fehler: {{message}}",
+    "added": "Hinzugefügt",
     "addCondition": "Bedingung hinzufügen",
     "saveRule": "Regel speichern",
     "copyRule": "Regel kopieren",
@@ -225,6 +229,11 @@
     "confirmRemoval": "Löschen bestätigen",
     "confirmRemoveMessage": "Sind Sie sicher, dass Sie die Klassifizierung <code>{{code}}</code> entfernen möchten? Diese Aktion kann nicht rückgängig gemacht werden.",
     "confirmRemoveAllMessage": "Sind Sie sicher, dass Sie alle Klassifizierungen entfernen möchten? Diese Aktion kann nicht rückgängig gemacht werden."
+  },
+  "bsdd": {
+    "title": "bSDD-Klassifikationen suchen",
+    "searchPlaceholder": "Klassen suchen...",
+    "noResults": "Keine Klassen gefunden."
   },
   "rules": {
     "addNew": "Neue Regel hinzufügen",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -131,6 +131,10 @@
     "ecccBatError": "eCCC-Bat Error: {{message}}",
     "loadEcccBat": "Load eCCC-Bat ({{count}})",
     "noEcccBatFound": "No eCCC-Bat items found.",
+    "searchBsdd": "Search bSDD",
+    "loadingBsdd": "Loading bSDD...",
+    "bsddError": "bSDD Error: {{message}}",
+    "added": "Added",
     "addCondition": "Add Condition",
     "saveRule": "Save Rule",
     "copyRule": "Copy Rule",
@@ -223,6 +227,11 @@
     "confirmRemoval": "Confirm Removal",
     "confirmRemoveMessage": "Are you sure you want to remove the classification <code>{{code}}</code>? This action cannot be undone.",
     "confirmRemoveAllMessage": "Are you sure you want to remove all classifications? This action cannot be undone."
+  },
+  "bsdd": {
+    "title": "Search bSDD Classifications",
+    "searchPlaceholder": "Search classes...",
+    "noResults": "No classes found."
   },
   "rules": {
     "addNew": "Add New Rule",

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -131,6 +131,10 @@
         "ecccBatError": "Erreur eCCC-Bat : {{message}}",
         "loadEcccBat": "Charger eCCC-Bat ({{count}})",
         "noEcccBatFound": "Aucun élément eCCC-Bat trouvé.",
+        "searchBsdd": "Rechercher dans bSDD",
+        "loadingBsdd": "Chargement bSDD...",
+        "bsddError": "Erreur bSDD : {{message}}",
+        "added": "Ajouté",
         "addCondition": "Ajouter une condition",
         "saveRule": "Enregistrer la règle",
         "copyRule": "Copier la règle",
@@ -223,6 +227,11 @@
         "confirmRemoval": "Confirmer la suppression",
         "confirmRemoveMessage": "Êtes-vous sûr de vouloir supprimer la classification <code>{{code}}</code> ? Cette action est irréversible.",
         "confirmRemoveAllMessage": "Êtes-vous sûr de vouloir supprimer toutes les classifications ? Cette action est irréversible."
+    },
+    "bsdd": {
+        "title": "Rechercher des classifications bSDD",
+        "searchPlaceholder": "Rechercher des classes...",
+        "noResults": "Aucune classe trouvée."
     },
     "rules": {
         "addNew": "Ajouter une nouvelle règle",

--- a/public/locales/it/common.json
+++ b/public/locales/it/common.json
@@ -131,6 +131,10 @@
         "ecccBatError": "Errore eCCC-Bat: {{message}}",
         "loadEcccBat": "Carica eCCC-Bat ({{count}})",
         "noEcccBatFound": "Nessun elemento eCCC-Bat trovato.",
+        "searchBsdd": "Cerca in bSDD",
+        "loadingBsdd": "Caricamento bSDD...",
+        "bsddError": "Errore bSDD: {{message}}",
+        "added": "Aggiunto",
         "addCondition": "Aggiungi condizione",
         "saveRule": "Salva regola",
         "copyRule": "Copia regola",
@@ -223,6 +227,11 @@
         "confirmRemoval": "Conferma rimozione",
         "confirmRemoveMessage": "Sei sicuro di voler rimuovere la classificazione <code>{{code}}</code>? Questa azione non può essere annullata.",
         "confirmRemoveAllMessage": "Sei sicuro di voler rimuovere tutte le classificazioni? Questa azione non può essere annullata."
+    },
+    "bsdd": {
+        "title": "Cerca classificazioni bSDD",
+        "searchPlaceholder": "Cerca classi...",
+        "noResults": "Nessuna classe trovata."
     },
     "rules": {
         "addNew": "Aggiungi nuova regola",


### PR DESCRIPTION
## Summary
- integrate bSDD Uniclass API search into classification panel
- allow adding classifications from bSDD via new modal
- localize new strings in all languages

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68b886e6478c8320801ded6b5682ef1d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added bSDD classification search dialog accessible from Manage Data.
  * Supports live search with debounce, loading and error states, and no-results messaging.
  * View results and add classifications directly; prevents duplicate additions; includes Cancel to close.

* Translations
  * Added bSDD-related translations (titles, placeholders, buttons, loading, error, no-results, added) for English, German, French, and Italian.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->