### PR TITLE
feat: add bSDD classification search modal

### DIFF
--- a/app/api/bsdd/route.ts
+++ b/app/api/bsdd/route.ts
@@ -1,0 +1,36 @@
+import { NextResponse } from "next/server";
+
+const BSDD_DICTIONARY_URI = "https://identifier.buildingsmart.org/uri/nbs/uniclass2015/1";
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const search = searchParams.get("search") ?? "";
+
+  const params = new URLSearchParams({
+    DictionaryUri: BSDD_DICTIONARY_URI,
+    SearchText: search,
+    Limit: "100",
+  });
+
+  const res = await fetch(
+    `https://api.bsdd.buildingsmart.org/api/SearchInDictionary/v1?${params.toString()}`,
+    {
+      headers: { accept: "application/json" },
+    },
+  );
+
+  if (!res.ok) {
+    return new NextResponse("Failed to fetch bSDD classes", { status: 500 });
+  }
+
+  const data = await res.json();
+  const classes = data?.dictionary?.classes ?? [];
+  const mapped = classes.map((cls: any) => ({
+    uri: cls.uri,
+    code: cls.referenceCode,
+    name: cls.name,
+    classType: cls.classType,
+  }));
+
+  return NextResponse.json(mapped);
+}

--- a/components/bsdd-dialog.tsx
+++ b/components/bsdd-dialog.tsx
@@ -1,0 +1,164 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { fetchBSDDClasses, BsddClass } from "@/services/bsdd-service";
+import { Plus, Check, AlertCircle } from "lucide-react";
+import { useTranslation } from "react-i18next";
+
+interface BsddDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onAdd: (item: { code: string; name: string; color: string }) => void;
+  existingCodes: Set<string>;
+}
+
+const generateRandomColor = () => {
+  const hue = Math.floor(Math.random() * 360);
+  const saturation = 70 + Math.floor(Math.random() * 20);
+  const lightness = 45 + Math.floor(Math.random() * 10);
+  const h = hue / 360;
+  const s = saturation / 100;
+  const l = lightness / 100;
+  let r: number, g: number, b: number;
+  if (s === 0) {
+    r = g = b = l;
+  } else {
+    const hue2rgb = (p: number, q: number, t: number): number => {
+      if (t < 0) t += 1;
+      if (t > 1) t -= 1;
+      if (t < 1 / 6) return p + (q - p) * 6 * t;
+      if (t < 1 / 2) return q;
+      if (t < 2 / 3) return p + (q - p) * (2 / 3 - t) * 6;
+      return p;
+    };
+    const q = l < 0.5 ? l * (1 + s) : l + s - l * s;
+    const p = 2 * l - q;
+    r = hue2rgb(p, q, h + 1 / 3);
+    g = hue2rgb(p, q, h);
+    b = hue2rgb(p, q, h - 1 / 3);
+  }
+  const toHex = (x: number): string => {
+    const hex = Math.round(x * 255).toString(16);
+    return hex.length === 1 ? "0" + hex : hex;
+  };
+  return `#${toHex(r)}${toHex(g)}${toHex(b)}`;
+};
+
+export function BsddDialog({ open, onOpenChange, onAdd, existingCodes }: BsddDialogProps) {
+  const { t } = useTranslation();
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState<BsddClass[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const controller = new AbortController();
+    const timer = setTimeout(() => {
+      setLoading(true);
+      fetchBSDDClasses(query, controller.signal)
+        .then((cls) => {
+          setResults(cls);
+          setError(null);
+        })
+        .catch((e) => {
+          setError(e instanceof Error ? e.message : String(e));
+        })
+        .finally(() => setLoading(false));
+    }, 400);
+    return () => {
+      clearTimeout(timer);
+      controller.abort();
+    };
+  }, [query, open]);
+
+  const handleAdd = (cls: BsddClass) => {
+    onAdd({ code: cls.code, name: cls.name, color: generateRandomColor() });
+    onOpenChange(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>
+            {t("classifications.browseBSDDTitle", "Browse bSDD")}
+          </DialogTitle>
+        </DialogHeader>
+        <div className="flex flex-col gap-4 py-2">
+          <Input
+            placeholder={t(
+              "classifications.searchBSDDPlaceholder",
+              "Search bSDD...",
+            )}
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+          />
+          <ScrollArea className="h-64 border rounded-md">
+            {loading && (
+              <div className="p-4 text-sm text-muted-foreground">
+                {t("buttons.loadingBSDD", "Loading bSDD...")}
+              </div>
+            )}
+            {error && (
+              <div className="p-4 text-sm text-destructive flex items-center gap-2">
+                <AlertCircle className="h-4 w-4" /> {error}
+              </div>
+            )}
+            {!loading && !error && results.length === 0 && (
+              <div className="p-4 text-sm text-muted-foreground">
+                {t("classifications.noSearchResults")}
+              </div>
+            )}
+            {!loading && !error && results.length > 0 && (
+              <ul className="divide-y">
+                {results.map((cls) => {
+                  const added = existingCodes.has(cls.code);
+                  return (
+                    <li
+                      key={cls.code}
+                      className="flex items-center justify-between p-2"
+                    >
+                      <div className="mr-2">
+                        <div className="font-medium">{cls.code}</div>
+                        <div className="text-sm text-muted-foreground">
+                          {cls.name}
+                        </div>
+                      </div>
+                      {added ? (
+                        <Button variant="secondary" size="sm" disabled>
+                          <Check className="h-4 w-4 mr-1" />
+                          {t("buttons.added", "Added")}
+                        </Button>
+                      ) : (
+                        <Button size="sm" onClick={() => handleAdd(cls)}>
+                          <Plus className="h-4 w-4 mr-1" />
+                          {t("buttons.add")}
+                        </Button>
+                      )}
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+          </ScrollArea>
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            {t("buttons.cancel")}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/classification-panel.tsx
+++ b/components/classification-panel.tsx
@@ -70,6 +70,7 @@ import {
   ArchiveRestore,
   Star,
   Cuboid,
+  Search,
 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import {
@@ -78,6 +79,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { BsddDialog } from "@/components/bsdd-dialog";
 import {
   exportIfcWithClassificationsService,
   downloadFile,
@@ -143,6 +145,7 @@ export function ClassificationPanel() {
   } = useIFCContext();
   const { t } = useTranslation();
   const [isAddDialogOpen, setIsAddDialogOpen] = useState(false);
+  const [isBsddDialogOpen, setIsBsddDialogOpen] = useState(false);
   const [newClassification, setNewClassification] = useState({
     code: "",
     name: "",
@@ -1145,6 +1148,10 @@ export function ClassificationPanel() {
                   <Plus className="mr-2 h-4 w-4" />
                   {t("classifications.addNew")}
                 </DropdownMenuItem>
+                <DropdownMenuItem onSelect={() => setIsBsddDialogOpen(true)}>
+                  <Search className="mr-2 h-4 w-4" />
+                  {t("buttons.browseBSDD", "Browse bSDD")}
+                </DropdownMenuItem>
                 <DropdownMenuSeparator />
                 <DropdownMenuLabel className="text-xs font-semibold text-muted-foreground px-2 py-1.5">
                   {t("sections.defaultSets")}
@@ -1412,17 +1419,23 @@ export function ClassificationPanel() {
               >
                 {t("buttons.cancel")}
               </Button>
-              <Button onClick={handleAddClassification}>
-                {t("buttons.add")}
-              </Button>
-            </DialogFooter>
-          </DialogContent>
-        </Dialog>
-        {/* The old "Row 2 Management Dropdown section" is now fully replaced by the 3-dot menu in the header and this restored dialog. */}
-        {/* The hidden file input for import is kept at the end of the component. */}
-        <Dialog
-          open={isMapFromModelDialogOpen}
-          onOpenChange={(open) => {
+          <Button onClick={handleAddClassification}>
+            {t("buttons.add")}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+    <BsddDialog
+      open={isBsddDialogOpen}
+      onOpenChange={setIsBsddDialogOpen}
+      onAdd={(item) => addClassification(item)}
+      existingCodes={new Set(Object.keys(classifications))}
+    />
+    {/* The old "Row 2 Management Dropdown section" is now fully replaced by the 3-dot menu in the header and this restored dialog. */}
+    {/* The hidden file input for import is kept at the end of the component. */}
+    <Dialog
+      open={isMapFromModelDialogOpen}
+      onOpenChange={(open) => {
             setIsMapFromModelDialogOpen(open);
             if (!open) {
               // Reset form state when closing

--- a/public/locales/de/common.json
+++ b/public/locales/de/common.json
@@ -138,7 +138,10 @@
     "deleteRule": "Regel löschen",
     "previewRule": "Regelauswirkung anzeigen",
     "clearPreview": "Vorschau zurücksetzen",
-    "mapFromModel": "Aus Modell übernehmen"
+    "mapFromModel": "Aus Modell übernehmen",
+    "browseBSDD": "bSDD durchsuchen",
+    "loadingBSDD": "bSDD wird geladen...",
+    "added": "Hinzugefügt"
   },
   "messages": {
     "loading": "Wird geladen...",
@@ -215,6 +218,8 @@
     "classificationPlural": "Klassifikationen",
     "searchPlaceholder": "Klassifizierungen durchsuchen...",
     "noSearchResults": "Keine Klassifizierungen entsprechen Ihrer Suche.",
+    "browseBSDDTitle": "bSDD durchsuchen",
+    "searchBSDDPlaceholder": "bSDD durchsuchen...",
     "noClassificationFound": "Keine Klassifizierung gefunden. Tippen Sie, um zu erstellen.",
     "createNewClassification": "Neue Klassifizierung \"{{value}}\" erstellen",
     "mapFromModelTitle": "Klassifizierungen aus Modell übernehmen",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -138,7 +138,10 @@
     "deleteRule": "Delete Rule",
     "previewRule": "Preview Rule Impact",
     "clearPreview": "Clear Preview",
-    "mapFromModel": "Map From Model"
+    "mapFromModel": "Map From Model",
+    "browseBSDD": "Browse bSDD",
+    "loadingBSDD": "Loading bSDD...",
+    "added": "Added"
   },
   "messages": {
     "loading": "Loading...",
@@ -211,6 +214,8 @@
     "classificationPlural": "classifications",
     "searchPlaceholder": "Search classifications...",
     "noSearchResults": "No classifications match your search.",
+    "browseBSDDTitle": "Browse bSDD",
+    "searchBSDDPlaceholder": "Search bSDD...",
     "mapFromModelTitle": "Map Classifications from Model",
     "mapFromModelDescription": "Extract classifications from property values in the model",
     "export": "Export",

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -138,7 +138,10 @@
         "deleteRule": "Supprimer la règle",
         "previewRule": "Prévisualiser l'impact de la règle",
         "clearPreview": "Effacer la prévisualisation",
-        "mapFromModel": "Mapper depuis le modèle"
+        "mapFromModel": "Mapper depuis le modèle",
+        "browseBSDD": "Parcourir bSDD",
+        "loadingBSDD": "Chargement bSDD...",
+        "added": "Ajouté"
     },
     "messages": {
         "loading": "Chargement...",
@@ -215,6 +218,8 @@
         "classificationPlural": "classifications",
         "searchPlaceholder": "Rechercher des classifications...",
         "noSearchResults": "Aucune classification ne correspond à votre recherche.",
+        "browseBSDDTitle": "Parcourir bSDD",
+        "searchBSDDPlaceholder": "Rechercher dans bSDD...",
         "mapFromModelTitle": "Mapper les classifications depuis le modèle",
         "mapFromModelDescription": "Extraire les classifications des valeurs de propriétés dans le modèle",
         "psetName": "Nom du PSet",

--- a/public/locales/it/common.json
+++ b/public/locales/it/common.json
@@ -138,7 +138,10 @@
         "deleteRule": "Elimina regola",
         "previewRule": "Anteprima impatto regola",
         "clearPreview": "Cancella anteprima",
-        "mapFromModel": "Mappa dal modello"
+        "mapFromModel": "Mappa dal modello",
+        "browseBSDD": "Sfoglia bSDD",
+        "loadingBSDD": "Caricamento bSDD...",
+        "added": "Aggiunto"
     },
     "messages": {
         "loading": "Caricamento...",
@@ -215,6 +218,8 @@
         "classificationPlural": "classificazioni",
         "searchPlaceholder": "Cerca classificazioni...",
         "noSearchResults": "Nessuna classificazione corrisponde alla tua ricerca.",
+        "browseBSDDTitle": "Sfoglia bSDD",
+        "searchBSDDPlaceholder": "Cerca in bSDD...",
         "mapFromModelTitle": "Mappa classificazioni dal modello",
         "mapFromModelDescription": "Estrai classificazioni dai valori delle proprietà nel modello",
         "psetName": "Nome PSet",

--- a/services/bsdd-service.ts
+++ b/services/bsdd-service.ts
@@ -1,0 +1,21 @@
+export interface BsddClass {
+  uri: string;
+  code: string;
+  name: string;
+  classType: string;
+}
+
+export async function fetchBSDDClasses(
+  search: string,
+  signal?: AbortSignal,
+): Promise<BsddClass[]> {
+  const params = new URLSearchParams();
+  if (search) {
+    params.set("search", search);
+  }
+  const res = await fetch(`/api/bsdd?${params.toString()}`, { signal });
+  if (!res.ok) {
+    throw new Error("Failed to fetch bSDD classes");
+  }
+  return res.json();
+}


### PR DESCRIPTION
## Summary
- add bSDD classification lookup modal with search
- integrate modal into classification menu
- localize new bSDD strings
- proxy bSDD search through Next.js API to avoid CORS issues

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b886e6478c8320801ded6b5682ef1d