### PR TITLE
feat: add select-all controls in property panel

### DIFF
--- a/components/model-info.tsx
+++ b/components/model-info.tsx
@@ -203,6 +203,7 @@ interface PropertyRowProps {
   icon?: React.ReactNode;
   copyValue?: string;
   t?: (key: string, options?: any) => string;
+  propertyPath?: string[];
 }
 
 const PropertyRow: React.FC<PropertyRowProps> = ({
@@ -211,10 +212,16 @@ const PropertyRow: React.FC<PropertyRowProps> = ({
   icon,
   copyValue,
   t,
+  propertyPath,
 }) => {
-  const { ifcApi } = useIFCContext();
+  const { ifcApi, selectElementsByProperty } = useIFCContext();
   const handleCopy = () => {
     if (copyValue !== undefined) navigator.clipboard.writeText(copyValue);
+  };
+  const handleSelect = async () => {
+    if (propertyPath) {
+      await selectElementsByProperty(propertyPath, propValue);
+    }
   };
   return (
     <div className="grid grid-cols-[auto_1fr] gap-x-3 items-start py-1.5 border-b border-border/50 last:border-b-0">
@@ -233,6 +240,23 @@ const PropertyRow: React.FC<PropertyRowProps> = ({
         }
       >
         {renderPropertyValue(propValue, propKey, ifcApi, t)}
+        {propertyPath && (
+          <TooltipProvider delayDuration={100}>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  onClick={handleSelect}
+                  className="opacity-60 hover:opacity-100"
+                >
+                  <MousePointer2 className="w-3 h-3" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent>
+                {t ? t("selectAll") : "Select all"}
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        )}
         {copyValue !== undefined && (
           <button onClick={handleCopy} className="opacity-60 hover:opacity-100">
             <Copy className="w-3 h-3" />
@@ -361,6 +385,7 @@ export function ModelInfo() {
     getNaturalIfcClassName,
     getClassificationsForElement,
     getElementPropertiesCached,
+    selectElementsByProperty,
   } = useIFCContext();
   const { t, i18n } = useTranslation();
 
@@ -594,8 +619,27 @@ export function ModelInfo() {
                   <Box className="w-3.5 h-3.5 mr-1.5 opacity-80" />
                   <span>{t('IFC Class')}:</span>
                 </div>
-                <div className="text-xs truncate text-right font-medium">
+                <div className="text-xs truncate text-right font-medium flex items-center justify-end gap-1">
                   {ifcType || 'Unknown'}
+                  {ifcType && (
+                    <TooltipProvider delayDuration={100}>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <button
+                            onClick={() =>
+                              selectElementsByProperty(['ifcType'], ifcType)
+                            }
+                            className="opacity-60 hover:opacity-100"
+                          >
+                            <MousePointer2 className="w-3 h-3" />
+                          </button>
+                        </TooltipTrigger>
+                        <TooltipContent>
+                          {t('selectAll')}
+                        </TooltipContent>
+                      </Tooltip>
+                    </TooltipProvider>
+                  )}
                 </div>
               </div>
             </TooltipTrigger>
@@ -654,6 +698,7 @@ export function ModelInfo() {
             propValue={rawAttributes.Name.value || rawAttributes.Name}
             icon={<Info className="w-3.5 h-3.5" />}
             t={t}
+            propertyPath={["attributes", "Name"]}
           />
         )}
         {rawAttributes.Description && (
@@ -664,6 +709,7 @@ export function ModelInfo() {
             }
             icon={<Info className="w-3.5 h-3.5" />}
             t={t}
+            propertyPath={["attributes", "Description"]}
           />
         )}
         {rawAttributes.ObjectType && (
@@ -674,6 +720,7 @@ export function ModelInfo() {
             }
             icon={<Info className="w-3.5 h-3.5" />}
             t={t}
+            propertyPath={["attributes", "ObjectType"]}
           />
         )}
         <PropertyRow
@@ -704,6 +751,7 @@ export function ModelInfo() {
             propValue={value}
             icon={getPropertyIcon(key)}
             t={t}
+            propertyPath={["attributes", key]}
           />
         ))}
       </CollapsibleSection>
@@ -786,6 +834,7 @@ export function ModelInfo() {
                       propValue={propValue}
                       icon={getPropertyIcon(propName)}
                       t={t}
+                      propertyPath={["propertySets", psetName, propName]}
                     />
                   ),
                 )
@@ -821,6 +870,7 @@ export function ModelInfo() {
                   propValue={propValue}
                   icon={getPropertyIcon(propName)}
                   t={t}
+                  propertyPath={["typeSets", psetName, propName]}
                 />
               ))}
             </CollapsibleSection>

--- a/context/ifc-context.tsx
+++ b/context/ifc-context.tsx
@@ -144,6 +144,13 @@ interface IFCContextType {
     expressID: number,
   ) => Promise<ParsedElementProperties | null>;
   toggleShowAllClassificationColors: () => void; // Added new toggle function
+  /**
+   * Select all elements that have the same value at the given property path
+   * within ParsedElementProperties.
+   * Path segments should match the structure returned by getElementPropertiesCached
+   * e.g. ['ifcType'] or ['propertySets', 'Pset_WallCommon', 'IsExternal']
+   */
+  selectElementsByProperty: (path: string[], value: any) => Promise<void>;
 
   // Classification and Rule methods (can remain global or be refactored later if needed per model)
   addClassification: (classification: any) => void;
@@ -1559,6 +1566,49 @@ export function IFCContextProvider({ children }: { children: ReactNode }) {
     ],
   );
 
+  const selectElementsByProperty = useCallback(
+    async (path: string[], value: any) => {
+      if (!ifcApiInternal) return;
+      const matches: SelectedElementInfo[] = [];
+
+      const getValue = (obj: any, p: string[]) => p.reduce((acc, key) => (acc ? acc[key] : undefined), obj);
+
+      for (const model of loadedModels) {
+        if (model.modelID == null) continue;
+        const elements = IFCElementExtractor.getAllElements(ifcApiInternal, model.modelID);
+
+        if (path.length === 1 && path[0] === "ifcType") {
+          for (const el of elements) {
+            if (String(el.type).toLowerCase() === String(value).toLowerCase()) {
+              matches.push({ modelID: model.modelID, expressID: el.expressID });
+            }
+          }
+        } else {
+          for (const el of elements) {
+            try {
+              const props = await PropertyCache.getProperties(
+                ifcApiInternal,
+                model.modelID,
+                el.expressID,
+              );
+              const v = getValue(props, path);
+              if (v !== undefined && JSON.stringify(v) === JSON.stringify(value)) {
+                matches.push({ modelID: model.modelID, expressID: el.expressID });
+              }
+            } catch (e) {
+              // ignore errors for individual elements
+            }
+          }
+        }
+      }
+
+      if (matches.length) {
+        selectElements(matches);
+      }
+    },
+    [ifcApiInternal, loadedModels, selectElements],
+  );
+
   const clearSelection = useCallback(() => {
     setSelectedElements([]);
     setSelectedElement(null);
@@ -2296,6 +2346,7 @@ export function IFCContextProvider({ children }: { children: ReactNode }) {
         setRawBufferForModel,
         selectElement,
         selectElements,
+        selectElementsByProperty,
         toggleElementSelection,
         clearSelection,
         toggleClassificationHighlight,

--- a/public/locales/de/common.json
+++ b/public/locales/de/common.json
@@ -25,6 +25,7 @@
   "complexData": "Komplexe Daten",
   "loadingSchemaPreview": "Schema-Vorschau wird geladen...",
   "clickToExploreFullDocumentation": "Klicken Sie, um die vollständige Dokumentation zu erkunden",
+  "selectAll": "Alle mit gleichem Wert auswählen",
   "materials": "Materialien",
   "set": "Set",
   "sets": "Sets",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -25,6 +25,7 @@
   "complexData": "Complex data",
   "loadingSchemaPreview": "Loading schema preview...",
   "clickToExploreFullDocumentation": "Click to explore full documentation",
+  "selectAll": "Select all with same value",
   "materials": "Materials",
   "set": "set",
   "sets": "sets",

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -25,6 +25,7 @@
     "complexData": "Données complexes",
     "loadingSchemaPreview": "Chargement de l'aperçu du schéma...",
     "clickToExploreFullDocumentation": "Cliquez pour explorer la documentation complète",
+    "selectAll": "Sélectionner tous avec la même valeur",
     "materials": "Matériaux",
     "set": "ensemble",
     "sets": "ensembles",

--- a/public/locales/it/common.json
+++ b/public/locales/it/common.json
@@ -25,6 +25,7 @@
     "complexData": "Dati complessi",
     "loadingSchemaPreview": "Caricamento anteprima schema...",
     "clickToExploreFullDocumentation": "Clicca per esplorare la documentazione completa",
+    "selectAll": "Seleziona tutti con lo stesso valore",
     "materials": "Materiali",
     "set": "set",
     "sets": "set",


### PR DESCRIPTION
## Summary
- add `selectElementsByProperty` to context for selecting elements sharing a property value
- show select-all icon on property panel rows and IFC class field
- add i18n strings for select-all tooltip

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bfcd38ae2c832083cb631a050cd0b7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Select all” control next to property values in Model Info to select elements sharing the same value.
  * Supports attributes, property sets, type sets, and IFC Class (select all of the same type).

* **UI**
  * Minor layout adjustments to accommodate the new select-all icon and tooltips.

* **Localization**
  * Added “Select all with same value” translations for English, German, French, and Italian.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->