### PR TITLE
fix: resolve button overlap issue in bSDD dictionary selection dialog

### DIFF
--- a/components/bsdd-dialog.tsx
+++ b/components/bsdd-dialog.tsx
@@ -925,22 +925,6 @@ export function BsddDialog({ open, onOpenChange, onAdd, existingCodes, onRemove 
                     </div>
                   </ScrollArea>
                 </div>
-
-                <div className="flex items-center justify-between">
-                  <div className="text-sm text-muted-foreground">
-                    {selectedDictionaryUris.length > 0 ? `${selectedDictionaryUris.length} selected` : 'No dictionary selected'}
-                  </div>
-                  <div className="flex gap-2">
-                    {selectedDictionaryUris.length > 0 && (
-                      <Button variant="ghost" size="sm" onClick={() => setSelectedDictionaryUris([])}>
-                        <X className="h-4 w-4 mr-1" /> Clear
-                      </Button>
-                    )}
-                    <Button size="sm" disabled={selectedDictionaryUris.length === 0} onClick={() => setStep('search')}>
-                      Continue
-                    </Button>
-                  </div>
-                </div>
               </div>
             )}
 
@@ -1196,7 +1180,12 @@ export function BsddDialog({ open, onOpenChange, onAdd, existingCodes, onRemove 
         <DialogFooter>
           <div className="flex items-center justify-between w-full">
             <div className="text-sm text-muted-foreground">
-              {filteredAndSortedResults.length > 0 && (
+              {step === 'select' && (
+                <span>
+                  {selectedDictionaryUris.length > 0 ? `${selectedDictionaryUris.length} selected` : 'No dictionary selected'}
+                </span>
+              )}
+              {step === 'search' && filteredAndSortedResults.length > 0 && (
                 <span>
                   {filteredAndSortedResults.length} result{filteredAndSortedResults.length === 1 ? '' : 's'}
                   {dictionaryFilter !== 'all' && ' (filtered)'}
@@ -1209,6 +1198,18 @@ export function BsddDialog({ open, onOpenChange, onAdd, existingCodes, onRemove 
               <Button variant="outline" onClick={() => onOpenChange(false)}>
                 {t("buttons.cancel")}
               </Button>
+              {step === 'select' && (
+                <>
+                  {selectedDictionaryUris.length > 0 && (
+                    <Button variant="ghost" onClick={() => setSelectedDictionaryUris([])}>
+                      <X className="h-4 w-4 mr-1" /> Clear
+                    </Button>
+                  )}
+                  <Button disabled={selectedDictionaryUris.length === 0} onClick={() => setStep('search')}>
+                    Continue
+                  </Button>
+                </>
+              )}
             </div>
           </div>
         </DialogFooter>


### PR DESCRIPTION
Fixed button overlap that occurred when zooming in or on smaller viewports
by moving all action buttons (Cancel, Clear, Continue) into the DialogFooter.

Previously, the Clear and Continue buttons were inline in the content area
while the Cancel button was in the footer, causing them to overlap when
the browser was zoomed in or space was constrained.

Now all buttons are properly positioned in the footer based on the current step:
- 'select' step: Shows Cancel, Clear (conditional), and Continue buttons
- 'search' step: Shows only Cancel button

This ensures buttons maintain proper spacing and don't overlap at any zoom level.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Fix bSDD dialog action layout**
> 
> - Moved `Clear` and `Continue` controls from content area into `DialogFooter` alongside `Cancel`, rendered only during the `select` step
> - Updated footer info text: shows selected dictionary count in `select` step; shows search result stats and active filters in `search` step
> - Removed the previous inline button row within the selection section to avoid overlap/responsiveness issues
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3e577c28a62d4220103624e61ea0684348358e7d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Footer now displays context-specific controls and information
  * Selection counter shows number of chosen dictionaries or "No dictionary selected"
  * Added Clear and Continue action buttons for the dictionary selection
  * Continue button enabled only when at least one dictionary is selected
  * Search view footer displays results count and filter indicators

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->