### PR TITLE
fix: separate mobile close button from panel menus

### DIFF
--- a/components/ui/sheet.tsx
+++ b/components/ui/sheet.tsx
@@ -34,7 +34,8 @@ const SheetContent = React.forwardRef<
       ref={ref}
       className={cn(
         "fixed inset-x-0 bottom-0 z-50 mt-24 flex flex-col border border-border bg-background rounded-t-md animate-in slide-in-from-bottom-10",
-        className
+        className,
+        "pt-10 pr-10"
       )}
       {...props}
     >


### PR DESCRIPTION
## Summary
- add top and right padding to sheet content so the close button no longer sits on top of panel actions on mobile

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bfde065c5083209b24414657af496c