### PR TITLE
feat: add premium trial system scaffolding

### DIFF
--- a/app/api/admin/trials/grant/route.ts
+++ b/app/api/admin/trials/grant/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from 'next/server';
+import { TrialService } from '@/services/trial-service';
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json();
+    const { email, durationDays = 14, notes } = body;
+
+    if (!email) {
+      return NextResponse.json({ error: 'Email is required' }, { status: 400 });
+    }
+
+    const trial = await TrialService.grantTrial(email, durationDays);
+
+    return NextResponse.json({
+      success: true,
+      trial_id: trial.id,
+      user_id: trial.userId,
+      trial_end: trial.trialEnd,
+      notes,
+    });
+  } catch (err: any) {
+    return NextResponse.json({ error: err.message }, { status: 400 });
+  }
+}

--- a/components/PremiumFeatureGuard.tsx
+++ b/components/PremiumFeatureGuard.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import React from 'react';
+import { useUser } from '@clerk/nextjs';
+import { isTrialActive, getTrialDaysLeft, TrialMetadata } from '@/lib/utils/trial-utils';
+
+interface PremiumFeatureGuardProps {
+  children: React.ReactNode;
+  fallback?: React.ReactNode;
+}
+
+/**
+ * Guard component to protect premium-only features during an active trial.
+ */
+export function PremiumFeatureGuard({ children, fallback }: PremiumFeatureGuardProps) {
+  const { user, isLoaded } = useUser();
+
+  if (!isLoaded) return <div>Loading...</div>;
+
+  const trialData = (user?.publicMetadata?.premium_trial || null) as TrialMetadata | null;
+  const active = isTrialActive(trialData);
+  const daysLeft = getTrialDaysLeft(trialData);
+
+  if (!active) {
+    return (
+      fallback || (
+        <div className="p-6 bg-yellow-50 border border-yellow-200 rounded-lg">
+          <h3 className="text-lg font-semibold text-yellow-800">Premium Feature</h3>
+          <p className="text-yellow-700 mt-2">
+            This feature requires a premium subscription.
+            <a href="/pricing" className="ml-2 text-yellow-800 underline hover:text-yellow-900">
+              Upgrade now
+            </a>
+          </p>
+        </div>
+      )
+    );
+  }
+
+  return (
+    <div>
+      {daysLeft <= 3 && (
+        <div className="mb-4 p-4 bg-orange-50 border border-orange-200 rounded-lg">
+          <p className="text-orange-800">
+            ⚠️ Your premium trial ends in {daysLeft} day{daysLeft !== 1 ? 's' : ''}.
+            <a href="/pricing" className="ml-2 text-orange-800 underline hover:text-orange-900">
+              Upgrade now
+            </a>
+          </p>
+        </div>
+      )}
+      {children}
+    </div>
+  );
+}

--- a/components/admin/TrialManager.tsx
+++ b/components/admin/TrialManager.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import React, { useState } from 'react';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@/components/ui/select';
+import { toast } from 'sonner';
+
+export function TrialManager() {
+  const [email, setEmail] = useState('');
+  const [duration, setDuration] = useState(14);
+
+  const handleGrantTrial = async () => {
+    try {
+      const response = await fetch('/api/admin/trials/grant', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, durationDays: duration }),
+      });
+
+      if (response.ok) {
+        toast.success('Trial granted successfully');
+        setEmail('');
+      } else {
+        const data = await response.json();
+        toast.error(data.error || 'Failed to grant trial');
+      }
+    } catch (err) {
+      toast.error('Failed to grant trial');
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <Input
+        placeholder="user@example.com"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+      />
+      <Select value={String(duration)} onValueChange={(v) => setDuration(parseInt(v))}>
+        <SelectTrigger>
+          <SelectValue placeholder="Duration" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="7">7 days</SelectItem>
+          <SelectItem value="14">14 days</SelectItem>
+          <SelectItem value="30">30 days</SelectItem>
+        </SelectContent>
+      </Select>
+      <Button onClick={handleGrantTrial}>Grant Trial Access</Button>
+    </div>
+  );
+}

--- a/db/user_trials.sql
+++ b/db/user_trials.sql
@@ -1,0 +1,20 @@
+CREATE TABLE user_trials (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL,
+  email VARCHAR(255) NOT NULL,
+  trial_start TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  trial_end TIMESTAMP WITH TIME ZONE NOT NULL,
+  trial_status VARCHAR(20) DEFAULT 'active',
+  reminder_sent_7d BOOLEAN DEFAULT false,
+  reminder_sent_3d BOOLEAN DEFAULT false,
+  reminder_sent_1d BOOLEAN DEFAULT false,
+  created_by UUID NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  notes TEXT,
+  metadata JSONB
+);
+
+CREATE INDEX idx_user_trials_user_id ON user_trials(user_id);
+CREATE INDEX idx_user_trials_email ON user_trials(email);
+CREATE INDEX idx_user_trials_status ON user_trials(trial_status);
+CREATE INDEX idx_user_trials_end ON user_trials(trial_end);

--- a/emails/templates.ts
+++ b/emails/templates.ts
@@ -1,0 +1,10 @@
+import fs from 'fs';
+import path from 'path';
+
+function readTemplate(file: string): string {
+  return fs.readFileSync(path.join(process.cwd(), 'emails', file), 'utf8');
+}
+
+export const sevenDayTemplate = readTemplate('trial-reminder-7d.html');
+export const threeDayTemplate = readTemplate('trial-reminder-3d.html');
+export const oneDayTemplate = readTemplate('trial-reminder-1d.html');

--- a/emails/trial-reminder-1d.html
+++ b/emails/trial-reminder-1d.html
@@ -1,0 +1,13 @@
+<h1>🚨 FINAL REMINDER: Trial Ends Tomorrow</h1>
+
+<p>Dear {{user.name}},</p>
+
+<p><strong>FINAL NOTICE:</strong> Your premium trial ends <strong>tomorrow</strong> ({{trial.end_date}}).</p>
+
+<p>This is your last chance to upgrade and keep your templates!</p>
+
+<p><a href="{{upgrade_url}}" class="button critical">Upgrade Now</a></p>
+
+<p>Thank you for trying QTOpro.</p>
+
+<p>Best regards,<br/>The QTOpro Team</p>

--- a/emails/trial-reminder-3d.html
+++ b/emails/trial-reminder-3d.html
@@ -1,0 +1,19 @@
+<h1>⚠️ Your QTOpro Premium Trial Ends in 3 Days</h1>
+
+<p>Dear {{user.name}},</p>
+
+<p><strong>URGENT:</strong> Your premium trial ends in just 3 days ({{trial.end_date}}).</p>
+
+<p>Don't lose access to your premium features and templates!</p>
+
+<p><a href="{{upgrade_url}}" class="button urgent">Upgrade Now - Save 20%</a></p>
+
+<p>After {{trial.end_date}}, you'll lose access to:</p>
+<ul>
+  <li>Advanced template builders</li>
+  <li>Batch processing</li>
+  <li>Priority support</li>
+  <li>Your existing templates</li>
+</ul>
+
+<p>Best regards,<br/>The QTOpro Team</p>

--- a/emails/trial-reminder-7d.html
+++ b/emails/trial-reminder-7d.html
@@ -1,0 +1,15 @@
+<h1>Your QTOpro Premium Trial Ends Soon</h1>
+
+<p>Dear {{user.name}},</p>
+
+<p>Your 14-day premium trial with QTOpro is ending in <strong>7 days</strong> ({{trial.end_date}}).</p>
+
+<p>To continue enjoying premium features and retain your templates, please upgrade before the trial ends.</p>
+
+<p><a href="{{upgrade_url}}" class="button">Upgrade Now</a></p>
+
+<p>If you choose not to upgrade, your access to premium features and templates will be discontinued after {{trial.end_date}}.</p>
+
+<p>Thank you for trying QTOpro Premium.</p>
+
+<p>Best regards,<br/>The QTOpro Team</p>

--- a/lib/utils/trial-utils.ts
+++ b/lib/utils/trial-utils.ts
@@ -1,0 +1,29 @@
+export interface TrialMetadata {
+  start?: string;
+  end?: string;
+  status?: 'active' | 'expired' | 'converted';
+}
+
+/**
+ * Determine if the trial data represents an active trial.
+ */
+export function isTrialActive(trialData: TrialMetadata | null | undefined): boolean {
+  if (!trialData || trialData.status !== 'active') return false;
+
+  const now = new Date();
+  const trialEnd = trialData.end ? new Date(trialData.end) : new Date(0);
+  return now <= trialEnd;
+}
+
+/**
+ * Calculate the number of days left in an active trial.
+ */
+export function getTrialDaysLeft(trialData: TrialMetadata | null | undefined): number {
+  if (!trialData || trialData.status !== 'active' || !trialData.end) return 0;
+
+  const now = new Date();
+  const trialEnd = new Date(trialData.end);
+  const diffTime = trialEnd.getTime() - now.getTime();
+  const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
+  return Math.max(0, diffDays);
+}

--- a/scripts/send-trial-reminders.ts
+++ b/scripts/send-trial-reminders.ts
@@ -1,0 +1,38 @@
+// Scheduled job to send trial reminder emails.
+// This script queries trials ending in 7, 3, or 1 day and sends reminders.
+
+import { db } from '@/services/db'; // placeholder db module
+import { userTrials } from '@/services/schema'; // placeholder schema
+import { EmailService } from '@/services/email-service';
+import { eq, sql, not } from 'drizzle-orm';
+
+export async function sendTrialReminders() {
+  const now = new Date();
+  const reminderDays = [7, 3, 1];
+
+  for (const days of reminderDays) {
+    const targetDate = new Date();
+    targetDate.setDate(now.getDate() + days);
+
+    const trials = await db
+      .select()
+      .from(userTrials)
+      .where(eq(userTrials.trialStatus, 'active'))
+      .where(sql`DATE(${userTrials.trialEnd}) = DATE(${targetDate})`)
+      .where(not(sql`${userTrials[`reminderSent${days}d` as keyof typeof userTrials]}`));
+
+    for (const trial of trials) {
+      try {
+        await EmailService.sendTrialReminder(trial.userId, trial, days);
+        console.log(`Sent ${days}-day reminder to ${trial.email}`);
+      } catch (err) {
+        console.error(`Failed to send reminder to ${trial.email}:`, err);
+      }
+    }
+  }
+}
+
+// Allow running as standalone script
+if (require.main === module) {
+  sendTrialReminders().then(() => process.exit(0));
+}

--- a/services/db.ts
+++ b/services/db.ts
@@ -1,0 +1,3 @@
+// Placeholder database module. In a real application this would export a configured
+// database client or query builder instance.
+export const db: any = {};

--- a/services/email-service.ts
+++ b/services/email-service.ts
@@ -1,0 +1,71 @@
+// Email service for sending trial reminder notifications.
+// Assumes existence of an email sending utility and database access.
+
+import { clerkClient } from '@clerk/nextjs/server';
+import { db } from '@/services/db'; // placeholder db module
+import { userTrials, Trial } from '@/services/schema'; // placeholder schema
+import { sevenDayTemplate, threeDayTemplate, oneDayTemplate } from '@/emails/templates';
+
+interface TemplateInfo {
+  subject: string;
+  html: string;
+}
+
+export class EmailService {
+  static async sendTrialReminder(userId: string, trial: Trial, daysLeft: number) {
+    const user = await clerkClient.users.getUser(userId);
+    const template = this.getEmailTemplate(daysLeft);
+    if (!template) return;
+
+    await sendEmail({
+      to: user.emailAddresses[0].emailAddress,
+      subject: template.subject,
+      html: this.renderTemplate(template.html, {
+        user: {
+          name: user.firstName || 'there',
+          email: user.emailAddresses[0].emailAddress,
+        },
+        trial: {
+          end_date: trial.trialEnd.toLocaleDateString(),
+          days_left: daysLeft,
+        },
+        upgrade_url: `${process.env.NEXT_PUBLIC_APP_URL}/pricing`,
+      }),
+    });
+
+    await db
+      .update(userTrials)
+      .set({ [`reminderSent${daysLeft}d`]: true, updatedAt: new Date() })
+      .where((ut) => ut.id === trial.id);
+  }
+
+  private static getEmailTemplate(daysLeft: number): TemplateInfo | null {
+    switch (daysLeft) {
+      case 7:
+        return { subject: 'Your QTOpro Premium Trial Ends in 7 Days', html: sevenDayTemplate };
+      case 3:
+        return { subject: '⚠️ Your QTOpro Premium Trial Ends in 3 Days', html: threeDayTemplate };
+      case 1:
+        return { subject: '🚨 FINAL REMINDER: Trial Ends Tomorrow', html: oneDayTemplate };
+      default:
+        return null;
+    }
+  }
+
+  // Placeholder template rendering
+  private static renderTemplate(html: string, data: Record<string, any>): string {
+    return html.replace(/{{\s*(.*?)\s*}}/g, (_, key) => {
+      const keys = key.split('.');
+      let value: any = data;
+      for (const k of keys) {
+        value = value?.[k];
+      }
+      return value ?? '';
+    });
+  }
+}
+
+// Placeholder email sending function
+async function sendEmail(_payload: { to: string; subject: string; html: string }) {
+  // Implementation depends on chosen provider
+}

--- a/services/schema.ts
+++ b/services/schema.ts
@@ -1,0 +1,17 @@
+// Placeholder schema definitions for the trial system.
+export interface Trial {
+  id: string;
+  userId: string;
+  email: string;
+  trialEnd: Date;
+  trialStatus: string;
+  [key: string]: any;
+}
+
+export const userTrials: any = {
+  id: 'id',
+  userId: 'user_id',
+  email: 'email',
+  trialEnd: 'trial_end',
+  trialStatus: 'trial_status',
+};

--- a/services/trial-service.ts
+++ b/services/trial-service.ts
@@ -1,0 +1,68 @@
+// Service for granting and managing premium trials.
+// Note: This implementation assumes availability of a database and Clerk client.
+
+import { clerkClient } from '@clerk/nextjs/server';
+import { db } from '@/services/db'; // placeholder, actual db module should provide query builder
+import { userTrials } from '@/services/schema'; // placeholder schema
+import { eq } from 'drizzle-orm';
+
+export class TrialService {
+  /**
+   * Grant a premium trial to a user identified by email.
+   */
+  static async grantTrial(email: string, durationDays: number = 14) {
+    // 1. Find user by email
+    const user = await clerkClient.users.getUserList({ emailAddress: [email] });
+    if (!user.data.length) {
+      throw new Error('User not found');
+    }
+    const userId = user.data[0].id;
+
+    // 2. Check for existing active trial
+    const existing = await db
+      .select()
+      .from(userTrials)
+      .where(eq(userTrials.userId, userId))
+      .where(eq(userTrials.trialStatus, 'active'))
+      .limit(1);
+
+    if (existing.length > 0) {
+      throw new Error('User already has an active trial');
+    }
+
+    // 3. Create trial record
+    const trialEnd = new Date();
+    trialEnd.setDate(trialEnd.getDate() + durationDays);
+
+    const [trial] = await db
+      .insert(userTrials)
+      .values({
+        userId,
+        email,
+        trialEnd,
+        trialStatus: 'active',
+        createdBy: await this.getCurrentUserId(),
+      })
+      .returning();
+
+    // 4. Update Clerk metadata
+    await clerkClient.users.updateUser(userId, {
+      publicMetadata: {
+        ...user.data[0].publicMetadata,
+        premium_trial: {
+          start: new Date().toISOString(),
+          end: trialEnd.toISOString(),
+          status: 'active',
+        },
+      },
+    });
+
+    return trial;
+  }
+
+  // Placeholder helper to retrieve current admin user id
+  private static async getCurrentUserId(): Promise<string> {
+    // Implement according to authentication mechanism
+    return 'admin-id';
+  }
+}


### PR DESCRIPTION
## Summary
- scaffold premium trial data layer, services, and API to grant trials by email
- add React guard and admin interface for managing premium trials
- include reminder email templates and scheduled reminder script

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b9a4475f1483208f92484984da8935