### PR TITLE
feat: add premium trial infrastructure

### DIFF
--- a/app/api/admin/trials/grant/route.ts
+++ b/app/api/admin/trials/grant/route.ts
@@ -1,0 +1,17 @@
+import { NextRequest, NextResponse } from "next/server";
+import { TrialService } from "@/lib/services/trial-service";
+
+export async function POST(req: NextRequest) {
+  const { email, durationDays } = await req.json();
+  try {
+    const trial = await TrialService.grantTrial(email, durationDays);
+    return NextResponse.json({
+      success: true,
+      trial_id: trial.id,
+      user_id: trial.userId,
+      trial_end: trial.trialEnd.toISOString(),
+    });
+  } catch (error: any) {
+    return NextResponse.json({ success: false, error: error.message }, { status: 400 });
+  }
+}

--- a/app/api/premium-feature/route.ts
+++ b/app/api/premium-feature/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from "next/server";
+import { requirePremiumAccess } from "@/lib/auth/premium-check";
+import { getTrialDaysLeft } from "@/lib/utils/trial-utils";
+
+export async function POST() {
+  try {
+    const { userId, trialData } = await requirePremiumAccess("stub-user");
+    const daysLeft = getTrialDaysLeft(trialData);
+    return NextResponse.json({ message: "Premium feature executed", userId, daysLeft });
+  } catch (error: any) {
+    return new NextResponse(error.message, { status: 403 });
+  }
+}

--- a/components/PremiumFeatureGuard.tsx
+++ b/components/PremiumFeatureGuard.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import type React from "react";
+import { useUser } from "@/lib/useUser";
+import { isTrialActive, getTrialDaysLeft } from "@/lib/utils/trial-utils";
+
+interface PremiumFeatureGuardProps {
+  children: React.ReactNode;
+  fallback?: React.ReactNode;
+}
+
+export function PremiumFeatureGuard({ children, fallback }: PremiumFeatureGuardProps) {
+  const { user, isLoaded } = useUser();
+
+  if (!isLoaded) return <div>Loading...</div>;
+
+  const trialData = user?.publicMetadata?.premium_trial;
+  const hasActiveTrial = isTrialActive(trialData);
+  const daysLeft = getTrialDaysLeft(trialData);
+
+  if (!hasActiveTrial) {
+    return (
+      fallback || (
+        <div className="p-6 bg-yellow-50 border border-yellow-200 rounded-lg">
+          <h3 className="text-lg font-semibold text-yellow-800">Premium Feature</h3>
+          <p className="text-yellow-700 mt-2">
+            This feature requires a premium subscription.
+            <a href="/pricing" className="ml-2 text-yellow-800 underline hover:text-yellow-900">
+              Upgrade now
+            </a>
+          </p>
+        </div>
+      )
+    );
+  }
+
+  return (
+    <div>
+      {daysLeft <= 3 && (
+        <div className="mb-4 p-4 bg-orange-50 border border-orange-200 rounded-lg">
+          <p className="text-orange-800">
+            ⚠️ Your premium trial ends in {daysLeft} day{daysLeft !== 1 ? "s" : ""}.
+            <a href="/pricing" className="ml-2 text-orange-800 underline hover:text-orange-900">
+              Upgrade now
+            </a>
+          </p>
+        </div>
+      )}
+      {children}
+    </div>
+  );
+}

--- a/components/admin/TrialManager.tsx
+++ b/components/admin/TrialManager.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { useState } from "react";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+} from "@/components/ui/select";
+
+export function TrialManager() {
+  const [email, setEmail] = useState("");
+  const [duration, setDuration] = useState("14");
+
+  const handleGrantTrial = async () => {
+    try {
+      const response = await fetch("/api/admin/trials/grant", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email, durationDays: Number(duration) }),
+      });
+
+      if (response.ok) {
+        alert("Trial granted successfully");
+        setEmail("");
+      } else {
+        alert("Failed to grant trial");
+      }
+    } catch (error) {
+      alert("Failed to grant trial");
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Grant Premium Trial</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <Input
+          placeholder="user@example.com"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+        />
+        <Select value={duration} onValueChange={setDuration}>
+          <SelectTrigger>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="7">7 days</SelectItem>
+            <SelectItem value="14">14 days</SelectItem>
+            <SelectItem value="30">30 days</SelectItem>
+          </SelectContent>
+        </Select>
+        <Button onClick={handleGrantTrial}>Grant Trial Access</Button>
+      </CardContent>
+    </Card>
+  );
+}

--- a/emails/trial-reminder-1d.html
+++ b/emails/trial-reminder-1d.html
@@ -1,0 +1,13 @@
+<h1>🚨 FINAL REMINDER: Trial Ends Tomorrow</h1>
+
+<p>Dear {{user.name}},</p>
+
+<p><strong>FINAL NOTICE:</strong> Your premium trial ends <strong>tomorrow</strong> ({{trial.end_date}}).</p>
+
+<p>This is your last chance to upgrade and keep your templates!</p>
+
+<p><a href="{{upgrade_url}}" class="button critical">Upgrade Now</a></p>
+
+<p>Thank you for trying QTOpro.</p>
+
+<p>Best regards,<br>The QTOpro Team</p>

--- a/emails/trial-reminder-3d.html
+++ b/emails/trial-reminder-3d.html
@@ -1,0 +1,19 @@
+<h1>⚠️ Your QTOpro Premium Trial Ends in 3 Days</h1>
+
+<p>Dear {{user.name}},</p>
+
+<p><strong>URGENT:</strong> Your premium trial ends in just 3 days ({{trial.end_date}}).</p>
+
+<p>Don't lose access to your premium features and templates!</p>
+
+<p><a href="{{upgrade_url}}" class="button urgent">Upgrade Now - Save 20%</a></p>
+
+<p>After {{trial.end_date}}, you'll lose access to:</p>
+<ul>
+  <li>Advanced template builders</li>
+  <li>Batch processing</li>
+  <li>Priority support</li>
+  <li>Your existing templates</li>
+</ul>
+
+<p>Best regards,<br>The QTOpro Team</p>

--- a/emails/trial-reminder-7d.html
+++ b/emails/trial-reminder-7d.html
@@ -1,0 +1,15 @@
+<h1>Your QTOpro Premium Trial Ends Soon</h1>
+
+<p>Dear {{user.name}},</p>
+
+<p>Your 14-day premium trial with QTOpro is ending in <strong>7 days</strong> ({{trial.end_date}}).</p>
+
+<p>To continue enjoying premium features and retain your templates, please upgrade before the trial ends.</p>
+
+<p><a href="{{upgrade_url}}" class="button">Upgrade Now</a></p>
+
+<p>If you choose not to upgrade, your access to premium features and templates will be discontinued after {{trial.end_date}}.</p>
+
+<p>Thank you for trying QTOpro Premium.</p>
+
+<p>Best regards,<br>The QTOpro Team</p>

--- a/lib/auth/premium-check.ts
+++ b/lib/auth/premium-check.ts
@@ -1,0 +1,11 @@
+import { clerkClient } from "@/lib/clerk";
+import { isTrialActive } from "@/lib/utils/trial-utils";
+
+export async function requirePremiumAccess(userId: string) {
+  const user = await clerkClient.users.getUser(userId);
+  const trialData = user.publicMetadata?.premium_trial;
+  if (!isTrialActive(trialData)) {
+    throw new Error("Premium access required");
+  }
+  return { userId, trialData };
+}

--- a/lib/clerk.ts
+++ b/lib/clerk.ts
@@ -1,0 +1,19 @@
+// Minimal Clerk client stub for development and testing environments
+export const clerkClient = {
+  users: {
+    async getUserList(_: { emailAddress: string[] }) {
+      return { data: [{ id: 'stub-user', publicMetadata: {} }] };
+    },
+    async updateUser(_: string, __: any) {
+      return {};
+    },
+    async getUser(id: string) {
+      return {
+        id,
+        firstName: 'User',
+        emailAddresses: [{ emailAddress: 'user@example.com' }],
+        publicMetadata: { premium_trial: null },
+      };
+    },
+  },
+};

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -1,0 +1,34 @@
+export interface UserTrial {
+  id: string;
+  userId: string;
+  email: string;
+  trialStart: Date;
+  trialEnd: Date;
+  trialStatus: 'active' | 'expired' | 'converted';
+  reminderSent7d: boolean;
+  reminderSent3d: boolean;
+  reminderSent1d: boolean;
+  createdBy: string;
+  createdAt: Date;
+  notes?: string;
+  metadata?: Record<string, unknown>;
+}
+
+// Simple in-memory store used as placeholder for a real database
+const trials: UserTrial[] = [];
+
+export const db = {
+  insertTrial(trial: UserTrial) {
+    trials.push(trial);
+    return trial;
+  },
+  findActiveTrialByUser(userId: string) {
+    return trials.find(t => t.userId === userId && t.trialStatus === 'active');
+  },
+  updateTrial(id: string, data: Partial<UserTrial>) {
+    const trial = trials.find(t => t.id === id);
+    if (trial) Object.assign(trial, data);
+    return trial;
+  },
+  trials,
+};

--- a/lib/services/email-service.ts
+++ b/lib/services/email-service.ts
@@ -1,0 +1,50 @@
+import fs from "fs";
+import path from "path";
+import { clerkClient } from "@/lib/clerk";
+import { db, UserTrial } from "@/lib/db";
+
+const templatesDir = path.join(process.cwd(), "emails");
+const sevenDayTemplate = fs.readFileSync(
+  path.join(templatesDir, "trial-reminder-7d.html"),
+  "utf8"
+);
+const threeDayTemplate = fs.readFileSync(
+  path.join(templatesDir, "trial-reminder-3d.html"),
+  "utf8"
+);
+const oneDayTemplate = fs.readFileSync(
+  path.join(templatesDir, "trial-reminder-1d.html"),
+  "utf8"
+);
+
+export class EmailService {
+  static async sendTrialReminder(userId: string, trial: UserTrial, daysLeft: number) {
+    const user = await clerkClient.users.getUser(userId);
+    const template = this.getEmailTemplate(daysLeft);
+
+    const html = template.html
+      .replace(/{{user.name}}/g, user.firstName || "there")
+      .replace(/{{trial.end_date}}/g, trial.trialEnd.toLocaleDateString())
+      .replace(/{{upgrade_url}}/g, `${process.env.NEXT_PUBLIC_APP_URL || ''}/pricing`);
+
+    console.log(`Sending email to ${user.emailAddresses[0].emailAddress}: ${template.subject}`);
+    console.log(html.substring(0, 60));
+
+    db.updateTrial(trial.id, {
+      [`reminderSent${daysLeft}d`]: true as any,
+    });
+  }
+
+  private static getEmailTemplate(daysLeft: number) {
+    switch (daysLeft) {
+      case 7:
+        return { subject: "Your QTOpro Premium Trial Ends in 7 Days", html: sevenDayTemplate };
+      case 3:
+        return { subject: "⚠️ Your QTOpro Premium Trial Ends in 3 Days", html: threeDayTemplate };
+      case 1:
+        return { subject: "🚨 FINAL REMINDER: Trial Ends Tomorrow", html: oneDayTemplate };
+      default:
+        return { subject: "", html: "" };
+    }
+  }
+}

--- a/lib/services/trial-service.ts
+++ b/lib/services/trial-service.ts
@@ -1,0 +1,49 @@
+import { randomUUID } from "crypto";
+import { db, UserTrial } from "@/lib/db";
+import { clerkClient } from "@/lib/clerk";
+
+export class TrialService {
+  static async grantTrial(email: string, durationDays = 14) {
+    const user = await clerkClient.users.getUserList({ emailAddress: [email] });
+    if (!user.data.length) {
+      throw new Error("User not found");
+    }
+
+    const userId = user.data[0].id;
+    const existing = db.findActiveTrialByUser(userId);
+    if (existing) {
+      throw new Error("User already has an active trial");
+    }
+
+    const trialEnd = new Date();
+    trialEnd.setDate(trialEnd.getDate() + durationDays);
+
+    const trial: UserTrial = {
+      id: randomUUID(),
+      userId,
+      email,
+      trialStart: new Date(),
+      trialEnd,
+      trialStatus: "active",
+      reminderSent7d: false,
+      reminderSent3d: false,
+      reminderSent1d: false,
+      createdBy: userId,
+      createdAt: new Date(),
+    };
+
+    db.insertTrial(trial);
+
+    await clerkClient.users.updateUser(userId, {
+      publicMetadata: {
+        premium_trial: {
+          start: trial.trialStart.toISOString(),
+          end: trial.trialEnd.toISOString(),
+          status: "active",
+        },
+      },
+    });
+
+    return trial;
+  }
+}

--- a/lib/useUser.ts
+++ b/lib/useUser.ts
@@ -1,0 +1,3 @@
+export function useUser() {
+  return { user: { publicMetadata: { premium_trial: null } }, isLoaded: true };
+}

--- a/lib/utils/trial-utils.ts
+++ b/lib/utils/trial-utils.ts
@@ -1,0 +1,19 @@
+export function isTrialActive(trialData: any): boolean {
+  if (!trialData || trialData.status !== "active") return false;
+
+  const now = new Date();
+  const trialEnd = new Date(trialData.end);
+
+  return now <= trialEnd;
+}
+
+export function getTrialDaysLeft(trialData: any): number {
+  if (!trialData || trialData.status !== "active") return 0;
+
+  const now = new Date();
+  const trialEnd = new Date(trialData.end);
+  const diffTime = trialEnd.getTime() - now.getTime();
+  const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
+
+  return Math.max(0, diffDays);
+}

--- a/scripts/migrations/001_create_user_trials.sql
+++ b/scripts/migrations/001_create_user_trials.sql
@@ -1,0 +1,20 @@
+CREATE TABLE user_trials (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL,
+  email VARCHAR(255) NOT NULL,
+  trial_start TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  trial_end TIMESTAMP WITH TIME ZONE NOT NULL,
+  trial_status VARCHAR(20) DEFAULT 'active',
+  reminder_sent_7d BOOLEAN DEFAULT false,
+  reminder_sent_3d BOOLEAN DEFAULT false,
+  reminder_sent_1d BOOLEAN DEFAULT false,
+  created_by UUID NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  notes TEXT,
+  metadata JSONB
+);
+
+CREATE INDEX idx_user_trials_user_id ON user_trials(user_id);
+CREATE INDEX idx_user_trials_email ON user_trials(email);
+CREATE INDEX idx_user_trials_status ON user_trials(trial_status);
+CREATE INDEX idx_user_trials_end ON user_trials(trial_end);

--- a/scripts/send-trial-reminders.ts
+++ b/scripts/send-trial-reminders.ts
@@ -1,0 +1,25 @@
+import { db } from "@/lib/db";
+import { EmailService } from "@/lib/services/email-service";
+
+export async function sendTrialReminders() {
+  const now = new Date();
+  const reminderDays = [7, 3, 1];
+
+  for (const days of reminderDays) {
+    const target = new Date();
+    target.setDate(now.getDate() + days);
+
+    for (const trial of db.trials.filter(t => t.trialStatus === "active")) {
+      const sameDate = trial.trialEnd.toDateString() === target.toDateString();
+      const flag = (trial as any)[`reminderSent${days}d`];
+      if (sameDate && !flag) {
+        try {
+          await EmailService.sendTrialReminder(trial.userId, trial, days);
+          console.log(`Sent ${days}-day reminder to ${trial.email}`);
+        } catch (err) {
+          console.error(`Failed to send reminder to ${trial.email}:`, err);
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- set up in-memory trial management service and API endpoint for granting user trials
- add admin UI and premium feature guard to support trial access and display reminders
- include reminder email system, SQL schema, and scheduled job template for trial reminders

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68b9a4475f1483208f92484984da8935