### PR TITLE
feat: add select-all controls to property panel

### DIFF
--- a/components/model-info.tsx
+++ b/components/model-info.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useIFCContext } from "@/context/ifc-context";
+import type { IndexKey } from "@/services/selection-index";
 import type { IfcAPI } from "web-ifc";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -382,6 +383,8 @@ export function ModelInfo() {
     getClassificationsForElement,
     getElementPropertiesCached,
     selectElementsByProperty,
+    selectElementsByIndex,
+    selectionIndexReadyByModel,
   } = useIFCContext();
   const { t, i18n } = useTranslation();
 
@@ -598,8 +601,33 @@ export function ModelInfo() {
 
   const naturalIfcInfo = getNaturalIfcClassName(ifcType, lang);
 
-  const createSelectAllHandler = (path: string[], value: any) => () =>
-    selectElementsByProperty(modelID, path, value);
+  // Map allowed properties to index keys; return null if unsupported
+  const toIndexKey = (path: string[], value: any): IndexKey | null => {
+    if (path.length === 1 && path[0] === "ifcType") return { kind: "IFC_CLASS" };
+    if (path.length >= 2 && path[0] === "attributes" && path[1] === "Name") return { kind: "NAME" };
+    if (path.length >= 2 && path[0] === "typeSets" && /Type Attributes:/.test(path[1]) && path[path.length - 1] === "Name") {
+      return { kind: "TYPE_NAME" };
+    }
+    if (path.length >= 3 && path[0] === "propertySets" && /^PSet_.*Common$/i.test(path[1])) {
+      const psetName = path[1];
+      const propName = path[2];
+      return { kind: "PSET_COMMON", psetName, propName };
+    }
+    return null;
+  };
+
+  const createSelectAllHandler = (path: string[], value: any) => () => {
+    const key = toIndexKey(path, value);
+    if (key) {
+      if (selectionIndexReadyByModel[modelID]) {
+        selectElementsByIndex(modelID, key, value);
+      } else {
+        console.warn("Selection index not ready; ignoring Select All to avoid slow path.");
+      }
+      return;
+    }
+    console.warn("Select All unsupported for path", path.join("."));
+  };
 
   // Render the detailed property information
   return (
@@ -629,12 +657,15 @@ export function ModelInfo() {
                             createSelectAllHandler(["ifcType"], ifcType)();
                           }}
                           className="opacity-60 hover:opacity-100"
+                          disabled={!selectionIndexReadyByModel[modelID]}
                         >
                           <MousePointerClick className="w-3 h-3" />
                         </button>
                       </TooltipTrigger>
                       <TooltipContent side="left">
-                        {t("selectAllWithValue") || "Select all with this value"}
+                        {selectionIndexReadyByModel[modelID]
+                          ? (t("selectAllWithValue") || "Select all with this value")
+                          : (t('messages.loading') || 'Loading...')}
                       </TooltipContent>
                     </Tooltip>
                   </TooltipProvider>
@@ -843,21 +874,21 @@ export function ModelInfo() {
             >
               {props && typeof props === "object"
                 ? Object.entries(props as Record<string, any>).map(
-                    ([propName, propValue]) => (
-                      <PropertyRow
-                        key={propName}
-                        propKey={propName}
-                        propValue={propValue}
-                        icon={getPropertyIcon(propName)}
-                        t={t}
-                        onSelectAll={createSelectAllHandler([
-                          "propertySets",
-                          psetName,
-                          propName,
-                        ], propValue)}
-                      />
-                    ),
-                  )
+                  ([propName, propValue]) => (
+                    <PropertyRow
+                      key={propName}
+                      propKey={propName}
+                      propValue={propValue}
+                      icon={getPropertyIcon(propName)}
+                      t={t}
+                      onSelectAll={createSelectAllHandler([
+                        "propertySets",
+                        psetName,
+                        propName,
+                      ], propValue)}
+                    />
+                  ),
+                )
                 : null}
             </CollapsibleSection>
           ))}

--- a/components/model-info.tsx
+++ b/components/model-info.tsx
@@ -23,6 +23,7 @@ import {
   Box,
   Tag,
   MousePointer2,
+  MousePointerClick,
 } from "lucide-react";
 import React, { useState, useMemo, useEffect } from "react";
 import { MaterialSectionDisplay } from "./material-section-display";
@@ -203,6 +204,7 @@ interface PropertyRowProps {
   icon?: React.ReactNode;
   copyValue?: string;
   t?: (key: string, options?: any) => string;
+  onSelectAll?: () => void;
 }
 
 const PropertyRow: React.FC<PropertyRowProps> = ({
@@ -211,6 +213,7 @@ const PropertyRow: React.FC<PropertyRowProps> = ({
   icon,
   copyValue,
   t,
+  onSelectAll,
 }) => {
   const { ifcApi } = useIFCContext();
   const handleCopy = () => {
@@ -237,6 +240,23 @@ const PropertyRow: React.FC<PropertyRowProps> = ({
           <button onClick={handleCopy} className="opacity-60 hover:opacity-100">
             <Copy className="w-3 h-3" />
           </button>
+        )}
+        {onSelectAll && (
+          <TooltipProvider delayDuration={300}>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  onClick={onSelectAll}
+                  className="opacity-60 hover:opacity-100"
+                >
+                  <MousePointerClick className="w-3 h-3" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent side="left">
+                {t?.("selectAllWithValue") || "Select all with this value"}
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
         )}
       </div>
     </div>
@@ -361,6 +381,7 @@ export function ModelInfo() {
     getNaturalIfcClassName,
     getClassificationsForElement,
     getElementPropertiesCached,
+    selectElementsByProperty,
   } = useIFCContext();
   const { t, i18n } = useTranslation();
 
@@ -577,6 +598,9 @@ export function ModelInfo() {
 
   const naturalIfcInfo = getNaturalIfcClassName(ifcType, lang);
 
+  const createSelectAllHandler = (path: string[], value: any) => () =>
+    selectElementsByProperty(modelID, path, value);
+
   // Render the detailed property information
   return (
     <div className="space-y-2">
@@ -594,8 +618,26 @@ export function ModelInfo() {
                   <Box className="w-3.5 h-3.5 mr-1.5 opacity-80" />
                   <span>{t('IFC Class')}:</span>
                 </div>
-                <div className="text-xs truncate text-right font-medium">
+                <div className="text-xs truncate text-right font-medium flex items-center justify-end gap-1">
                   {ifcType || 'Unknown'}
+                  <TooltipProvider delayDuration={300}>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <button
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            createSelectAllHandler(["ifcType"], ifcType)();
+                          }}
+                          className="opacity-60 hover:opacity-100"
+                        >
+                          <MousePointerClick className="w-3 h-3" />
+                        </button>
+                      </TooltipTrigger>
+                      <TooltipContent side="left">
+                        {t("selectAllWithValue") || "Select all with this value"}
+                      </TooltipContent>
+                    </Tooltip>
+                  </TooltipProvider>
                 </div>
               </div>
             </TooltipTrigger>
@@ -654,6 +696,10 @@ export function ModelInfo() {
             propValue={rawAttributes.Name.value || rawAttributes.Name}
             icon={<Info className="w-3.5 h-3.5" />}
             t={t}
+            onSelectAll={createSelectAllHandler([
+              "attributes",
+              "Name",
+            ], rawAttributes.Name.value || rawAttributes.Name)}
           />
         )}
         {rawAttributes.Description && (
@@ -664,6 +710,10 @@ export function ModelInfo() {
             }
             icon={<Info className="w-3.5 h-3.5" />}
             t={t}
+            onSelectAll={createSelectAllHandler(
+              ["attributes", "Description"],
+              rawAttributes.Description.value || rawAttributes.Description,
+            )}
           />
         )}
         {rawAttributes.ObjectType && (
@@ -674,6 +724,10 @@ export function ModelInfo() {
             }
             icon={<Info className="w-3.5 h-3.5" />}
             t={t}
+            onSelectAll={createSelectAllHandler(
+              ["attributes", "ObjectType"],
+              rawAttributes.ObjectType.value || rawAttributes.ObjectType,
+            )}
           />
         )}
         <PropertyRow
@@ -681,12 +735,14 @@ export function ModelInfo() {
           propValue={`${expressID}`}
           icon={<Hash className="w-3.5 h-3.5" />}
           t={t}
+          onSelectAll={createSelectAllHandler(["expressID"], expressID)}
         />
         <PropertyRow
           propKey="Model"
           propValue={modelDisplayName}
           icon={<Info className="w-3.5 h-3.5" />}
           t={t}
+          onSelectAll={createSelectAllHandler(["modelID"], modelID)}
         />
         {rawAttributes.GlobalId && (
           <PropertyRow
@@ -695,6 +751,10 @@ export function ModelInfo() {
             icon={<Hash className="w-3.5 h-3.5" />}
             copyValue={rawAttributes.GlobalId.value || rawAttributes.GlobalId}
             t={t}
+            onSelectAll={createSelectAllHandler(
+              ["attributes", "GlobalId"],
+              rawAttributes.GlobalId.value || rawAttributes.GlobalId,
+            )}
           />
         )}
         {Object.entries(displayableAttributes).map(([key, value]) => (
@@ -704,6 +764,10 @@ export function ModelInfo() {
             propValue={value}
             icon={getPropertyIcon(key)}
             t={t}
+            onSelectAll={createSelectAllHandler([
+              "attributes",
+              key,
+            ], value)}
           />
         ))}
       </CollapsibleSection>
@@ -779,16 +843,21 @@ export function ModelInfo() {
             >
               {props && typeof props === "object"
                 ? Object.entries(props as Record<string, any>).map(
-                  ([propName, propValue]) => (
-                    <PropertyRow
-                      key={propName}
-                      propKey={propName}
-                      propValue={propValue}
-                      icon={getPropertyIcon(propName)}
-                      t={t}
-                    />
-                  ),
-                )
+                    ([propName, propValue]) => (
+                      <PropertyRow
+                        key={propName}
+                        propKey={propName}
+                        propValue={propValue}
+                        icon={getPropertyIcon(propName)}
+                        t={t}
+                        onSelectAll={createSelectAllHandler([
+                          "propertySets",
+                          psetName,
+                          propName,
+                        ], propValue)}
+                      />
+                    ),
+                  )
                 : null}
             </CollapsibleSection>
           ))}
@@ -821,6 +890,11 @@ export function ModelInfo() {
                   propValue={propValue}
                   icon={getPropertyIcon(propName)}
                   t={t}
+                  onSelectAll={createSelectAllHandler([
+                    "typeSets",
+                    psetName,
+                    propName,
+                  ], propValue)}
                 />
               ))}
             </CollapsibleSection>

--- a/context/ifc-context.tsx
+++ b/context/ifc-context.tsx
@@ -143,6 +143,11 @@ interface IFCContextType {
     modelID: number,
     expressID: number,
   ) => Promise<ParsedElementProperties | null>;
+  selectElementsByProperty: (
+    modelID: number,
+    path: string[],
+    value: any,
+  ) => Promise<void>;
   toggleShowAllClassificationColors: () => void; // Added new toggle function
 
   // Classification and Rule methods (can remain global or be refactored later if needed per model)
@@ -1716,6 +1721,42 @@ export function IFCContextProvider({ children }: { children: ReactNode }) {
     [ifcApiInternal],
   );
 
+  const selectElementsByProperty = useCallback(
+    async (modelID: number, path: string[], value: any) => {
+      if (!ifcApiInternal) return;
+      const elements = IFCElementExtractor.getAllElements(ifcApiInternal, modelID);
+      const matches: SelectedElementInfo[] = [];
+
+      const getValueByPath = (obj: any, p: string[]): any => {
+        return p.reduce((acc, key) => (acc ? acc[key] : undefined), obj);
+      };
+
+      for (const el of elements) {
+        let candidate: any;
+        if (path.length === 1 && path[0] === "ifcType") {
+          candidate = el.type;
+        } else {
+          const props = await getElementPropertiesCached(modelID, el.expressID);
+          if (!props) continue;
+          candidate = getValueByPath(props, path);
+          if (candidate && typeof candidate === "object" && "value" in candidate) {
+            candidate = candidate.value;
+          }
+        }
+        if (
+          candidate !== undefined &&
+          JSON.stringify(candidate) === JSON.stringify(value)
+        ) {
+          matches.push({ modelID, expressID: el.expressID });
+        }
+      }
+      if (matches.length > 0) {
+        selectElements(matches);
+      }
+    },
+    [ifcApiInternal, getElementPropertiesCached, selectElements],
+  );
+
   const showElements = useCallback((elements: SelectedElementInfo[]) => {
     setUserHiddenElements((prev) =>
       prev.filter(
@@ -2304,6 +2345,7 @@ export function IFCContextProvider({ children }: { children: ReactNode }) {
         setAvailableProperties,
         setIfcApi,
         getElementPropertiesCached,
+        selectElementsByProperty,
         toggleShowAllClassificationColors,
         toggleIsolateUnclassified,
         baseCoordinationMatrix,

--- a/context/ifc-context.tsx
+++ b/context/ifc-context.tsx
@@ -20,6 +20,7 @@ import { exportRulesToExcel } from "@/services/rule-export-service";
 import { exportClassificationsToExcel } from "@/services/classification-export-service";
 import { parseClassificationsFromExcel } from "@/services/classification-import-service";
 import { getBufferedConsole, type ConsoleUpdate } from "@/services/buffered-console-service";
+import { SelectionIndex, type IndexKey } from "@/services/selection-index";
 
 // Define interfaces for progress tracking
 export interface RuleProgress {
@@ -148,6 +149,9 @@ interface IFCContextType {
     path: string[],
     value: any,
   ) => Promise<void>;
+  // Indexed selection for instant Select All (IfcClass, Name, Type Name, PSet_*Common)
+  selectElementsByIndex: (modelID: number, key: IndexKey, value: any) => void;
+  selectionIndexReadyByModel: Record<number, boolean>;
   toggleShowAllClassificationColors: () => void; // Added new toggle function
 
   // Classification and Rule methods (can remain global or be refactored later if needed per model)
@@ -243,6 +247,7 @@ export function IFCContextProvider({ children }: { children: ReactNode }) {
   const [baseCoordinationMatrix, setBaseCoordinationMatrix] = useState<
     number[] | null
   >(null);
+  const [selectionIndexReadyByModel, setSelectionIndexReadyByModel] = useState<Record<number, boolean>>({});
 
   // Rule application progress state (for UI feedback)
   const [ruleProgress, setRuleProgress] = useState<RuleProgress>({
@@ -1432,6 +1437,7 @@ export function IFCContextProvider({ children }: { children: ReactNode }) {
       IFCElementExtractor.clearCache();
       PropertyCache.clearCache();
       elementPropsCache.current.clear();
+      try { SelectionIndex.clear(); } catch { }
       setLoadedModels([commonLoadLogic(url, name, fileId)]);
       return null;
     },
@@ -1447,6 +1453,8 @@ export function IFCContextProvider({ children }: { children: ReactNode }) {
               ifcApiInternal.CloseModel(m.modelID);
               // Clear element cache for this model to prevent stale data
               IFCElementExtractor.clearCache(m.modelID);
+              // Clear selection index for this model
+              try { SelectionIndex.clear(ifcApiInternal, m.modelID); } catch { }
             } catch (e) {
               console.error("Error closing model:", e);
             }
@@ -1471,6 +1479,13 @@ export function IFCContextProvider({ children }: { children: ReactNode }) {
         setSelectedElement(null);
         setElementPropertiesInternal(null);
       }
+      // Drop readiness flag for removed model IDs
+      setSelectionIndexReadyByModel(prev => {
+        const next = { ...prev } as Record<number, boolean>;
+        const removedModel = loadedModels.find((m) => m.id === id);
+        if (removedModel?.modelID != null) delete next[removedModel.modelID];
+        return next;
+      });
     },
     [
       ifcApiInternal,
@@ -1513,6 +1528,30 @@ export function IFCContextProvider({ children }: { children: ReactNode }) {
     },
     [],
   );
+
+  // Build selection index in background once a model is open (modelID) and ifcApi available
+  useEffect(() => {
+    const buildIndices = async () => {
+      if (!ifcApiInternal) return;
+      const modelsWithId = loadedModels.filter(m => m.modelID != null) as Array<LoadedModelData & { modelID: number }>;
+      for (const m of modelsWithId) {
+        const mid = m.modelID as number;
+        if (selectionIndexReadyByModel[mid]) continue;
+        try {
+          bufferedConsole.current.updateProgress(`Indexing model ${mid}…`, 1);
+          await SelectionIndex.build(ifcApiInternal, mid, (percent, message) => {
+            bufferedConsole.current.updateProgress(message || `Indexing…`, Math.max(1, Math.min(90, percent)));
+          });
+          setSelectionIndexReadyByModel(prev => ({ ...prev, [mid]: true }));
+          bufferedConsole.current.updateProgress(`Index ready`, 92);
+        } catch (e) {
+          console.warn(`Selection index build failed for model ${mid}`, e);
+        }
+      }
+    };
+    buildIndices();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [ifcApiInternal, loadedModels.map(m => m.modelID).join(',')]);
 
   const selectElement = useCallback(
     (selection: SelectedElementInfo | null) => {
@@ -1721,9 +1760,24 @@ export function IFCContextProvider({ children }: { children: ReactNode }) {
     [ifcApiInternal],
   );
 
+  // Instant selection using prebuilt index (IfcClass, Name, Type Name, PSet_*Common)
+  const selectElementsByIndex = useCallback(
+    (modelID: number, key: IndexKey, value: any) => {
+      if (!ifcApiInternal) return;
+      if (!SelectionIndex.isReady(ifcApiInternal, modelID)) {
+        console.warn("Selection index not ready for model", modelID);
+        return;
+      }
+      const results = SelectionIndex.query(ifcApiInternal, modelID, key, value);
+      if (results.length > 0) selectElements(results);
+    },
+    [ifcApiInternal, selectElements]
+  );
+
   const selectElementsByProperty = useCallback(
     async (modelID: number, path: string[], value: any) => {
       if (!ifcApiInternal) return;
+
       const elements = IFCElementExtractor.getAllElements(ifcApiInternal, modelID);
       const matches: SelectedElementInfo[] = [];
 
@@ -1731,28 +1785,100 @@ export function IFCContextProvider({ children }: { children: ReactNode }) {
         return p.reduce((acc, key) => (acc ? acc[key] : undefined), obj);
       };
 
-      for (const el of elements) {
-        let candidate: any;
-        if (path.length === 1 && path[0] === "ifcType") {
-          candidate = el.type;
-        } else {
-          const props = await getElementPropertiesCached(modelID, el.expressID);
+      const valuesEqual = (a: any, b: any) => {
+        if (a === b) return true;
+        if (typeof a === 'object' || typeof b === 'object') {
+          try {
+            return JSON.stringify(a) === JSON.stringify(b);
+          } catch {
+            return false;
+          }
+        }
+        return false;
+      };
+
+      // Special cases for ultra-fast paths
+      if (path.length === 1) {
+        const key = path[0];
+        if (key === "ifcType") {
+          for (const el of elements) {
+            if (valuesEqual(el.type, value)) {
+              matches.push({ modelID, expressID: el.expressID });
+            }
+          }
+          if (matches.length > 0) selectElements(matches);
+          return;
+        }
+        if (key === "expressID" && typeof value === 'number') {
+          // Direct select by ID
+          selectElements([{ modelID, expressID: value }]);
+          return;
+        }
+        if (key === "modelID" && typeof value === 'number') {
+          // Select all elements in this model
+          const all = elements.map((el) => ({ modelID, expressID: el.expressID }));
+          if (all.length > 0) selectElements(all);
+          return;
+        }
+      }
+
+      // Fast path for direct element attributes (e.g., ["attributes","Name"]) using GetLine without expensive property extraction
+      if (path.length >= 2 && path[0] === "attributes") {
+        const attrPath = path.slice(1); // e.g., ["Name"]
+        let processed = 0;
+        for (const el of elements) {
+          try {
+            const line = await ifcApiInternal.GetLine(modelID, el.expressID, false);
+            let candidate = getValueByPath(line, attrPath);
+            if (candidate && typeof candidate === "object" && "value" in candidate) {
+              candidate = candidate.value;
+            }
+            if (candidate !== undefined && valuesEqual(candidate, value)) {
+              matches.push({ modelID, expressID: el.expressID });
+            }
+          } catch {
+            // Ignore individual element errors
+          }
+          processed++;
+          // Yield periodically to keep UI responsive on large models
+          if (processed % 250 === 0) {
+            await yieldToMainThread();
+          }
+        }
+        if (matches.length > 0) selectElements(matches);
+        return;
+      }
+
+      // Fallback: full property fetch path (chunked with yields)
+      const CHUNK_SIZE = 32;
+      for (let i = 0; i < elements.length; i += CHUNK_SIZE) {
+        const chunk = elements.slice(i, i + CHUNK_SIZE);
+        const propsList = await Promise.all(
+          chunk.map(async (el) => {
+            try {
+              const props = await getElementPropertiesCached(modelID, el.expressID);
+              return { el, props } as const;
+            } catch {
+              return { el, props: null } as const;
+            }
+          })
+        );
+
+        for (const { el, props } of propsList) {
           if (!props) continue;
-          candidate = getValueByPath(props, path);
+          let candidate: any = getValueByPath(props, path);
           if (candidate && typeof candidate === "object" && "value" in candidate) {
             candidate = candidate.value;
           }
+          if (candidate !== undefined && valuesEqual(candidate, value)) {
+            matches.push({ modelID, expressID: el.expressID });
+          }
         }
-        if (
-          candidate !== undefined &&
-          JSON.stringify(candidate) === JSON.stringify(value)
-        ) {
-          matches.push({ modelID, expressID: el.expressID });
-        }
+
+        await yieldToMainThread();
       }
-      if (matches.length > 0) {
-        selectElements(matches);
-      }
+
+      if (matches.length > 0) selectElements(matches);
     },
     [ifcApiInternal, getElementPropertiesCached, selectElements],
   );
@@ -2346,6 +2472,9 @@ export function IFCContextProvider({ children }: { children: ReactNode }) {
         setIfcApi,
         getElementPropertiesCached,
         selectElementsByProperty,
+        // New: indexed selection and readiness
+        selectElementsByIndex,
+        selectionIndexReadyByModel,
         toggleShowAllClassificationColors,
         toggleIsolateUnclassified,
         baseCoordinationMatrix,

--- a/public/locales/de/common.json
+++ b/public/locales/de/common.json
@@ -23,6 +23,7 @@
   "emptyList": "Leere Liste",
   "listCount": "Liste ({{count}} Elemente)",
   "complexData": "Komplexe Daten",
+  "selectAllWithValue": "Alle mit diesem Wert auswählen",
   "loadingSchemaPreview": "Schema-Vorschau wird geladen...",
   "clickToExploreFullDocumentation": "Klicken Sie, um die vollständige Dokumentation zu erkunden",
   "materials": "Materialien",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -23,6 +23,7 @@
   "emptyList": "Empty list",
   "listCount": "List ({{count}} items)",
   "complexData": "Complex data",
+  "selectAllWithValue": "Select all with this value",
   "loadingSchemaPreview": "Loading schema preview...",
   "clickToExploreFullDocumentation": "Click to explore full documentation",
   "materials": "Materials",

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -23,6 +23,7 @@
     "emptyList": "Liste vide",
     "listCount": "Liste ({{count}} éléments)",
     "complexData": "Données complexes",
+    "selectAllWithValue": "Sélectionner tout avec cette valeur",
     "loadingSchemaPreview": "Chargement de l'aperçu du schéma...",
     "clickToExploreFullDocumentation": "Cliquez pour explorer la documentation complète",
     "materials": "Matériaux",

--- a/public/locales/it/common.json
+++ b/public/locales/it/common.json
@@ -23,6 +23,7 @@
     "emptyList": "Lista vuota",
     "listCount": "Lista ({{count}} elementi)",
     "complexData": "Dati complessi",
+    "selectAllWithValue": "Seleziona tutti con questo valore",
     "loadingSchemaPreview": "Caricamento anteprima schema...",
     "clickToExploreFullDocumentation": "Clicca per esplorare la documentazione completa",
     "materials": "Materiali",

--- a/services/selection-index.ts
+++ b/services/selection-index.ts
@@ -1,0 +1,533 @@
+import type { IfcAPI } from "web-ifc";
+// We intentionally avoid using IFCElementExtractor here to allow yielding during enumeration
+
+export interface SelectedElementInfo {
+    modelID: number;
+    expressID: number;
+}
+
+export type IndexKeyKind =
+    | "IFC_CLASS"
+    | "NAME"
+    | "TYPE_NAME"
+    | "PSET_COMMON"; // Use compound key for pset/property
+
+export type IndexKey =
+    | { kind: "IFC_CLASS" }
+    | { kind: "NAME" }
+    | { kind: "TYPE_NAME" }
+    | { kind: "PSET_COMMON"; psetName: string; propName: string };
+
+type InternalIndex = {
+    // Map<IndexBucketKey, Map<ValueKey, Uint32Array>>
+    buckets: Map<string, Map<string, Uint32Array>>;
+    // Optional helpers for UI
+    elementToTypeName: Map<number, string>;
+    // Basic stats
+    elementCount: number;
+    valueCount: number;
+    ready: boolean;
+};
+
+function makeBucketKey(key: IndexKey): string {
+    switch (key.kind) {
+        case "IFC_CLASS":
+            return "IFC_CLASS";
+        case "NAME":
+            return "NAME";
+        case "TYPE_NAME":
+            return "TYPE_NAME";
+        case "PSET_COMMON":
+            return `PSET_COMMON:${key.psetName}:${key.propName}`;
+    }
+}
+
+function serializeValueKey(val: unknown): string {
+    if (val === null) return "null";
+    const t = typeof val;
+    if (t === "string") return `s:${(val as string).trim()}`;
+    if (t === "number") return `n:${val as number}`;
+    if (t === "boolean") return `b:${val ? "1" : "0"}`;
+    // Fallback: JSON stringify small values
+    try {
+        return `j:${JSON.stringify(val)}`;
+    } catch {
+        return "[unsupported]";
+    }
+}
+
+function unwrap(val: any): any {
+    if (val && typeof val === "object" && "value" in val) return val.value;
+    return val;
+}
+
+function isCommonPsetName(name: string | undefined): name is string {
+    if (!name) return false;
+    return /^PSet_.*Common$/i.test(name);
+}
+
+function addToBucket(
+    index: InternalIndex,
+    key: IndexKey,
+    value: unknown,
+    expressID: number,
+): void {
+    const bucketKey = makeBucketKey(key);
+    const valueKey = serializeValueKey(value);
+    if (valueKey === "[unsupported]") return;
+
+    let bucket = index.buckets.get(bucketKey);
+    if (!bucket) {
+        bucket = new Map();
+        index.buckets.set(bucketKey, bucket);
+    }
+
+    let arr = bucket.get(valueKey);
+    if (!arr) {
+        // Start with small JS array, convert to typed array later during finalize
+        // We'll temporarily store as a JS array in a hidden property
+        // Use a symbol-like convention to avoid confusion
+        const tmp = new (Array as any)() as number[];
+        (tmp as any).__tmp = true;
+        (tmp as any).push(expressID);
+        // @ts-expect-error storing temp
+        bucket.set(valueKey, tmp);
+        index.valueCount++;
+    } else {
+        // If it's a Uint32Array, we should not be here yet (finalized)
+        if ((arr as any).__tmp) {
+            // @ts-expect-error tmp push
+            (arr as any).push(expressID);
+        } else {
+            // Convert to dynamic array (shouldn't happen before finalize, safe-guard)
+            const list: number[] = Array.from(arr as unknown as Uint32Array);
+            list.push(expressID);
+            // @ts-expect-error store back as tmp
+            bucket.set(valueKey, list as any);
+        }
+    }
+}
+
+function finalizeBuckets(index: InternalIndex): void {
+    for (const [bucketKey, valueMap] of index.buckets.entries()) {
+        for (const [valKey, list] of valueMap.entries()) {
+            if ((list as any).__tmp) {
+                const jsList = list as unknown as number[];
+                // Deduplicate and sort for stable behavior
+                jsList.sort((a, b) => a - b);
+                const dedup: number[] = [];
+                let last = -1;
+                for (const id of jsList) {
+                    if (id !== last) {
+                        dedup.push(id);
+                        last = id;
+                    }
+                }
+                const typed = new Uint32Array(dedup);
+                valueMap.set(valKey, typed as unknown as any);
+            }
+        }
+    }
+}
+
+function getApiIdFactory() {
+    const apiIds = new WeakMap<IfcAPI, number>();
+    let nextApiId = 1;
+    return (ifcApi: IfcAPI) => {
+        if (!apiIds.has(ifcApi)) apiIds.set(ifcApi, nextApiId++);
+        return apiIds.get(ifcApi)!;
+    };
+}
+
+const getApiId = getApiIdFactory();
+
+// Index storage: Map<apiKey, Map<modelID, InternalIndex>>
+const apiToModelIndex = new Map<number, Map<number, InternalIndex>>();
+
+async function yieldToMainThread(): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+export const SelectionIndex = {
+    isReady(ifcApi: IfcAPI, modelID: number): boolean {
+        const apiKey = getApiId(ifcApi);
+        return apiToModelIndex.get(apiKey)?.get(modelID)?.ready === true;
+    },
+
+    async build(
+        ifcApi: IfcAPI,
+        modelID: number,
+        onProgress?: (percent: number, message?: string) => void,
+    ): Promise<void> {
+        const apiKey = getApiId(ifcApi);
+        let modelMap = apiToModelIndex.get(apiKey);
+        if (!modelMap) {
+            modelMap = new Map();
+            apiToModelIndex.set(apiKey, modelMap);
+        }
+        if (modelMap.get(modelID)?.ready) return; // Already built
+
+        const index: InternalIndex = {
+            buckets: new Map(),
+            elementToTypeName: new Map(),
+            elementCount: 0,
+            valueCount: 0,
+            ready: false,
+        };
+        modelMap.set(modelID, index);
+
+        // Step 1 + 2 combined: Enumerate elements with yielding and index IFC_CLASS + NAME
+        let allExpressIds: number[] = [];
+        try {
+            // Prefer GetAllLines for performance
+            const allLines = ifcApi.GetAllLines(modelID);
+            const total = allLines.size();
+            index.elementCount = total;
+            if (onProgress) onProgress(5, `Indexing ${total} elements`);
+
+            const batchSize = 1000;
+            for (let i = 0; i < total; i++) {
+                const expressID = allLines.get(i);
+                allExpressIds.push(expressID);
+                try {
+                    const line = await ifcApi.GetLine(modelID, expressID, false);
+                    const typeName = typeof line?.type === "number" ? ifcApi.GetNameFromTypeCode(line.type) : String(line?.type || "");
+                    if (typeName) addToBucket(index, { kind: "IFC_CLASS" }, typeName, expressID);
+                    const name = unwrap(line?.Name);
+                    if (name !== undefined && name !== null && name !== "") {
+                        addToBucket(index, { kind: "NAME" }, name, expressID);
+                    }
+                } catch {
+                    // skip
+                }
+
+                if ((i + 1) % batchSize === 0) {
+                    if (onProgress) onProgress(10 + Math.round(((i + 1) / total) * 20), "Indexing IfcClass/Name");
+                    await yieldToMainThread();
+                }
+            }
+
+            // Cleanup
+            if (allLines && typeof (allLines as any).delete === 'function') {
+                try { (allLines as any).delete(); } catch { }
+            }
+        } catch {
+            // Fallback: iterate by max express id range if GetAllLines fails
+            try {
+                const maxId = ifcApi.GetMaxExpressID(modelID);
+                index.elementCount = maxId;
+                if (onProgress) onProgress(5, `Indexing up to ${maxId} IDs`);
+                const batchSize = 1000;
+                for (let i = 1; i <= maxId; i++) {
+                    allExpressIds.push(i);
+                    try {
+                        const line = await ifcApi.GetLine(modelID, i, false);
+                        if (!line || !line.type) continue;
+                        const typeName = typeof line.type === "number" ? ifcApi.GetNameFromTypeCode(line.type) : String(line.type);
+                        if (typeName) addToBucket(index, { kind: "IFC_CLASS" }, typeName, i);
+                        const name = unwrap(line?.Name);
+                        if (name !== undefined && name !== null && name !== "") {
+                            addToBucket(index, { kind: "NAME" }, name, i);
+                        }
+                    } catch {
+                        // ignore missing ids
+                    }
+                    if (i % batchSize === 0) {
+                        if (onProgress) onProgress(10 + Math.round((i / maxId) * 20), "Indexing IfcClass/Name");
+                        await yieldToMainThread();
+                    }
+                }
+            } catch {
+                // Give up on enumeration gracefully
+                allExpressIds = [];
+            }
+        }
+
+        // Step 3: Build type data once per element (deduped)
+        const elementToTypeId = new Map<number, number>();
+        const uniqueTypeIds = new Set<number>();
+        const typeChunk = 300;
+        if (ifcApi.properties && ifcApi.properties.getTypeProperties && allExpressIds.length) {
+            for (let i = 0; i < allExpressIds.length; i += typeChunk) {
+                const chunk = allExpressIds.slice(i, i + typeChunk);
+                await Promise.all(
+                    chunk.map(async (expressID) => {
+                        try {
+                            const typeObjs = await ifcApi.properties.getTypeProperties(modelID, expressID, false);
+                            if (Array.isArray(typeObjs) && typeObjs.length > 0) {
+                                const typeObj = typeObjs[0];
+                                const typeId: number | undefined = typeObj?.expressID ?? (typeObj?.value as number | undefined);
+                                if (typeof typeId === "number") {
+                                    elementToTypeId.set(expressID, typeId);
+                                    uniqueTypeIds.add(typeId);
+                                }
+                            }
+                        } catch {
+                            // ignore
+                        }
+                    }),
+                );
+                if (onProgress) onProgress(35 + Math.round((i / allExpressIds.length) * 10), "Discovering types");
+                await yieldToMainThread();
+            }
+        }
+
+        // Step 4: Fetch each unique type once; index TYPE_NAME and PSet_*Common from type
+        const typeIdToName = new Map<number, string>();
+        const typeIds = Array.from(uniqueTypeIds.values());
+        const typeInfoChunk = 100;
+        for (let i = 0; i < typeIds.length; i += typeInfoChunk) {
+            const chunk = typeIds.slice(i, i + typeInfoChunk);
+            await Promise.all(
+                chunk.map(async (typeId) => {
+                    try {
+                        const typeObj = await ifcApi.GetLine(modelID, typeId, true);
+                        const typeName = unwrap(typeObj?.Name);
+                        if (typeName !== undefined && typeName !== null && typeName !== "") {
+                            typeIdToName.set(typeId, typeName);
+                        }
+
+                        // Index PSet_*Common from type if available
+                        if (Array.isArray(typeObj?.HasPropertySets)) {
+                            for (const psetRef of typeObj.HasPropertySets) {
+                                const psetId = unwrap(psetRef);
+                                if (typeof psetId !== "number") continue;
+                                try {
+                                    const pset = await ifcApi.GetLine(modelID, psetId, true);
+                                    const psetName = unwrap(pset?.Name);
+                                    if (!isCommonPsetName(psetName)) continue;
+
+                                    // Extract properties from IFCPROPERTYSET
+                                    if (pset?.HasProperties) {
+                                        const propsArray = Array.isArray(pset.HasProperties) ? pset.HasProperties : [pset.HasProperties];
+                                        for (const propRef of propsArray) {
+                                            let propLine: any = null;
+                                            const propId = unwrap(propRef);
+                                            if (typeof propId === "number") {
+                                                try {
+                                                    propLine = await ifcApi.GetLine(modelID, propId, true);
+                                                } catch {
+                                                    propLine = null;
+                                                }
+                                            } else if (propRef && typeof propRef === "object" && propRef.Name) {
+                                                propLine = propRef;
+                                            }
+                                            if (!propLine?.Name) continue;
+                                            const propName = unwrap(propLine.Name);
+                                            const val = unwrap(propLine.NominalValue) ?? unwrap(propLine.Value);
+                                            if (val === undefined || val === null || val === "") continue;
+
+                                            // We cannot add elements yet because this is type-level. We'll attach later by elements with this typeId.
+                                            // So stash under a temporary map per typeId.
+                                            // We'll reuse typeIdToName and a separate map typeId -> Map<psetName, Map<propName, value>>
+                                        }
+                                    }
+                                } catch {
+                                    // ignore single pset failure
+                                }
+                            }
+                        }
+                    } catch {
+                        // ignore
+                    }
+                }),
+            );
+            if (onProgress) onProgress(45 + Math.round((i / Math.max(1, typeIds.length)) * 10), "Reading type data");
+            await yieldToMainThread();
+        }
+
+        // Step 4b: Build lightweight map of typeId -> PSet_*Common simple properties
+        // Re-fetch with limited scope (done sequentially to control memory)
+        const typeCommonProps = new Map<number, Map<string, Map<string, unknown>>>();
+        for (let i = 0; i < typeIds.length; i++) {
+            const typeId = typeIds[i];
+            try {
+                const typeObj = await ifcApi.GetLine(modelID, typeId, true);
+                if (Array.isArray(typeObj?.HasPropertySets)) {
+                    for (const psetRef of typeObj.HasPropertySets) {
+                        const psetId = unwrap(psetRef);
+                        if (typeof psetId !== "number") continue;
+                        try {
+                            const pset = await ifcApi.GetLine(modelID, psetId, true);
+                            const psetName = unwrap(pset?.Name);
+                            if (!isCommonPsetName(psetName)) continue;
+                            if (!typeCommonProps.has(typeId)) typeCommonProps.set(typeId, new Map());
+                            const psetMap = typeCommonProps.get(typeId)!;
+                            if (!psetMap.has(psetName)) psetMap.set(psetName, new Map());
+                            const propMap = psetMap.get(psetName)!;
+                            if (pset?.HasProperties) {
+                                const propsArray = Array.isArray(pset.HasProperties) ? pset.HasProperties : [pset.HasProperties];
+                                for (const propRef of propsArray) {
+                                    let propLine: any = null;
+                                    const propId = unwrap(propRef);
+                                    if (typeof propId === "number") {
+                                        try {
+                                            propLine = await ifcApi.GetLine(modelID, propId, true);
+                                        } catch {
+                                            propLine = null;
+                                        }
+                                    } else if (propRef && typeof propRef === "object" && propRef.Name) {
+                                        propLine = propRef;
+                                    }
+                                    if (!propLine?.Name) continue;
+                                    const propName = unwrap(propLine.Name);
+                                    const val = unwrap(propLine.NominalValue) ?? unwrap(propLine.Value);
+                                    if (val === undefined || val === null || val === "") continue;
+                                    propMap.set(String(propName), val);
+                                }
+                            }
+                        } catch {
+                            // ignore pset failure
+                        }
+                    }
+                }
+            } catch {
+                // ignore type failure
+            }
+            if (i % 50 === 0) {
+                if (onProgress) onProgress(55 + Math.round((i / Math.max(1, typeIds.length)) * 10), "Indexing type common sets");
+                await yieldToMainThread();
+            }
+        }
+
+        // Step 5: Attach type-derived data to each element
+        for (let i = 0; i < allExpressIds.length; i++) {
+            const expressID = allExpressIds[i];
+            const typeId = elementToTypeId.get(expressID);
+            if (typeId !== undefined) {
+                const typeName = typeIdToName.get(typeId);
+                if (typeName !== undefined) {
+                    addToBucket(index, { kind: "TYPE_NAME" }, typeName, expressID);
+                    index.elementToTypeName.set(expressID, String(typeName));
+                }
+                const psetMap = typeCommonProps.get(typeId);
+                if (psetMap) {
+                    for (const [psetName, propMap] of psetMap.entries()) {
+                        for (const [propName, propVal] of propMap.entries()) {
+                            addToBucket(index, { kind: "PSET_COMMON", psetName, propName }, propVal, expressID);
+                        }
+                    }
+                }
+            }
+            if (i % 1000 === 0) await yieldToMainThread();
+        }
+
+        // Step 6: Instance-level PSet_*Common
+        if (ifcApi.properties && ifcApi.properties.getPropertySets && allExpressIds.length) {
+            const instChunk = 200;
+            for (let i = 0; i < allExpressIds.length; i += instChunk) {
+                const chunk = allExpressIds.slice(i, i + instChunk);
+                await Promise.all(
+                    chunk.map(async (expressID) => {
+                        try {
+                            const psets = await ifcApi.properties.getPropertySets(modelID, expressID, true, false);
+                            if (Array.isArray(psets)) {
+                                for (const pset of psets) {
+                                    const psetName = unwrap(pset?.Name);
+                                    if (!isCommonPsetName(psetName)) continue;
+                                    if (pset?.HasProperties) {
+                                        const propsArray = Array.isArray(pset.HasProperties) ? pset.HasProperties : [pset.HasProperties];
+                                        for (const propRef of propsArray) {
+                                            let propLine: any = null;
+                                            const propId = unwrap(propRef);
+                                            if (typeof propId === "number") {
+                                                try {
+                                                    propLine = await ifcApi.GetLine(modelID, propId, true);
+                                                } catch {
+                                                    propLine = null;
+                                                }
+                                            } else if (propRef && typeof propRef === "object" && propRef.Name) {
+                                                propLine = propRef;
+                                            }
+                                            if (!propLine?.Name) continue;
+                                            const propName = unwrap(propLine.Name);
+                                            const val = unwrap(propLine.NominalValue) ?? unwrap(propLine.Value);
+                                            if (val === undefined || val === null || val === "") continue;
+                                            addToBucket(index, { kind: "PSET_COMMON", psetName, propName }, val, expressID);
+                                        }
+                                    }
+                                }
+                            }
+                        } catch {
+                            // ignore element failure
+                        }
+                    }),
+                );
+                if (onProgress) onProgress(70 + Math.round((i / allExpressIds.length) * 20), "Indexing instance common sets");
+                await yieldToMainThread();
+            }
+        }
+
+        // Finalize buckets (dedupe + convert to typed arrays)
+        finalizeBuckets(index);
+        index.ready = true;
+        if (onProgress) onProgress(100, "Index ready");
+    },
+
+    query(
+        ifcApi: IfcAPI,
+        modelID: number,
+        key: IndexKey,
+        value: unknown,
+    ): SelectedElementInfo[] {
+        const apiKey = getApiId(ifcApi);
+        const index = apiToModelIndex.get(apiKey)?.get(modelID);
+        if (!index || !index.ready) return [];
+        const bucketKey = makeBucketKey(key);
+        const valueKey = serializeValueKey(value);
+        const typed = index.buckets.get(bucketKey)?.get(valueKey) as Uint32Array | undefined;
+        if (!typed || typed.length === 0) return [];
+        const out: SelectedElementInfo[] = new Array(typed.length);
+        for (let i = 0; i < typed.length; i++) {
+            out[i] = { modelID, expressID: typed[i] };
+        }
+        return out;
+    },
+
+    clear(ifcApi?: IfcAPI, modelID?: number): void {
+        if (!ifcApi && modelID === undefined) {
+            apiToModelIndex.clear();
+            return;
+        }
+        if (ifcApi) {
+            const apiKey = getApiId(ifcApi);
+            if (modelID !== undefined) {
+                apiToModelIndex.get(apiKey)?.delete(modelID);
+            } else {
+                apiToModelIndex.delete(apiKey);
+            }
+            return;
+        }
+        // If only modelID provided (rare), clear all api maps of that modelID
+        if (modelID !== undefined) {
+            for (const modelMap of apiToModelIndex.values()) {
+                modelMap.delete(modelID);
+            }
+        }
+    },
+
+    getTypeNameForElement(ifcApi: IfcAPI, modelID: number, expressID: number): string | null {
+        const apiKey = getApiId(ifcApi);
+        const index = apiToModelIndex.get(apiKey)?.get(modelID);
+        if (!index || !index.ready) return null;
+        return index.elementToTypeName.get(expressID) ?? null;
+    },
+
+    getStats(ifcApi: IfcAPI, modelID: number) {
+        const apiKey = getApiId(ifcApi);
+        const index = apiToModelIndex.get(apiKey)?.get(modelID);
+        if (!index) return null;
+        let totalEntries = 0;
+        for (const m of index.buckets.values()) totalEntries += m.size;
+        return {
+            ready: index.ready,
+            elementCount: index.elementCount,
+            valueCount: index.valueCount,
+            bucketKinds: Array.from(index.buckets.keys()).slice(0, 5),
+            totalBucketKinds: index.buckets.size,
+            totalEntries,
+        };
+    },
+};
+
+


### PR DESCRIPTION
## Summary
- add Select All buttons to property rows and IFC class display in property panel
- support programmatic selection of elements sharing a property value
- add translation key for select-all tooltip

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bfcd38ae2c832083cb631a050cd0b7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added “Select all with this value” across IFC class, attributes, and property/type sets.
  * Per-row Select All controls with icon, tooltip, and disabled/loading states until ready.
  * Faster, large-scale selections enabled by a background-prepared selection index.

* **Chores**
  * Background indexing and lifecycle handling to keep the UI responsive during large selections.
  * Added translations for the new tooltip in English, German, French, and Italian.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->