### PR TITLE
feat: add bSDD classification search

### DIFF
--- a/components/classification-panel.tsx
+++ b/components/classification-panel.tsx
@@ -25,6 +25,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import { ScrollArea } from "@/components/ui/scroll-area";
 import {
   Dialog,
   DialogContent,
@@ -115,6 +116,16 @@ interface AppSettings {
 }
 const SETTINGS_KEY = "appSettings";
 
+interface BSDDClass {
+  uri: string;
+  code: string;
+  name: string;
+  classType: string;
+  referenceCode: string;
+  parentClassCode?: string;
+  descriptionPart?: string;
+}
+
 export function ClassificationPanel() {
   const {
     classifications,
@@ -161,6 +172,13 @@ export function ClassificationPanel() {
   const [mapPropertyNameError, setMapPropertyNameError] = useState<
     string | null
   >(null);
+  const [isBSDDDialogOpen, setIsBSDDDialogOpen] = useState(false);
+  const [bsddSearch, setBsddSearch] = useState("");
+  const [bsddResults, setBsddResults] = useState<BSDDClass[]>([]);
+  const [isBSDDLoading, setIsBSDDLoading] = useState(false);
+  const [bsddError, setBsddError] = useState<string | null>(null);
+  const BSDD_DICTIONARY_URI =
+    "https://identifier.buildingsmart.org/uri/nbs/uniclass2015/1";
   const [defaultUniclassPr, setDefaultUniclassPr] = useState<
     ClassificationItem[]
   >([]);
@@ -396,6 +414,43 @@ export function ClassificationPanel() {
     if (!file) return;
     importClassificationsFromExcel(file);
     e.target.value = "";
+  };
+
+  const handleBSDDSearch = useCallback(async () => {
+    if (!bsddSearch.trim()) return;
+    setIsBSDDLoading(true);
+    setBsddError(null);
+    try {
+      const url = `https://api.bsdd.buildingsmart.org/api/Dictionary/v1/Classes?Uri=${encodeURIComponent(
+        BSDD_DICTIONARY_URI
+      )}&SearchText=${encodeURIComponent(bsddSearch.trim())}&Limit=100`;
+      const response = await fetch(url, {
+        headers: { accept: "application/json" },
+      });
+      if (!response.ok) {
+        throw new Error(`Failed to fetch bSDD data: ${response.statusText}`);
+      }
+      const data = await response.json();
+      setBsddResults(data.classes || []);
+    } catch (error) {
+      console.error("Error searching bSDD:", error);
+      setBsddError(
+        error instanceof Error ? error.message : t("messages.error")
+      );
+      setBsddResults([]);
+    } finally {
+      setIsBSDDLoading(false);
+    }
+  }, [bsddSearch, t, BSDD_DICTIONARY_URI]);
+
+  const handleAddBSDDClassification = (cls: BSDDClass) => {
+    if (!classifications[cls.code]) {
+      addClassification({
+        code: cls.code,
+        name: cls.name,
+        color: "#3b82f6",
+      });
+    }
   };
 
   // Effect to manage the default selected model for export
@@ -1276,6 +1331,9 @@ export function ClassificationPanel() {
                       {t("buttons.noUniclassFound")}
                     </DropdownMenuItem>
                   )}
+                <DropdownMenuItem onClick={() => setIsBSDDDialogOpen(true)}>
+                  {t("buttons.searchBSDD")}
+                </DropdownMenuItem>
                 <DropdownMenuSeparator />
                 <DropdownMenuLabel className="text-xs font-semibold text-muted-foreground px-2 py-1.5">
                   {t("sections.manageData")}
@@ -1412,12 +1470,77 @@ export function ClassificationPanel() {
               >
                 {t("buttons.cancel")}
               </Button>
-              <Button onClick={handleAddClassification}>
-                {t("buttons.add")}
-              </Button>
-            </DialogFooter>
-          </DialogContent>
-        </Dialog>
+          <Button onClick={handleAddClassification}>
+            {t("buttons.add")}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+    <Dialog open={isBSDDDialogOpen} onOpenChange={setIsBSDDDialogOpen}>
+      <DialogContent className="sm:max-w-xl">
+        <DialogHeader>
+          <DialogTitle>
+            {t("classifications.searchBSDDTitle")}
+          </DialogTitle>
+        </DialogHeader>
+        <div className="flex gap-2 py-2">
+          <Input
+            value={bsddSearch}
+            onChange={(e) => setBsddSearch(e.target.value)}
+            placeholder={t("classifications.bsdSearchPlaceholder")}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") handleBSDDSearch();
+            }}
+          />
+          <Button onClick={handleBSDDSearch} disabled={isBSDDLoading}>
+            {isBSDDLoading ? t("buttons.loading") : t("buttons.search")}
+          </Button>
+        </div>
+        {bsddError && (
+          <div className="text-sm text-destructive">{bsddError}</div>
+        )}
+        <ScrollArea className="h-64 mt-2">
+          {isBSDDLoading ? (
+            <div className="p-4 text-center text-sm">
+              {t("messages.loading")}
+            </div>
+          ) : bsddResults.length === 0 ? (
+            <div className="p-4 text-center text-sm text-muted-foreground">
+              {t("classifications.noBsdResults")}
+            </div>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>{t("classifications.code")}</TableHead>
+                  <TableHead>{t("classifications.name")}</TableHead>
+                  <TableHead className="text-right"></TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {bsddResults.map((cls) => (
+                  <TableRow key={cls.code}>
+                    <TableCell>{cls.code}</TableCell>
+                    <TableCell>{cls.name}</TableCell>
+                    <TableCell className="text-right">
+                      <Button
+                        size="sm"
+                        onClick={() => handleAddBSDDClassification(cls)}
+                        disabled={!!classifications[cls.code]}
+                      >
+                        {classifications[cls.code]
+                          ? t("buttons.added")
+                          : t("buttons.add")}
+                      </Button>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </ScrollArea>
+      </DialogContent>
+    </Dialog>
         {/* The old "Row 2 Management Dropdown section" is now fully replaced by the 3-dot menu in the header and this restored dialog. */}
         {/* The hidden file input for import is kept at the end of the component. */}
         <Dialog

--- a/public/locales/de/common.json
+++ b/public/locales/de/common.json
@@ -138,7 +138,9 @@
     "deleteRule": "Regel löschen",
     "previewRule": "Regelauswirkung anzeigen",
     "clearPreview": "Vorschau zurücksetzen",
-    "mapFromModel": "Aus Modell übernehmen"
+    "mapFromModel": "Aus Modell übernehmen",
+    "searchBSDD": "bSDD durchsuchen",
+    "added": "Hinzugefügt"
   },
   "messages": {
     "loading": "Wird geladen...",
@@ -224,7 +226,10 @@
     "manageClassifications": "Klassifizierungen verwalten",
     "confirmRemoval": "Löschen bestätigen",
     "confirmRemoveMessage": "Sind Sie sicher, dass Sie die Klassifizierung <code>{{code}}</code> entfernen möchten? Diese Aktion kann nicht rückgängig gemacht werden.",
-    "confirmRemoveAllMessage": "Sind Sie sicher, dass Sie alle Klassifizierungen entfernen möchten? Diese Aktion kann nicht rückgängig gemacht werden."
+    "confirmRemoveAllMessage": "Sind Sie sicher, dass Sie alle Klassifizierungen entfernen möchten? Diese Aktion kann nicht rückgängig gemacht werden.",
+    "searchBSDDTitle": "bSDD durchsuchen (Uniclass 2015)",
+    "bsdSearchPlaceholder": "Begriff zur Suche im bSDD eingeben...",
+    "noBsdResults": "Keine bSDD-Klassifikationen gefunden."
   },
   "rules": {
     "addNew": "Neue Regel hinzufügen",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -138,7 +138,9 @@
     "deleteRule": "Delete Rule",
     "previewRule": "Preview Rule Impact",
     "clearPreview": "Clear Preview",
-    "mapFromModel": "Map From Model"
+    "mapFromModel": "Map From Model",
+    "searchBSDD": "Search bSDD",
+    "added": "Added"
   },
   "messages": {
     "loading": "Loading...",
@@ -222,7 +224,10 @@
     "manageClassifications": "Manage Classifications",
     "confirmRemoval": "Confirm Removal",
     "confirmRemoveMessage": "Are you sure you want to remove the classification <code>{{code}}</code>? This action cannot be undone.",
-    "confirmRemoveAllMessage": "Are you sure you want to remove all classifications? This action cannot be undone."
+    "confirmRemoveAllMessage": "Are you sure you want to remove all classifications? This action cannot be undone.",
+    "searchBSDDTitle": "Search bSDD (Uniclass 2015)",
+    "bsdSearchPlaceholder": "Enter term to search bSDD...",
+    "noBsdResults": "No bSDD classifications found."
   },
   "rules": {
     "addNew": "Add New Rule",

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -138,7 +138,9 @@
         "deleteRule": "Supprimer la règle",
         "previewRule": "Prévisualiser l'impact de la règle",
         "clearPreview": "Effacer la prévisualisation",
-        "mapFromModel": "Mapper depuis le modèle"
+        "mapFromModel": "Mapper depuis le modèle",
+        "searchBSDD": "Rechercher bSDD",
+        "added": "Ajouté"
     },
     "messages": {
         "loading": "Chargement...",
@@ -222,7 +224,10 @@
         "manageClassifications": "Gérer les classifications",
         "confirmRemoval": "Confirmer la suppression",
         "confirmRemoveMessage": "Êtes-vous sûr de vouloir supprimer la classification <code>{{code}}</code> ? Cette action est irréversible.",
-        "confirmRemoveAllMessage": "Êtes-vous sûr de vouloir supprimer toutes les classifications ? Cette action est irréversible."
+        "confirmRemoveAllMessage": "Êtes-vous sûr de vouloir supprimer toutes les classifications ? Cette action est irréversible.",
+        "searchBSDDTitle": "Rechercher bSDD (Uniclass 2015)",
+        "bsdSearchPlaceholder": "Entrez un terme pour rechercher dans bSDD...",
+        "noBsdResults": "Aucune classification bSDD trouvée."
     },
     "rules": {
         "addNew": "Ajouter une nouvelle règle",

--- a/public/locales/it/common.json
+++ b/public/locales/it/common.json
@@ -138,7 +138,9 @@
         "deleteRule": "Elimina regola",
         "previewRule": "Anteprima impatto regola",
         "clearPreview": "Cancella anteprima",
-        "mapFromModel": "Mappa dal modello"
+        "mapFromModel": "Mappa dal modello",
+        "searchBSDD": "Cerca bSDD",
+        "added": "Aggiunto"
     },
     "messages": {
         "loading": "Caricamento...",
@@ -222,7 +224,10 @@
         "manageClassifications": "Gestisci classificazioni",
         "confirmRemoval": "Conferma rimozione",
         "confirmRemoveMessage": "Sei sicuro di voler rimuovere la classificazione <code>{{code}}</code>? Questa azione non può essere annullata.",
-        "confirmRemoveAllMessage": "Sei sicuro di voler rimuovere tutte le classificazioni? Questa azione non può essere annullata."
+        "confirmRemoveAllMessage": "Sei sicuro di voler rimuovere tutte le classificazioni? Questa azione non può essere annullata.",
+        "searchBSDDTitle": "Cerca nel bSDD (Uniclass 2015)",
+        "bsdSearchPlaceholder": "Inserisci un termine per cercare nel bSDD...",
+        "noBsdResults": "Nessuna classificazione bSDD trovata."
     },
     "rules": {
         "addNew": "Aggiungi nuova regola",


### PR DESCRIPTION
## Summary
- add bSDD search modal to classification panel with live API lookup
- integrate menu option and translations for bSDD classifications

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b886e6478c8320801ded6b5682ef1d