### PR TITLE
fix: prevent mobile sheet close button from overlapping menu

### DIFF
--- a/components/ui/sheet.tsx
+++ b/components/ui/sheet.tsx
@@ -34,7 +34,8 @@ const SheetContent = React.forwardRef<
       ref={ref}
       className={cn(
         "fixed inset-x-0 bottom-0 z-50 mt-24 flex flex-col border border-border bg-background rounded-t-md animate-in slide-in-from-bottom-10",
-        className
+        className,
+        "pr-10"
       )}
       {...props}
     >


### PR DESCRIPTION
## Summary
- add default right padding to mobile SheetContent so close button no longer overlaps panel controls

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bfde065c5083209b24414657af496c